### PR TITLE
NSL-4945:  Loader: Searches on any-batch: with an argument will give an error message; field help now also explains it takes no argument

### DIFF
--- a/app/models/search/loader/name/field_rule.rb
+++ b/app/models/search/loader/name/field_rule.rb
@@ -718,7 +718,8 @@ having count(*) > 2
    and parent_match.name_id != cot_name.id
    and child.record_type != 'misapplied'
      ))"},
-  "any-batch:" => { where_clause: "1=1" },
+  "any-batch:" => { where_clause: "1=1",
+                    takes_no_arg: true},
   "no-family-heading:" => { 
       where_clause: "id in (
       select id 

--- a/app/views/loader/names/help/_fields.html.erb
+++ b/app/views/loader/names/help/_fields.html.erb
@@ -6,7 +6,7 @@
   <% [
     {field_name: 'batch-id:', descr: "Search within a batch using its ID."},
     {field_name: 'batch-name:', descr: "Search within a batch using its name. Accepts wild-cards."},
-    {field_name: 'any-batch:', descr: "Search across all batches."},
+    {field_name: 'any-batch:', descr: "Search across all batches. Takes no argument."},
     {field_name: 'id:', descr: "Search by ID or IDs (comma separated)."},
     {field_name: 'raw-id:', descr: "Search by raw-ID or raw-IDs (comma separated). Raw ID is the ID assigned in the original data - these can be duplicated across batches."},
     {field_name: 'has-review-comment:',

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 27-Feb-2024
+  :jira_id: '4945'
+  :description: |-
+    Loader: Searches on <code>any-batch:</code> with an argument will give an error message; field help now also explains it takes no argument
+- :date: 27-Feb-2024
   :jira_id: '4948'
   :description: |-
     Loader: Changes to Ref Instance tab in hopes of reducing the sticky tabs problem

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.15.05
+appversion=4.0.15.06


### PR DESCRIPTION
Added this to the on_model search code, which is the latest version of the search engine.