### PR TITLE
NSL-4910:  Loader: Remove 'undefined method' error when creating misa…

### DIFF
--- a/app/models/loader/name.rb
+++ b/app/models/loader/name.rb
@@ -311,7 +311,7 @@ class Loader::Name < ActiveRecord::Base
     return nil if accepted?
     return nil if excluded?
 
-    return InstanceType.find_by_name(synonym_type).id if misapplied?
+    return InstanceType.find_by_name(synonym_type || "misapplied").id if misapplied?
 
     if taxonomic?
       return InstanceType.find_by_name("doubtful pro parte taxonomic synonym").id if doubtful? && pp?

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 16-Feb-2024
+  :jira_id: '4910'
+  :description: |-
+    Loader: Remove 'undefined method' error when creating misapplied preferred matches on parsed batches - default the relationship type to 'misapplied'
 - :date: 13-Feb-2024
   :jira_id: '4909'
   :description: |-


### PR DESCRIPTION
NSL-4910:  Loader: Remove 'undefined method' error when creating misapplied preferred matches on parsed batches - default the relationship type to 'misapplied'