### PR TITLE
NSL-4944: Loader: Allow copy of concepts to a loader batch from target instances only

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -251,7 +251,9 @@ class InstancesController < ApplicationController
     end
     offer << "tab_comments"
     offer << "tab_copy_to_new_reference" if offer_tab_copy_to_new_ref?
-    if Rails.configuration.try('batch_loader_aware') && can?('loader/names', 'update')
+    if Rails.configuration.try('batch_loader_aware') &&
+          can?('loader/names', 'update') &&
+          offer_loader_tab?
         offer << "tab_batch_loader" 
     end
     offer
@@ -260,6 +262,15 @@ class InstancesController < ApplicationController
   def offer_tab_copy_to_new_ref?
     @instance.standalone? &&
       params["row-type"] == "instance_as_part_of_concept_record"
+  end
+
+  def offer_loader_tab?
+    return true if @instance.standalone? &&
+      params["row-type"] == "instance_as_part_of_concept_record"
+    return true if @instance.relationship? &&
+      params["row-type"] == "instance_is_cited_by" && !@instance.unsourced?
+
+    false
   end
 
   def render_create_error(base_error_string, focus_id)

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 26-Feb-2024
+  :jira_id: '4944'
+  :description: |-
+    Loader: Allow copy of concepts to a loader batch from target instances only
 - :date: 23-Feb-2024
   :jira_id: '4937'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.14.64
+appversion=4.0.15.01


### PR DESCRIPTION
Limit the display of Instance Loader tab in a way similar to the Copy tab, but extended to synonyms.  