### PR TITLE
NSL-5113:  Loader: Match relationship type will take account of doubt

### DIFF
--- a/app/models/concerns/loader/name/doubt.rb
+++ b/app/models/concerns/loader/name/doubt.rb
@@ -10,10 +10,27 @@ module Loader::Name::Doubt
   # This method may need to be adjusted to clarify rules in future.
   def doubtful?
     if synonym_type.present? 
-      return true if  self.synonym_type.match(/doubtful/)
+      return true if self.synonym_type.match(/doubtful/)
     else
       return true if self.doubtful == true
     end
+
+    false
+  end
+
+  # The method below is for use in the riti method.
+  #
+  # riti is used to determine the relationship instance type when 
+  # creating a preferred match
+  #
+  # The above doubtful? method was being called in riti but was creating 
+  # problems because it ignores the doubtful field when synonym type is present
+  # - and synonym_type is usually present in parsed synonyms, but, as parsed, 
+  # it ignores doubt # because doubt was recorded in a separate doubtful field.
+  #
+  def riti_doubtful?
+    return true if self.synonym_type.match(/doubtful/)
+    return true if self.doubtful == true
 
     false
   end

--- a/app/models/loader/name.rb
+++ b/app/models/loader/name.rb
@@ -318,18 +318,18 @@ class Loader::Name < ActiveRecord::Base
     return InstanceType.find_by_name(synonym_type || "misapplied").id if misapplied?
 
     if taxonomic?
-      return InstanceType.find_by_name("doubtful pro parte taxonomic synonym").id if doubtful? && pp?
+      return InstanceType.find_by_name("doubtful pro parte taxonomic synonym").id if riti_doubtful? && pp?
       
-      return InstanceType.find_by_name("doubtful taxonomic synonym").id if doubtful?
+      return InstanceType.find_by_name("doubtful taxonomic synonym").id if riti_doubtful?
 
       return InstanceType.find_by_name("pro parte taxonomic synonym").id if pp?
 
       return InstanceType.find_by_name("taxonomic synonym").id
 
     elsif nomenclatural?
-      return InstanceType.find_by_name("doubtful pro parte nomenclatural synonym").id if doubtful? && pp?
+      return InstanceType.find_by_name("doubtful pro parte nomenclatural synonym").id if riti_doubtful? && pp?
 
-      return InstanceType.find_by_name("doubtful nomenclatural synonym").id if doubtful?
+      return InstanceType.find_by_name("doubtful nomenclatural synonym").id if riti_doubtful?
 
       return InstanceType.find_by_name("pro parte nomenclatural synonym").id if pp?
 

--- a/app/views/loader/names/help/_fields.html.erb
+++ b/app/views/loader/names/help/_fields.html.erb
@@ -413,7 +413,7 @@
     {field_name: 'not-created-by:',
      description: "non-match on created by field"},
     {field_name: 'not-created-by-batch:',
-     description: "records note created by batch"},
+     description: "records not created by batch"},
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 12-Jun-2024
+  :jira_id: '5113'
+  :description: |-
+    Loader: Match relationship type will take account of doubt
+- :date: 12-Jun-2024
   :jira_id: '5112'
   :description: |-
     Editor: Remove repeated duplicate-of info from Author details tab metadata

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.22.12
+appversion=4.0.22.13


### PR DESCRIPTION
Background

In Feb I added a doubtful? method that gave precedence to loader_name.synonym_type - if that field existed, the code ignored loader_name.doubtful field.

This was designed for print output - displaying question marks.

Unfortunately it had a side-effect on the process for determining relationship type in preferred matches - result was that doubt was not taken into account for synonyms.

Change

I’ve now split the code so the side-effect will not happen.  Relationship type should now take account of doubt.

Extra

Also fixed incidental typo in loader name search help