### PR TITLE
NSL-5013:  Loader: Stop flagging synonyms as clashing with names in taxonomy if the synonym loader_name_match record has a partial relationship type

### DIFF
--- a/app/controllers/loader/batch/bulk_controller/remove_syn_conflicts_job.rb
+++ b/app/controllers/loader/batch/bulk_controller/remove_syn_conflicts_job.rb
@@ -50,7 +50,6 @@ class Loader::Batch::BulkController::RemoveSynConflictsJob
     preflight_check_for_nfp(tree_join_record)
     true
   rescue => e
-    Rails.logger.error("Loader::Batch::BulkController::RemoveSynConflictsJob.preflight_checks_pass?: #{e}")
     log_preflight_decline_to_table(tree_join_record, e.to_s)
     result_h = {attempts: 1, declines: 1, decline_reasons: {"#{e.to_s}": 1}}
     @job_h.deep_merge!(result_h) { |key, old, new| old + new}

--- a/app/models/concerns/loader/name/partials.rb
+++ b/app/models/concerns/loader/name/partials.rb
@@ -1,4 +1,4 @@
-module Loader::Name::Misapplieds
+module Loader::Name::Partials
   extend ActiveSupport::Concern
 
   # synonym_type takes precedence
@@ -8,5 +8,10 @@ module Loader::Name::Misapplieds
     else
       publ_partly&.match(/p\.p\./)
     end
+  end
+
+  def partial_or_match_is_partial?
+    synonym_type&.match?(/pro parte/) |
+      preferred_match&.relationship_instance_type&.pro_parte?
   end
 end

--- a/app/models/loader/name.rb
+++ b/app/models/loader/name.rb
@@ -27,7 +27,7 @@ class Loader::Name < ActiveRecord::Base
   include InBatchNote
   include InBatchCompilerNote
   include HeadingRecord
-  include Misapplieds
+  include Partials
   include Doubt
   include SeqGapMaker
   attr_accessor :add_sibling_synonyms

--- a/app/models/loader/name/bulk_syn_conflicts_search.rb
+++ b/app/models/loader/name/bulk_syn_conflicts_search.rb
@@ -40,16 +40,19 @@ class Loader::Name::BulkSynConflictsSearch
   # and the loader_name_match is for a loader_name
   # and the name's name status is legitimate or n/a
   # in a nominated batch
+  # and the preferred match is not a partial relationship instance type
   def bulk_processing_search
     @search = TreeJoinV
     .joins(" inner join instance on instance.id = tree_join_v.instance_id")
     .joins(" inner join name on instance.name_id = name.id")
     .joins(" inner join loader_name_match on loader_name_match.name_id = name.id")
+    .joins(" inner join instance_type on instance_type.id = loader_name_match.relationship_instance_type_id")
     .joins(" inner join loader_name on loader_name.id = loader_name_match.loader_name_id")
     .joins(" inner join loader_batch on loader_batch.id = loader_name.loader_batch_id")
     .where(" loader_name.loader_batch_id = ? ", @batch_id)
     .where(" loader_name.record_type = 'synonym' ")
     .where(" loader_name.synonym_type not like '%partial%' ")
+    .where(" not instance_type.pro_parte ")
     .where(" loader_name.partly is null ")
     .where(" tree_join_v.published = false ")
     .where(" tree_join_v.accepted_tree = true ")

--- a/app/models/loader/name/match.rb
+++ b/app/models/loader/name/match.rb
@@ -22,21 +22,28 @@ class Loader::Name::Match < ActiveRecord::Base
   self.table_name = "loader_name_match"
   self.primary_key = "id"
   self.sequence_name = "nsl_global_seq"
-  belongs_to :loader_name, class_name: "Loader::Name", foreign_key: "loader_name_id"
+  belongs_to :loader_name, class_name: "Loader::Name",
+                foreign_key: "loader_name_id"
   belongs_to :name, class_name: "::Name", foreign_key: "name_id"
   belongs_to :instance
-  belongs_to :instance_type, foreign_key: :relationship_instance_type_id, optional: true
   belongs_to :standalone_instance, class_name: "::Instance",
