### PR TITLE
NSL-4966: Loader: Allow family search directive on the loader tab to accept a comma-separated list of family names

### DIFF
--- a/app/views/loader/batches/bulk/_form.html.erb
+++ b/app/views/loader/batches/bulk/_form.html.erb
@@ -4,6 +4,7 @@ Directives available here: <code>family: [family name string]</code>,  <code>acc
 <br>
 Wildcards are allowed but are <b>not</b> added automatically.<br>
 (Adding them automatically would stop you specifying non-wildcarded sets of names to process.)<br>
+Special usage for Create Preferred Matches, Create Draft Instances, and Add to Taxonomy - the <code>family:</code> directive can take a comma-separated list of family names <em>without</em> wildcards<br>
 <%= form_tag({controller: "loader/batch/bulk", action: "operation"}, method: "post", remote: true) do %>
 
   <div class="width-64em">

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 09-Apr-2024
+  :jira_id: '4966'
+  :description: |-
+    Loader: Allow <code>family</code> search directive on the loader tab to accept a comma-separated list of family names but without wildcards
+- :date: 09-Apr-2024
   :jira_id: '5017'
   :description: |-
     Loader: Require an argument for search directive <code>syn-match-in-tree</code>


### PR DESCRIPTION
But the list of family names will use a SQL "in" clause so wildcards won't work.