### PR TITLE
NSL-4916: Loader: Add a checkbox for the Doubtful field to the edit f…

### DIFF
--- a/app/views/loader/names/tabs/forms/_form_for_misapp.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_misapp.html.erb
@@ -27,6 +27,14 @@
     <%= render partial: "loader/names/tabs/forms/misapp_synonym_type", 
                locals: {f: f, loader_name: loader_name} %>
 
+    <div class="form-group">
+    <label class="form-check-label" title="Misapplication may be doubtful" >
+      <%= f.check_box(:doubtful, {class: '',
+                                  title: 'Misapplication may be doubtful'}) %>
+      Doubtful
+    </label>
+    </div>
+
     <% unless loader_name.new_record? %>
 
     <div class="form-group">

--- a/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
@@ -21,6 +21,14 @@
 
     <%= render partial: "loader/names/tabs/forms/synonym_type", locals: {f: f, loader_name: loader_name} %>
 
+    <div class="form-group">
+    <label class="form-check-label" title="Synonymy may be doubtful" >
+      <%= f.check_box(:doubtful, {class: '',
+                                  title: 'Synonymy may be doubtful'}) %>
+      Doubtful
+    </label>
+    </div>
+
     <% unless loader_name.new_record? %>
 
     <div class="form-group">

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 16-Feb-2024
+  :jira_id: '4916'
+  :description: |-
+    Loader: Add a checkbox for the Doubtful field to the edit forms for synonyms and misapplieds
+- :date: 16-Feb-2024
   :jira_id: '4911'
   :description: |-
     Loader: Report a clearly expressed error on attempt to create draft instances needing a batch default reference when no such default is set

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.14.55
+appversion=4.0.14.56


### PR DESCRIPTION
NSL-4916:  Loader: Add a checkbox for the Doubtful field to the edit forms for synonyms and misapplieds