-                                   foreign_key: "standalone_instance_id", optional: true
+                foreign_key: "standalone_instance_id", optional: true
   belongs_to :relationship_instance, class_name: "::Instance",
-                                     foreign_key: "relationship_instance_id", optional: true
+                foreign_key: "relationship_instance_id", optional: true
+
+  # would like to deprecate instance_type in favour of 
+  # relationship_instance_type
+  belongs_to :instance_type, 
+                foreign_key: :relationship_instance_type_id, optional: true
+  belongs_to :relationship_instance_type, class_name: "::InstanceType",
+                foreign_key: "relationship_instance_type_id", optional: true
+
   belongs_to :source_for_copy, class_name: "::Instance",
-                               foreign_key: "source_for_copy_instance_id", optional: true
+                foreign_key: "source_for_copy_instance_id", optional: true
   belongs_to :intended_tree_parent_name, class_name: "::Name",
-                                             foreign_key: "intended_tree_parent_name_id", 
-                                             optional: true
+                foreign_key: "intended_tree_parent_name_id", optional: true
   validates :loader_name_id, uniqueness: true,
-                             unless: proc { |a| a.loader_name.record_type == "misapplied" }
+                unless: proc { |a| a.loader_name.record_type == "misapplied" }
   validate :misapp_pref_matches_from_only_one_name
 
   before_destroy :can_destroy?

--- a/app/models/search/loader/name/field_rule.rb
+++ b/app/models/search/loader/name/field_rule.rb
@@ -608,6 +608,8 @@ having count(*) > 2
   from loader_name ln 
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
+       join instance_type rel_type
+       on lnm.relationship_instance_type_id = rel_type.id
        join instance i
        on lnm.name_id = i.name_id 
        join tree_join_v tjv 
@@ -620,6 +622,7 @@ having count(*) > 2
    and not tjv.published
    and tjv.accepted_tree
    and ln.synonym_type not like '%partial%'
+   and not rel_type.pro_parte
    and ln.partly is null
    and lower(ln.simple_name) like lower(?))",
    not_exists_clause: " needs an argument"
@@ -628,6 +631,8 @@ having count(*) > 2
   from loader_name ln 
        join loader_name_match lnm
        on ln.id = lnm.loader_name_id
+       join instance_type rel_type
+       on lnm.relationship_instance_type_id = rel_type.id
        join instance i
        on lnm.name_id = i.name_id 
        join tree_join_v tjv 
@@ -640,6 +645,7 @@ having count(*) > 2
    and not tjv.published
    and tjv.accepted_tree
    and ln.synonym_type not like '%partial%'
+   and not rel_type.pro_parte
    and ln.partly is null
    and lower(ln.family) like lower(?))",
    not_exists_clause: " needs an argument"

--- a/app/views/loader/names/tabs/details/matches/synonyms/forms/preferred_matches/_one_match.html.erb
+++ b/app/views/loader/names/tabs/details/matches/synonyms/forms/preferred_matches/_one_match.html.erb
@@ -26,8 +26,10 @@
                           title: "Search for #{matching_name.full_name}",
                           class: 'blue') %>
 
-          <% if TreeJoinV.synonym_in_names?(matching_name.id) %>
-            <span class="red">Warning: synonym is a name in the accepted tree</span>
+          <% unless @loader_name.partial_or_match_is_partial? %>
+            <% if TreeJoinV.synonym_in_names?(matching_name.id) %>
+              <span class="red">Warning: synonym is a name in the accepted tree</span>
+            <% end %>
           <% end %>
       <br>
     <% matching_name.primary_instances.each do |p_i| %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 17-May-2024
+  :jira_id: '5013'
+  :description: |-
+    Loader: Stop flagging synonyms as clashing with names in taxonomy if the synonym <code>loader_name_match</code> record has a partial relationship type
 - :date: 16-May-2024
   :jira_id: '5073'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.20.11
+appversion=4.0.20.12


### PR DESCRIPTION
Required changes to:

  * syn-match-in-tree report sql
  * syn-match-in-tree family sql
  * loader name details tab warning code
  * search for bulk job to remove syn conflicts