### PR TITLE
NSL-4483:  Services: Remove unnecessary services index page which listed the ping service. 

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -19,10 +19,6 @@
 class ServicesController < ApplicationController
   skip_before_action :authenticate
 
-  def index
-    render layout: "services"
-  end
-
   def ping
     render plain: "✓", status: :ok, layout: false
   end

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 21-Feb-2024
+  :jira_id: '4483'
+  :description: |-
+    Services: Remove unnecessary services index page which listed the ping service.  Ping, build, and other services will still be available.
+- :date: 21-Feb-2024
   :jira_id: '4633'
   :description: |-
     Loader: Minor tweak to Ref Instance tab logic to remove unneeded SQL query for synonym logic - no change to behaviour

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,6 @@ Rails.application.routes.draw do
   match "/ping", as: "ping_service", to: "services#ping", via: :get
   match "/version", as: "version_service", to: "services#version", via: :get
   match "/build", as: "build_service", to: "services#build", via: :get
-  match "services", as: "services", to: "services#index", via: :get
 
   resources :name_tag_names, only: %i[show post create new]
   match "name_tag_names/:name_id/:tag_id",

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.14.58
+appversion=4.0.14.59

--- a/test/controllers/services_controller_test.rb
+++ b/test/controllers/services_controller_test.rb
@@ -23,13 +23,19 @@ class ServicesControllerTest < ActionController::TestCase
   setup do
   end
 
-  test "unauthenticated user should get index" do
+  test "no user should get index" do
+    assert_raises(ActionController::UrlGenerationError) {
     get(:index, params: {}, session: {})
-    assert_response :success
+    }
   end
 
   test "unauthenticated user should get ping" do
     get(:ping, params: {}, session: {})
+    assert_response :success
+  end
+
+  test "unauthenticated user should get build" do
+    get(:build, params: {}, session: {})
     assert_response :success
   end
 end


### PR DESCRIPTION
Ping, build, and other services will still be available.