### PR TITLE
Fix definition of class to match file path for editor/app/controllers/name/matches/typeaheads/for_unpub_cit_controller.rb

### DIFF
--- a/app/controllers/name/matches/typeaheads/for_unpub_cit_controller.rb
+++ b/app/controllers/name/matches/typeaheads/for_unpub_cit_controller.rb
@@ -17,7 +17,7 @@
 #   limitations under the License.
 #
 #   Names are central to the NSL.
-class Names::Typeaheads::ForUnpubCitController < ApplicationController
+class Names::Matches::Typeaheads::ForUnpubCitController < ApplicationController
   def index
     typeahead = Name::AsTypeahead::ForUnpubCit.new(params)
     render json: typeahead.suggestions

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.18.9
+appversion=4.0.18.10


### PR DESCRIPTION
…/name/matches/typeaheads/for_unpub_cit_controller.rb