### PR TITLE
NSL-4941: Loader: When copying synonymy include existing matches for misapplications

### DIFF
--- a/app/models/concerns/loader/name/preferred_match.rb
+++ b/app/models/concerns/loader/name/preferred_match.rb
@@ -7,8 +7,6 @@ module Loader::Name::PreferredMatch
   end
 
   def create_match_to_loaded_from_instance_name(current_user_username)
-    return if misapplied?
-
     instance = Instance.find(loaded_from_instance_id)
     loader_name_match = ::Loader::Name::Match.new
     loader_name_match.loader_name_id = id

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 26-Feb-2024
+  :jira_id: '4941'
+  :description: |-
+    Loader: When copying synonymy include existing matches for misapplications
+- :date: 26-Feb-2024
   :jira_id: '4946'
   :description: |-
     Search: Remove some code no longer used 

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.15.02
+appversion=4.0.15.03


### PR DESCRIPTION
…misapplications