### PR TITLE
NSL-2820: Synonymy typeahead: Treat 4 consecutive digits as a year for searching

### DIFF
--- a/app/models/instance/as_typeahead/for_synonymy.rb
+++ b/app/models/instance/as_typeahead/for_synonymy.rb
@@ -46,7 +46,8 @@ class Instance::AsTypeahead::ForSynonymy
   def initialize(terms, name_id)
     @results = []
     @name_binds = []
-    terms_without_year = terms.gsub(/[0-9]/, "").strip.gsub("  ", " ")
+    terms_without_year = terms.gsub(/[1,2][0-9]{3}/, "").strip.gsub("  ", " ")
+    Rails.logger.debug("terms_without_year: #{terms_without_year}")
     return if terms_without_year.blank?
 
     @name_binds.push(" lower(f_unaccent(full_name)) like lower(f_unaccent(?)) ")
@@ -106,7 +107,10 @@ class Instance::AsTypeahead::ForSynonymy
 
   def reference_binds(terms)
     reference_binds = []
-    reference_year = terms.gsub(/[^0-9]/, "")
+    match = terms.match(/[1,2][0-9]{3}/)
+    return reference_binds if match.blank?
+
+    reference_year = match.to_s 
     if reference_year.present? &&
        reference_year.to_i > 1000 && reference_year.to_i < 3000
       reference_binds.push(" iso_publication_date like ? ||'%' ")

--- a/app/views/instances/_form_create_synonymy.html.erb
+++ b/app/views/instances/_form_create_synonymy.html.erb
@@ -20,7 +20,7 @@ The name (and optional year)*, as referenced below:
            tabindex="<%= increment_tab_index %>"
            type="text"
            required='true'
-           placeholder="Instance for synonym - typeahead using name and (optional) year"
+           placeholder="Name typeahead to list instances, 4 consecutive digits treated as a year"
            value=""/>
   </section>
 </div>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,7 +1,7 @@
-- :date: 16-Feb-2024
-  :jira_id: '4916'
+- :date: 19-Feb-2024
+  :jira_id: '2820'
   :description: |-
-    Loader: Add a checkbox for the Doubtful field to the edit forms for synonyms and misapplieds
+    Synonymy typeahead: Treat 4 consecutive digits as a year for searching, rather than just any sequence of digits; improve placeholder text
 - :date: 16-Feb-2024
   :jira_id: '4911'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.14.56
+appversion=4.0.14.57

--- a/test/fixtures/authors.yml
+++ b/test/fixtures/authors.yml
@@ -577,3 +577,10 @@ juss:
   created_by: greg
   updated_by: greg
 
+briggs_and_leigh:
+  name: Briggs, J.D. & Leigh, J.H.
+  abbrev: J.D.Briggs & Leigh
+  namespace: apni
+  created_by: greg
+  updated_by: greg
+

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -1052,3 +1052,13 @@ instance_for_name_in_taxonomy:
   source_id_string: gcmd
   page: exclude-from-ordering-test
 
+darwinia_sp_7_in_briggs_and_leigh_1996:
+  name: darwinia_sp_7
+  reference: rare_or_threatened_australian_plants
+  instance_type: secondary_reference
+  page: exclude-from-ordering-test
+  verbatim_name_string: l
+  namespace: apni
+  created_by: tester
+  updated_by: tester
+

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -2679,4 +2679,20 @@ ptychocaryum_ghaeri:
   updated_by: greg
   created_by: greg
 
+darwinia_sp_7: 
+  simple_name: Darwinia sp. 7
+  full_name: Darwinia sp. 7 (Chiddarcooping; S.D.Hopper 6944)
+  name_element: sp. 7 (Chiddarcooping; S.D.Hopper 6944)
+  name_rank: species
+  name_status: na
+  name_type: phrase_name
+  namespace: apni
+  parent: 
+  family: cyperaceae
+  name_path: 'Eukaryota/Plantae/Magnoliophyta/Magnoliopsida/Rosidae/Myrtales/Myrtaceae/Darwinia/sp.'
+  uri: agh
+  updated_by: greg
+  created_by: greg
+
+
 

