### PR TITLE
NSL-4847:  Loader: Correct instance now being carried across when synonyms are copied into the loader

### DIFF
--- a/app/models/concerns/loader/name/sourced_synonyms.rb
+++ b/app/models/concerns/loader/name/sourced_synonyms.rb
@@ -17,7 +17,7 @@ module Loader::Name::SourcedSynonyms
                                full_name: sou_syn.name.full_name,
                                family: sou_syn.name.family.simple_name,
                                doubtful: sou_syn.instance_type.doubtful,
-                               loaded_from_instance_id: sou_syn.id,
+                               loaded_from_instance_id: sou_syn.cites_id,
                                created_manually: true,
                                created_by: current_user.username,
                                updated_by: current_user.username,

--- a/app/views/loader/names/tabs/_tab_matched_name.html.erb
+++ b/app/views/loader/names/tabs/_tab_matched_name.html.erb
@@ -8,7 +8,9 @@
     <ul>
       <li><%= loader_name_match.name.full_name %></li>
       <li><%= loader_name_match.instance.reference.citation %></li>
-      <li><%= loader_name_match.instance.page %></li>
+      <% unless loader_name_match.instance.page.blank? %>
+        <li><%= loader_name_match.instance.page %></li>
+      <% end %>
           <% if @loader_name.accepted? %>
             (No instance type to edit for accepted names.)
           <% else %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 21-Feb-2024
+  :jira_id: '4847'
+  :description: |-
+    Loader: Correct instance now being carried across when synonyms are copied into the loader from a standalone instance with synonyms
+- :date: 21-Feb-2024
   :jira_id: '4483'
   :description: |-
     Services: Remove unnecessary services index page which listed the ping service.  Ping, build, and other services will still be available.

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.14.59
+appversion=4.0.14.60


### PR DESCRIPTION
This is when copying synonyms from a standalone instance with synonyms into a loader batch.