### PR TITLE
NSL-4911: Loader: Report a clearly expressed error on attempt to crea…

### DIFF
--- a/app/models/loader/name/make_one_instance/make_one_standalone_instance.rb
+++ b/app/models/loader/name/make_one_instance/make_one_standalone_instance.rb
@@ -30,6 +30,7 @@ class Loader::Name::MakeOneInstance::MakeOneStandaloneInstance
   def create
     return using_existing_instance if using_existing_instance?
     return stand_already_noted if standalone_instance_already_noted?
+    return no_default_ref if no_default_ref?
     return stand_already_for_default_ref if standalone_instance_for_default_ref?
 
     if @match.instance_choice_confirmed == false
@@ -110,6 +111,16 @@ class Loader::Name::MakeOneInstance::MakeOneStandaloneInstance
 
   def standalone_instance_already_noted?
     true unless @match.standalone_instance_id.blank?
+  end
+
+  def no_default_ref?
+    @loader_name.loader_batch.default_reference.blank?
+  end
+
+  def no_default_ref
+    log_to_table("#{Constants::DECLINED_INSTANCE} - no batch default ref " +
+                 "for #{@loader_name.simple_name} " + "#{@loader_name.id}")
+    {declines: 1, decline_reasons: {no_batch_default_ref: 1}}
   end
 
   def log_to_table(payload)

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 16-Feb-2024
+  :jira_id: '4911'
+  :description: |-
+    Loader: Report a clearly expressed error on attempt to create draft instances needing a batch default reference when no such default is set
+- :date: 16-Feb-2024
   :jira_id: '4910'
   :description: |-
     Loader: Remove 'undefined method' error when creating misapplied preferred matches on parsed batches - default the relationship type to 'misapplied'

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.14.54
+appversion=4.0.14.55


### PR DESCRIPTION
NSL-4911:  Loader: Report a clearly expressed error on attempt to create draft instances needing a batch default reference when no such default is set