### PR TITLE
NSL-4997: Loader: Prevent edits to simple or full name when a preferred match has been set

### DIFF
--- a/app/views/loader/names/tabs/forms/_form_for_accepted_or_excluded.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_accepted_or_excluded.html.erb
@@ -25,23 +25,7 @@
 
     <%= render partial: "loader/names/tabs/forms/sort_key_or_seq", locals: {loader_name: loader_name, f: f} %>
 
-    <div class="form-group">
-      <label for="simple_name">Simple Name*</label>
-      <%= f.text_field :simple_name, class: 'form-control', required: true, title: "Enter simple name - the value of simple name, as loaded is retained in simple name as loaded", tabindex: increment_tab_index, autofocus: true %>
-      <% unless loader_name.simple_name == loader_name.simple_name_as_loaded %>
-        <p>As originally loaded: <%= loader_name.simple_name_as_loaded %></p>
-        <p>Simple Name is used for matching with name records, so editing it will likely change the matches.</p>
-      <% end %>
-    </div>
-
-
-    <div class="form-group">
-      <label for="full_name">Full Name*</label>
-      <%= f.text_field :full_name, class: 'form-control',
-        required: true, title: "Enter full name",
-        tabindex: increment_tab_index, autofocus: true %>
-    </div>
-
+    <%= render partial: "loader/names/tabs/forms/simple_name_full_name", locals: {loader_name: loader_name, f: f} %>
 
     <div class="form-group">
       <label for="family">Family Name*</label>

--- a/app/views/loader/names/tabs/forms/_form_for_heading.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_heading.html.erb
@@ -26,21 +26,7 @@
 
     <%= render partial: "loader/names/tabs/forms/sort_key_or_seq", locals: {loader_name: loader_name, f: f} %>
 
-    <div class="form-group">
-      <label for="simple_name">Simple Name*</label>
-      <%= f.text_field :simple_name, class: 'form-control give-me-focus', required: true, title: "Enter simple name - the value of simple name, as loaded is retained in simple name as loaded", tabindex: increment_tab_index, autofocus: true %>
-      <% unless loader_name.simple_name == loader_name.simple_name_as_loaded %>
-        <p>As originally loaded: <%= loader_name.simple_name_as_loaded %></p>
-        <p>Simple Name is used for matching with name records, so editing it will likely change the matches.</p>
-      <% end %>
-    </div>
-
-    <div class="form-group">
-      <label for="full_name">Full Name*</label>
-      <%= f.text_field :full_name, class: 'form-control give-me-focus',
-        required: true, title: "Enter full name",
-        tabindex: increment_tab_index, autofocus: true %>
-    </div>
+    <%= render partial: "loader/names/tabs/forms/simple_name_full_name", locals: {loader_name: loader_name, f: f} %>
 
     <div class="form-group">
       <label for="family">Family Name*</label>

--- a/app/views/loader/names/tabs/forms/_form_for_misapp.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_misapp.html.erb
@@ -2,15 +2,7 @@
 
     <%= render partial: "loader/names/tabs/forms/sort_key_or_seq", locals: {loader_name: loader_name, f: f} %>
 
-    <div class="form-group">
-      <label for="simple_name">Simple Name*</label>
-      <%= f.text_field :simple_name, class: 'form-control', required: true, title: "Enter simple name", tabindex: increment_tab_index, autofocus: true %>
-    </div>
-
-    <div class="form-group">
-      <label for="full_name">Full Name*</label>
-      <%= f.text_field :full_name, class: 'form-control', required: true, title: "Enter full name", tabindex: increment_tab_index, autofocus: true %>
-    </div>
+    <%= render partial: "loader/names/tabs/forms/simple_name_full_name", locals: {loader_name: loader_name, f: f} %>
 
     <div class="form-group">
       <label for="rank">Rank</label>

--- a/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
@@ -2,16 +2,7 @@
 
     <%= render partial: "loader/names/tabs/forms/sort_key_or_seq", locals: {loader_name: loader_name, f: f} %>
 
-    <div class="form-group">
-      <label for="simple_name">Simple Name*</label>
-      <%= f.text_field :simple_name, class: 'form-control give-me-focus', required: true, title: "Enter simple name", tabindex: increment_tab_index, autofocus: true %>
-    </div>
-
-    <div class="form-group">
-      <label for="full_name">Full Name*</label>
-      <%= f.text_field :full_name, class: 'form-control give-me-focus',
-        required: true, title: "Enter full name", tabindex: increment_tab_index %>
-    </div>
+    <%= render partial: "loader/names/tabs/forms/simple_name_full_name", locals: {loader_name: loader_name, f: f} %>
 
     <div class="form-group">
       <label for="rank">Rank</label>

--- a/app/views/loader/names/tabs/forms/_simple_name_full_name.html.erb
+++ b/app/views/loader/names/tabs/forms/_simple_name_full_name.html.erb
@@ -1,0 +1,38 @@
+
+    <% if loader_name.preferred_match? %>
+
+      Has preferred match - cannot edit simple name.
+      <br>
+      <label for="simple_name">Simple Name*</label>
+      <br>
+      <%= loader_name.simple_name %>
+      <br>
+      <br>
+      Has preferred match - cannot edit full name.
+      <br>
+      <label for="full_name">Full Name*</label>
+      <br>
+      <%= loader_name.full_name %>
+      <br>
+      <br>
+    <% else %>
+
+    <div class="form-group">
+      <label for="simple_name">Simple Name*</label>
+      <%= f.text_field :simple_name, class: 'form-control', required: true, title: "Enter simple name - the value of simple name, as loaded is retained in simple name as loaded", tabindex: increment_tab_index, autofocus: true %>
+      <% unless loader_name.simple_name == loader_name.simple_name_as_loaded %>
+        <p>As originally loaded: <%= loader_name.simple_name_as_loaded %></p>
+        <p>Simple Name is used for matching with name records, so editing it will likely change the matches.</p>
+      <% end %>
+    </div>
+
+
+    <div class="form-group">
+      <label for="full_name">Full Name*</label>
+      <%= f.text_field :full_name, class: 'form-control',
+        required: true, title: "Enter full name",
+        tabindex: increment_tab_index, autofocus: true %>
+    </div>
+
+    <% end %>
+

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 11-Apr-2024
+  :jira_id: '4997'
+  :description: |-
+    Loader: Prevent edits to simple or full name when a preferred match has been set
+- :date: 11-Apr-2024
   :jira_id: '4979'
   :description: |-
     Loader: Improve accuracy of decline reasons for job that creates preferred matches

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.18.1
+appversion=4.0.18.2


### PR DESCRIPTION
Changes apply to forms for 
 - accepted/excluded names
 - synonyms
 - misapplieds
 - headings (just in case)

Extracted code for simple and full names into a partial to make this cleaner.