### PR TITLE
NSL-5104:  Editor: Make it possible to arrow in and out of new records created from the New menu

### DIFF
--- a/app/javascript/fresh.js
+++ b/app/javascript/fresh.js
@@ -729,10 +729,6 @@
       recordCurrentActiveTab(record_type);
       if (tabWasClicked) {
         debug('tab was clicked loadStandardDetails');
-        debug('tab was clicked loadStandardDetails');
-        debug('tab was clicked loadStandardDetails');
-        debug('tab was clicked loadStandardDetails');
-        debug('tab was clicked loadStandardDetails');
         if ($('.give-me-focus')) {
           return debug('give-me-focus ing - changed so not .give-me-focus ing because clicked a tab resulted in focus switching to the first record');
         } else {
@@ -828,7 +824,6 @@
         moveToSearchResultDetails($this, 'first');
         break;
       case arrowUp:
-        debug('searchResultKeyNavigation arrowUp');
         moveUpOneSearchResult($this);
         break;
       case arrowDown:
@@ -956,9 +951,6 @@
   };
 
   window.moveUpOneSearchResult = function(startRow) {
-    debug('moveUpOneSearchResult:  arrowUp');
-    debug('moveUpOneSearchResult:  '+startRow.prev().length.toString());
-    debug('moveUpOneSearchResult:  '+startRow.prev().find('a.show-details-link').length.toString());
     return startRow.prev().find('a.show-details-link').focus();
   };
 

--- a/app/models/name/as_new.rb
+++ b/app/models/name/as_new.rb
@@ -27,7 +27,7 @@ class Name::AsNew < Name
     name
   end
 
-  def self.scientific_family
+  def self.scientific_family_or_above
     name = Name.new
     name.name_type_id = NameType.find_by(name: "scientific").id
     name.name_rank_id = NameRank.find_by(name: "Familia").id

--- a/app/views/authors/_new_row.html.erb
+++ b/app/views/authors/_new_row.html.erb
@@ -1,4 +1,3 @@
-<% link = "link-new-author-#{@random_id}" %>
 <tr id="new-author-<%= @random_id %>" 
   class="new-record new-author search-result show-details"  
   data-record-type="author"
@@ -15,7 +14,7 @@
   <td class="takes-focus width-5-percent filler">&nbsp;</td>
   <script>
     $(document).ready(function () {
-      document.getElementById("<%= link %>").click();
+      document.getElementById("<%= link_id %>").click();
     })
   </script>
 </tr>

--- a/app/views/layouts/_new_menu.html.erb
+++ b/app/views/layouts/_new_menu.html.erb
@@ -20,8 +20,8 @@
 
 
             <li role="presentation">
-              <%= link_to "Scientific name family and above",
-                          name_new_row_path('scientific_family'),
+              <%= link_to "Scientific name family or above",
+                          name_new_row_path('scientific-family-or-above'),
                           title: 'Add a new scientific name family and above',
                           remote: true,
                           tabindex: '-1' %>

--- a/app/views/names/_new.html.erb
+++ b/app/views/names/_new.html.erb
@@ -2,6 +2,9 @@
   <div id="new-name-form-container" class="new-record-form-container">
             
     <h4><%= "New #{@name.name_category.name.titleize} Name".sub(/Name Name/,'Name') %></h4>
+    <% if @category == 'scientific-family-or-above' %>
+      <h5>Family or Above</h5>
+    <% end %>
     <hr>
     <%= render partial: 'names/form/base' %>
 

--- a/app/views/names/_new_row.html.erb
+++ b/app/views/names/_new_row.html.erb
@@ -1,30 +1,22 @@
-<% link = "link-new-thing-#{@random_id}" %>
-<tr id="new-name-<%= @random_id %>" 
-  class="new-record new-name"  
+<tr id="new-name-<%= @category %>-<%= @random_id %>" 
+  class="new-record new-name search-result show-details"  
   data-record-type="name"
   data-name-type="<%= @category %>"
-  data-edit-url="<%= new_name_path(@random_id) %>"
+  data-edit-url="<%= new_name_with_category_and_random_id_path(@category, @random_id) %>"
+  data-tab-url="<%= new_name_with_category_and_random_id_path(@category, @random_id) %>"
   tabindex="<%= increment_tab_index(100) %>"
     >
   <td class="nsl-tiny-icon-container takes-focus width-1-percent"><%= record_icon('name') %></td>
   <td class="text takes-focus name main-content min-width-40-percent max-width-100-percent width-90-percent give-me-focus" colspan="9">
-    <%= link_to("New #{@category} name", 
-                              new_name_path(category: @category, 
-                                            random_id: @random_id, 
-                                            tabIndex: increment_tab_index(0) + 5), 
-                              class: "show-details-link", 
-                              id: "#{link}",
-                              tabindex: "#{ increment_tab_index }", 
-                              title: "New name record.  Click to show details.",
-                              remote: true) %>
+    <a id="<%= link_id %>" class="show-details-link" title="<%= link_title %> Select to show details" tabindex="1000">
+      <%= link_text %> 
+    </a>
   </td>
   <td class="takes-focus width-5-percent filler">&nbsp;</td>
+  <script>
+    $(document).ready(function () {
+      document.getElementById("<%= link_id %>").click();
+    })
+  </script>
 </tr>
-
-<script>
-  $(document).ready(function () {
-    document.getElementById("<%= link %>").click();
-  })
-</script>
-
 

--- a/app/views/names/new.html.erb
+++ b/app/views/names/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'new' %>

--- a/app/views/names/new.js.erb
+++ b/app/views/names/new.js.erb
@@ -1,6 +1,0 @@
-$('div#search-result-details').html("<%= escape_javascript(h(render partial: 'new')) %>");
-$('.showing-details').removeClass('showing-details');
-$('tr#new-name-<%= params[:random_id] %>').addClass('showing-details');
-$('#search-result-details').show();
-$('#search-result-details').removeClass('hidden');
-

--- a/app/views/names/new_row.js.erb
+++ b/app/views/names/new_row.js.erb
@@ -1,2 +1,35 @@
-$('#search-results-table').prepend("<%= escape_javascript(h(render partial: 'new_row')) %>");
+if ($('#search-results-table tbody').length == 0) {
+  // No search results
+  $('#search-results-table').append("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+} else {
+  // Some search results
+  $('#search-results-table tr:first').before("<%= escape_javascript(h(render partial: partial, locals: locals_for_partial )) %>");
+};
+
 $('li.dropdown.open').removeClass('open');
+
+// set up events on the new row
+$(document).on('keydown', "#new-name-<%= @category %>-<%= @random_id %>", function(event){
+  return searchResultKeyNavigation(event, $(this));
+});
+
+//$('body').on('keydown', 'tr.search-result td.takes-focus', function(event) {
+  //return searchResultKeyNavigation(event, $(this));
+//});
+
+$('body').on('focus', 'tr.search-result td.takes-focus', function(event) {
+  return searchResultFocus(event, $(this).parent('tr'));
+});
+$('body').on('click', 'tr.search-result td.takes-focus', function(event) {
+  return searchResultFocus(event, $(this).parent('tr'));
+});
+$('tr.search-result td.takes-focus').focus(function(event) {
+  return searchResultFocus(event, $(this).parent('tr'));
+});
+
+$('tr.search-result td.takes-focus').click(function(event) {
+  debug('takes-focus event');
+  return searchResultFocus(event, $(this).parent('tr'));
+});
+
+

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 12-Jun-2024
+  :jira_id: '5104'
+  :description: |-
+    Editor: Make it possible to arrow in and out of new records created from the New menu (8 types of new Name records)
 - :date: 11-Jun-2024
   :jira_id: '5109'
   :description: |-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,12 +143,14 @@ Rails.application.routes.draw do
         as: "name_new_row",
         to: "names#new_row",
         via: :get,
-        type: /scientific|scientific_family|phrase|hybrid.*formula|hybrid-formula-unknown-2nd-parent|cultivar-hybrid|cultivar|other/
+        type: /scientific|scientific-family-or-above|phrase|hybrid.*formula|hybrid-formula-unknown-2nd-parent|cultivar-hybrid|cultivar|other/
   match "names/:id/tab/:tab", as: "name_tab", to: "names#tab", via: :get
   match "names/:id/tab/:tab/as/:new_category",
         as: "name_edit_as_category", to: "names#edit_as_category", via: :get
   match "names/:id/copy", as: "name_copy", to: "names#copy", via: :post
-  resources :names, only: %i[new create update destroy]
+  match "names/new/:category/:random_id",
+        as: "new_name_with_category_and_random_id", to: "names#new", via: :get
+  resources :names, only: %i[create update destroy]
   match "names/:id",
         as: "name_show",
         to: "names#show",

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.22.10
+appversion=4.0.22.11

--- a/test/controllers/names/new/scientific_family_or_above/simple_test.rb
+++ b/test/controllers/names/new/scientific_family_or_above/simple_test.rb
@@ -28,13 +28,14 @@ class NamesNewScientificFamilyOrAboveSimpleTest < ActionController::TestCase
     @request.session["user_full_name"] = "Fred Jones"
     @request.session["groups"] = ["edit"]
     get(:new,
-        params: { category: "scientific_family",
+        params: { category: "scientific-family-or-above",
                   random_id: "123445",
                   tabIndex: "107" },
         session: {},
         xhr: true)
     assert_response :success, "Cannot enter new scientific name family or above"
     assert_select("h4", /New Scientific Name/)
+    assert_select("h5", /Family or Above/)
     assert_select "input" do |inputs|
       inputs.each do |input|
         if input.to_s.match(/name-parent-typeahead/)

--- a/test/controllers/names/new_row/cultivar/simple_test.rb
+++ b/test/controllers/names/new_row/cultivar/simple_test.rb
@@ -35,7 +35,7 @@ class NamesNewRowCultivarNameSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element")
-    assert_match(/names.new.category=cultivar/,
+    assert_match(/New Cultivar Name/,
                  response.body.to_s,
                  "Missing expected element")
   end

--- a/test/controllers/names/new_row/cultivar_hybrid/simple_test.rb
+++ b/test/controllers/names/new_row/cultivar_hybrid/simple_test.rb
@@ -35,7 +35,7 @@ class NamesNewRowCultivarHybridNameSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element")
-    assert_match(/names.new.category=cultivar.hybrid/,
+    assert_match(/New Cultivar Hybrid Name/,
                  response.body.to_s,
                  "Missing expected element")
   end

--- a/test/controllers/names/new_row/hybrid_formula/simple_test.rb
+++ b/test/controllers/names/new_row/hybrid_formula/simple_test.rb
@@ -36,7 +36,7 @@ class NamesNewRowScientificHybridFormulaSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element 1")
-    assert_match(/names.new.category=hybrid.formula/,
+    assert_match(/New Hybrid Formula Name/,
                  response.body.to_s,
                  "Missing expected element 2")
   end

--- a/test/controllers/names/new_row/hybrid_formula_unknown_2nd_parent/simple_test.rb
+++ b/test/controllers/names/new_row/hybrid_formula_unknown_2nd_parent/simple_test.rb
@@ -37,7 +37,7 @@ class NamesNewRowScientHybridFormUnk2ParSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element 1")
-    assert_match(/names.new.category=hybrid.formula.unknown.2nd.parent/,
+    assert_match(/New Hybrid Formula Unknown 2nd Parent Name/,
                  response.body.to_s,
                  "Missing expected element 2")
   end

--- a/test/controllers/names/new_row/other/simple_test.rb
+++ b/test/controllers/names/new_row/other/simple_test.rb
@@ -35,7 +35,7 @@ class NamesNewRowOtherNameSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element")
-    assert_match(/names.new.category=other/,
+    assert_match(/New Other Name/i,
                  response.body.to_s,
                  "Missing expected element")
   end

--- a/test/controllers/names/new_row/phrase_name/simple_test.rb
+++ b/test/controllers/names/new_row/phrase_name/simple_test.rb
@@ -35,7 +35,7 @@ class NamesNewRowPhraseNameSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element")
-    assert_match(/names.new.category=phrase/,
+    assert_match(/New Phrase Name/,
                  response.body.to_s,
                  "Missing expected element")
   end

--- a/test/controllers/names/new_row/scientific/simple_test.rb
+++ b/test/controllers/names/new_row/scientific/simple_test.rb
@@ -35,7 +35,7 @@ class NamesNewRowScientificSimpleTest < ActionController::TestCase
     assert_match(/search-results-table/,
                  response.body.to_s,
                  "Missing expected element")
-    assert_match(/names.new.category=scientific/,
+    assert_match(/New Scientific Name/,
                  response.body.to_s,
                  "Missing expected element")
   end

--- a/test/controllers/names/routes/new_test.rb
+++ b/test/controllers/names/routes/new_test.rb
@@ -22,8 +22,10 @@ require "test_helper"
 class NameNewRouteTest < ActionController::TestCase
   tests NamesController
   test "names new should route to a new name" do
-    assert_routing "/names/new",
-                   controller: "names",
-                   action: "new"
+    assert_routing("/names/new/scientific/324133124124",
+                   {controller: "names",
+                    action: "new",
+                    category: 'scientific',
+                    random_id: '324133124124'})
   end
 end


### PR DESCRIPTION
Covers the 8 types of Name records

  - Arrow up/down navigation now working for the 8 types of new name records.

Extra changes

While working on the code for inserting new name records I noticed several trivial but annoying inconsistencies, so I tidied them up while there. 

  - Standardised the title case of the names on the LHS records to match the title on the RHS tab for each type of name.

Extras for “Scientific Name Family and Above”:

  - Changed the New menu entry from Scientific name family and above   to Scientific name family or above (and to or)
  - Changed the LHS record title from: New scientific_family name to New Scientific Name - Family or Above
  - Added a sub-heading on the RHS data entry form: Family or Above