### PR TITLE
NSL-5086: Loader: Refresh sort key values when loader records are edited

### DIFF
--- a/app/models/concerns/loader/name/sort_key.rb
+++ b/app/models/concerns/loader/name/sort_key.rb
@@ -3,41 +3,42 @@ module Loader::Name::SortKey
 
   def consider_sort_key
     if loader_batch.use_sort_key_for_ordering
-      set_sort_key_if_blank
+      set_sort_key if sort_key.blank?
+      set_sort_key if should_reset_sort_key?
     else
       self.sort_key = nil
     end
   end
 
-  # If a user sets a sort key we want to respect that
-  # so don't over-write it
-  # Conversely, if a user wants a sort_key reset they can simply
-  # blank it out and hit save.
-  def set_sort_key_if_blank
+  def should_reset_sort_key?
+    return false if %w(in-batch-note in-batch-compile-note heading).include? record_type
+    return true if self.changed? && !self.changes_to_save.keys.include?('sort_key')
+    false    
+  end
+
+  def set_sort_key
     normalise_sort_key unless sort_key.blank?
-    if sort_key.blank?
-      case record_type
-      when "accepted"
-        self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{' agenus' if rank == 'genus'}"
-      when "excluded"
-        self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{' agenus' if rank == 'genus'}"
-      when "synonym"
-        self.sort_key = synonym_sort_key(parent.sort_key)
-      when "misapplied"
-        self.sort_key = misapp_sort_key(parent.sort_key)
-      when "heading"
-        self.sort_key = if rank.blank? || rank.downcase == "family"
-                          "#{family.downcase}.family"
-                        else
-                          "aaa-rank-#{rank}-heading"
-                        end
-      when "in-batch-note"
-        self.sort_key = in_batch_note_sort_key if sort_key.blank?
-      when "in-batch-compiler-note"
-        self.sort_key = in_batch_compiler_note_sort_key if sort_key.blank?
-      else
-        self.sort_key = "aaaaaa-unexpected-record-type-#{record_type}"
-      end
+    case record_type
+    when "accepted"
+      self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{' agenus' if rank == 'genus'}"
+    when "excluded"
+      self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{' agenus' if rank == 'genus'}"
+    when "synonym"
+      self.sort_key = synonym_sort_key(parent.sort_key)
+    when "misapplied"
+      self.sort_key = misapp_sort_key(parent.sort_key)
+    when "heading"
+      self.sort_key = if rank.blank? || rank.downcase == "family"
+                        "#{family.downcase}.family"
+                      else
+                        "aaa-rank-#{rank}-heading"
+                      end
+    when "in-batch-note"
+      self.sort_key = in_batch_note_sort_key
+    when "in-batch-compiler-note"
+      self.sort_key = in_batch_compiler_note_sort_key
+    else
+      self.sort_key = "aaaaaa-unexpected-record-type-#{record_type}"
     end
   rescue StandardError => e
     puts e

--- a/app/views/loader/names/tabs/forms/_sort_key_or_seq.html.erb
+++ b/app/views/loader/names/tabs/forms/_sort_key_or_seq.html.erb
@@ -3,7 +3,8 @@
    <div class="form-group">
         <label for="sort_key">Sort key</label>
         <%= f.text_field :sort_key, class: 'form-control', title: "Enter sorting value", tabindex: increment_tab_index %>
-        <p>This value is generated automatically when you clear it or leave it blank.  Edit it for special cases only.</p>
+        <p>This value is generated automatically when you clear it or leave it blank.  Edit it for special cases only.
+        It will be refreshed on all updates unless the record is a header or a note</p>
    </div>
    <% end %>
 <% else %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 06-Jun-2024
+  :jira_id: '5086'
+  :description: |-
+    Loader: Refresh sort key values when loader records are edited
+- :date: 06-Jun-2024
   :jira_id: '5098'
   :description: |-
     Loader: Use <code>misapp_html</code> for misapplications in 2022 Updates list

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.22.7
+appversion=4.0.22.8


### PR DESCRIPTION
### Change
In general, when you save changes to a `loader_name` record the `sort_key` will be reset.  That general rule has some exceptions and details to understand.

#### Detailed Rules for sort_key being set or reset
1. If the batch is sequence-ordered the `sort_key` will be emptied.
1. For `sort_key` ordered batches:
     1. if `sort_key` is empty it will be set to a calculated/default value
     1. if `sort_key` has a value and the `record_type` is one of the following it will not be reset:
             - heading
             - in-batch-note
             - in-batch-compiler-note

     1. if `sort_key` has a value and the `sort_key` was NOT also changed in the submitted data, the value will  be reset
             -  we assume a change to `sort_key` value is someone setting a custom value, that’s why we don’t reset it in this case