### PR TITLE
NSL-5017:  Loader: Require an argument for search directive syn-match-in-tree

### DIFF
--- a/app/models/search/loader/name/field_rule.rb
+++ b/app/models/search/loader/name/field_rule.rb
@@ -623,7 +623,8 @@ having count(*) > 2
    and tjv.accepted_tree
    and ln.synonym_type not like '%partial%'
    and ln.partly is null
-   and lower(ln.simple_name) like lower(?))"
+   and lower(ln.simple_name) like lower(?))",
+   not_exists_clause: " needs an argument"
      },
 "syn-match-in-tree-family:" => { where_clause: " id in (select ln.id
   from loader_name ln 

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 09-Apr-2024
+  :jira_id: '5017'
+  :description: |-
+    Loader: Require an argument for search directive <code>syn-match-in-tree</code>
 - :date: 08-Apr-2024
   :jira_id: '5005'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.17.4
+appversion=4.0.17.5


### PR DESCRIPTION
If syn-match-in-tree directive is submitted without an argument the user gets a general message urging them to review their search directives and arguments.