### PR TITLE
NSL-4979: Loader: Improve accuracy of decline reasons for job that creates preferred matches

### DIFF
--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 11-Apr-2024
+  :jira_id: '4979'
+  :description: |-
+    Loader: Improve accuracy of decline reasons for job that creates preferred matches
 - :date: 10-Apr-2024
   :release: true
 - :date: 10-Apr-2024

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.18.0
+appversion=4.0.18.1


### PR DESCRIPTION
Three decline tests were bundled into one decline path, so separate these decline tests into separate steps.

Also minor refactoring by adding a single decline method that takes the reason as an argument.

Retain the correct process for allowing the job to collect numbers declined and reasons declined.