--- a/test/fixtures/references.yml
+++ b/test/fixtures/references.yml
@@ -2289,3 +2289,18 @@ syntrinema_genus_novum:
   volume: 21(8-20)
   created_by: tester
   updated_by: tester
+
+rare_or_threatened_australian_plants:
+  title: rare_or_threatened_australian_plants
+  citation: Briggs, J.D. & Leigh, J.H. (1996), Rare or Threatened Australian Plants
+  citation_html: Briggs, J.D. & Leigh, J.H. (1996), Rare or Threatened Australian Plants
+  display_title: Rare or Threatened Australian Plants
+  author: briggs_and_leigh
+  ref_author_role: author
+  language: undetermined
+  namespace: apni
+  ref_type: book
+  iso_publication_date: 1996
+  created_by: tester
+  updated_by: tester
+

--- a/test/models/instance/as_typeahead/for_synonymy/phrase_name_with_digit_search.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/phrase_name_with_digit_search.rb
@@ -20,15 +20,20 @@ require "test_helper"
 require "models/instance/as_typeahead/for_synonymy/test_helper"
 
 # Single instance typeahead search.
-class ForNameAndReferenceYearTest < ActiveSupport::TestCase
+class For_phrase_name_with_digit_search < ActiveSupport::TestCase
+
+
   def setup
-    @typeahead = Instance::AsTypeahead::ForSynonymy.new("angophora costata 178",
+    @typeahead = Instance::AsTypeahead::ForSynonymy.new("Darwinia sp. 7",
                                                         names(:a_species).id)
   end
 
-  test "name and incomplete year search" do
+  test "phrase name with digit search" do
     assert @typeahead.results.instance_of?(Array), "Results should be an array."
-    assert @typeahead.results.size == 0,
-      "Incomplete year should not be ignored and no records should be returned."
+    assert @typeahead.results.size == 1,
+      "Incomplete year should not be ignored and one record should be returned."
+    assert @typeahead.results
+                     .collect { |r| r[:value] }
+                     .include?(DARWINIA_SP_7_CITATION), DARWINIA_SP_7_ERROR
   end
 end

--- a/test/models/instance/as_typeahead/for_synonymy/test_helper.rb
+++ b/test/models/instance/as_typeahead/for_synonymy/test_helper.rb
@@ -28,3 +28,5 @@ ANGOPHORA_COSTATA_JOURNAL_1916_STRING  =
 ANGOPHORA_COSTATA_JOURNAL_1916_ERROR   =
   "Results should include the Angophora constata Journal of Botany 1916 \
   instance."
+DARWINIA_SP_7_CITATION = "Darwinia sp. 7 (Chiddarcooping; S.D.Hopper 6944) in Briggs, J.D. & Leigh, J.H. (1996), Rare or Threatened Australian Plants:1996 [exclude-from-ordering-test]"
+DARWINIA_SP_7_ERROR   = "Results should include Darwinia sp. 7 in Briggs and Leigh 1996."

--- a/test/models/search/on_instance/name_status_not/simple_test.rb
+++ b/test/models/search/on_instance/name_status_not/simple_test.rb
@@ -28,6 +28,7 @@ class SearchOnInstanceNameStatusNotSimpleTest < ActiveSupport::TestCase
       current_user: build_edit_user
     )
     search = Search::Base.new(params)
-    assert search.executed_query.results.size == 34, "34 expected."
+    assert search.executed_query.results.size == 35,
+      "35 expected not #{search.executed_query.results.size}"
   end
 end


### PR DESCRIPTION
NSL-2820: Synonymy typeahead: Treat 4 consecutive digits as a year for searching, rather than just any sequence of digits; improve placeholder text