### PR TITLE
NSL-3119 and NSL-4909: move the "as a draft" checkbox and apply consi…

### DIFF
--- a/app/views/instances/_form_update_standalone.html.erb
+++ b/app/views/instances/_form_update_standalone.html.erb
@@ -9,7 +9,6 @@
             </ul>
         </div>
     <% end %>
-  <%= render partial: "instances/widgets/edit_draft", locals: {f: f} %>
 
   <%= link_to(@instance.name.try('full_name'),
                 search_path(query_string:
@@ -49,6 +48,7 @@
     with BHL URL
     <%= f.text_field :bhl_url, class: "form-control", title: "Enter BHL URL", tabindex: increment_tab_index %>
     <br>
+    <%= render partial: "instances/widgets/as_a_draft", locals: {f: f} %>
     <%= f.submit class: 'btn btn-primary pull-right no-right-margin', title: "Save changes", tabindex: increment_tab_index %>
     <br>
   <div id="form-update-info-message-container" class="message-container"></div>

--- a/app/views/instances/widgets/_as_a_draft.html.erb
+++ b/app/views/instances/widgets/_as_a_draft.html.erb
@@ -1,7 +1,7 @@
 <% if Rails.configuration.try("draft_instances") && @current_user.treebuilder? && @working_draft %>
   <br>
   <label class="form-check-label plain" title="Mark this instance as a draft">
-    <%= f.check_box(:draft, {tabindex: increment_tab_index, checked: @working_draft.draft_instance_default?}) %>
+    <%= f.check_box(:draft, {tabindex: increment_tab_index}) %>
     as a draft
   </label>
 <% end %>

--- a/app/views/instances/widgets/_edit_draft.html.erb
+++ b/app/views/instances/widgets/_edit_draft.html.erb
@@ -1,7 +1,0 @@
-<% if Rails.configuration.try("draft_instances") && @current_user.treebuilder? %>
-  <label class="form-check-label plain" title="Mark this instance as a draft">
-    <%= f.check_box(:draft, {tabindex: increment_tab_index}) %>
-    as a draft
-  </label>
-  <br>
-<% end %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,11 @@
+- :date: 13-Feb-2024
+  :jira_id: '4909'
+  :description: |-
+    Instance: Apply the same rules to display of the "as a draft" checkbox on the Edit form as on the New Instance form i.e. a draft tree must be selected
+- :date: 13-Feb-2024
+  :jira_id: '3119'
+  :description: |-
+    Instance: Move "as a draft" checkbox to bottom of Edit form to match its position on the New Instance form
 - :date: 07-Feb-2024
   :jira_id: '4897'
   :description: |-

--- a/test/controllers/instances/tabs/authorisation/for_editor_with_treebuilder/edit_draft_selected_test.rb
+++ b/test/controllers/instances/tabs/authorisation/for_editor_with_treebuilder/edit_draft_selected_test.rb
@@ -19,22 +19,23 @@
 require "test_helper"
 
 # Single controller test.
-class InstanceEditTabForEditorTest < ActionController::TestCase
+class InstEditTabForEditWithTreeBuilderAndDraftTest < ActionController::TestCase
   tests InstancesController
   setup do
     @triodia_in_brassard = instances(:triodia_in_brassard)
     @draft_tree_version = tree_version(:draft_version)
   end
-  test "should show instance edit tab to editor" do
+
+  test "should include as a draft checkbox for edit" do
     @request.headers["Accept"] = "application/javascript"
     get(:show,
         params: { id: @triodia_in_brassard.id, tab: "tab_edit" },
         session: { username: "fred",
                    user_full_name: "Fred Jones",
                    draft: @draft_tree_version,
-                   groups: ["edit"] })
+                   groups: ["edit", "treebuilder"] })
     assert_response :success
-    assert_match 'on page', response.body, "Should show: 'on page'"
-    assert_no_match 'as a draft', response.body, "Should not be authorised to show: 'as a draft'"
+    assert_match 'on page', @response.body, "Missing: 'on page'"
+    assert_match 'as a draft', @response.body, "Missing: 'as a draft'"
   end
 end

--- a/test/controllers/instances/tabs/authorisation/for_editor_with_treebuilder/edit_no_draft_selected_test.rb
+++ b/test/controllers/instances/tabs/authorisation/for_editor_with_treebuilder/edit_no_draft_selected_test.rb
@@ -19,22 +19,21 @@
 require "test_helper"
 
 # Single controller test.
-class InstanceEditTabForEditorTest < ActionController::TestCase
+class InstEditTabForEditWithTreeBuilderNoDraftTest < ActionController::TestCase
   tests InstancesController
   setup do
     @triodia_in_brassard = instances(:triodia_in_brassard)
-    @draft_tree_version = tree_version(:draft_version)
   end
-  test "should show instance edit tab to editor" do
+
+  test "should include as a draft checkbox for edit" do
     @request.headers["Accept"] = "application/javascript"
     get(:show,
         params: { id: @triodia_in_brassard.id, tab: "tab_edit" },
         session: { username: "fred",
                    user_full_name: "Fred Jones",
-                   draft: @draft_tree_version,
-                   groups: ["edit"] })
+                   groups: ["edit", "treebuilder"] })
     assert_response :success
-    assert_match 'on page', response.body, "Should show: 'on page'"
-    assert_no_match 'as a draft', response.body, "Should not be authorised to show: 'as a draft'"
+    assert_match 'on page', @response.body, "Missing: 'on page'"
+    assert_no_match 'as a draft', @response.body, "Missing: 'as a draft'"
   end
 end


### PR DESCRIPTION
Move the "as a draft" checkbox and apply consistent rules for its display including a draft being selected