### PR TITLE
NSL-5099:  Loader: Added elapsed time to the job summary reports.

### DIFF
--- a/app/controllers/loader/batch/bulk_controller/create_preferred_matches_job.rb
+++ b/app/controllers/loader/batch/bulk_controller/create_preferred_matches_job.rb
@@ -19,6 +19,7 @@
 # Record a preferred matching name for a raw loader name record.
 class Loader::Batch::BulkController::CreatePreferredMatchesJob
   def initialize(batch_id, search_string, authorising_user, job_number)
+    @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     @batch = Loader::Batch.find(batch_id)
     @search_string = search_string
     @authorising_user = authorising_user
@@ -28,15 +29,27 @@ class Loader::Batch::BulkController::CreatePreferredMatchesJob
 
   def run
     log_start
-    @job_h = {attempts: 0, creates: 0, declines: 0, errors: 0}
+    @job_h = {Job: 'Create Preferred Matches',
+              Job_batch: @batch.name,
+              Job_search: @search_string,
+              attempts: 0, creates: 0, declines: 0, errors: 0}
     @search.order(:seq).each do |loader_name|
       do_one_loader_name(loader_name)
     end
+    record_elapsed
     log_finish
     @job_h
   end
 
   private
+
+  def record_elapsed
+    finish_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    @job_h[:time_seconds] = (finish_time - @start_time).round(1)
+    if @job_h[:time_seconds] > 60
+      @job_h[:time] = "#{((finish_time - @start_time)/60).round} min #{((finish_time - @start_time)%60).round} sec"
+    end
+  end
 
   def do_one_loader_name(loader_name)
     @job_h[:attempts] += 1

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 07-Jun-2024
+  :jira_id: '5099'
+  :description: |-
+    Loader: Added elapsed time to the job summary reports; also added job title, batch, and search specification.
 - :date: 06-Jun-2024
   :jira_id: '5086'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.22.8
+appversion=4.0.22.9


### PR DESCRIPTION
Added elapsed time for these jobs:

  - create preferred matches
  - create draft instances
  - remove syn conflicts
  - add to draft taxonomy

The elapsed time is shown:

  - as seconds if less than 60 seconds
  - as seconds and as minutes/seconds if more than 60 seconds

I also added some extra useful information:

  - job title
  - job batch
  - job search specification