### PR TITLE
NSL-2494: Ensure Name children/descendents' constructed fields are refreshed in more cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,8 +60,6 @@ group :test do
   gem "minitest"
   gem "minitest-rails"
   gem "minitest-reporters"
-  gem "mocha", "~> 1.11", ">= 1.11.2"
-  # gem "webdrivers"
   # NoMethodError: assert_template has been extracted to a gem. To continue using it, add:
   gem "rails-controller-testing"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,6 @@ GEM
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    mocha (1.16.1)
     msgpack (1.7.2)
     msgpack (1.7.2-java)
     net-imap (0.4.12)
@@ -371,7 +370,6 @@ DEPENDENCIES
   minitest
   minitest-rails
   minitest-reporters
-  mocha (~> 1.11, >= 1.11.2)
   net-ldap
   nokogiri (>= 1.13.4)
   pg (~> 1.1)

--- a/app/jobs/name_children_refresher_job.rb
+++ b/app/jobs/name_children_refresher_job.rb
@@ -3,15 +3,15 @@ class NameChildrenRefresherJob
   include SuckerPunch::Job
 
   def perform(name_id)
-    total = 0
-    npaths = 0
+    names_refreshed = 0
+    npaths_refreshed = 0
     Rails.logger.info("NameChildrenRefresherJob - a SuckerPunch::Job.")
     Rails.logger.info("May be asynchronous")
     ActiveRecord::Base.connection_pool.with_connection do
       name = Name.find(name_id)
-      total = name.refresh_tree
-      npaths = name.refresh_name_paths
+      names_refreshed = name.refresh_tree
+      npaths_refreshed = name.refresh_name_paths
     end
-    total
+    names_refreshed
   end
 end

--- a/app/models/concerns/name_namable.rb
+++ b/app/models/concerns/name_namable.rb
@@ -37,9 +37,6 @@ module NameNamable
   end
 
   def get_names_json
-    logger.debug("get_names_json start for id: #{id}")
-    logger.debug("Name::AsServices.name_strings_url(id) for
-                 id: #{id}: #{Name::AsServices.name_strings_url(id)}")
     JSON.load(RestClient.get(Name::AsServices.name_strings_url(id), "Accept" => "text/json"))
   end
 

--- a/app/models/concerns/name_name_pathable.rb
+++ b/app/models/concerns/name_name_pathable.rb
@@ -24,8 +24,12 @@ module NameNamePathable
     @tally ||= 0
     build_name_path
     if changed?
-      save!(touch: false)
-      @tally += 1
+      if name_path.blank?
+        logger.error("Error refreshing name_path for #{id}: empty name_path")
+      else
+        save!(touch: false)
+        @tally += 1
+      end
     end
     children.each do |child|
       @tally += child.refresh_name_paths

--- a/app/models/concerns/name_validatable.rb
+++ b/app/models/concerns/name_validatable.rb
@@ -53,6 +53,7 @@ module NameValidatable
               allow_blank: true
     validates :uri, uniqueness: true, allow_blank: true
     validate :genus_parent_must_match_family_if_both_ranked_family
+    validates :name_path, presence: true
   end
 
   def name_element_is_stripped

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 17-Jun-2024
+  :jira_id: '2494'
+  :description: |-
+    Name update: Ensure Name children/descendents' constructed fields are refreshed whenever a Name's simple or full name is changed
 - :date: 13-Jun-2024
   :jira_id: '5104'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.23.2
+appversion=4.0.23.3

--- a/test/controllers/names/edit/genus_name_update_with_no_name_change_test.rb
+++ b/test/controllers/names/edit/genus_name_update_with_no_name_change_test.rb
@@ -42,18 +42,16 @@ class GenusNameUpdateWithNoNameChangeTest < ActionController::TestCase
     stub_request(:get, %r{#{a}.nsl/services.rest.name.apni.[0-9]*.api.#{b}})
       .with(headers: { "Accept" => "text/json", "Accept-Encoding" => /.*/,
                        "User-Agent" => /rest-client.*ruby.*/ })
-      .to_return(status: 200, body: %({ "class": "silly name class",
-      "_links": { "permalink": [ ] }, "name_element":
-      "redundant name element for id 91755", "action": "unnecessary action",
-      "result": { "fullMarkedUpName": "full marked up name for id 91755",
-        "simpleMarkedUpName": "simple marked up name for id 91755",
-        "fullName": "full name for id 91755",
-        "simpleName": "simple name for id 91755" } }).to_json, headers: {})
+      .to_return(status: 200,
+                 body: {result: {simpleName:"Acacia",
+                                 fullName:"Acacia"}}.to_json,
+                 headers: {})
   end
+
 
   test "genus name update with no name change" do
     post(:update,
-         params: { name: { "name_element" => "Acacia", "verbatim_name" => "fred" },
+         params: { name: { "name_element" => "Acacia", "verbatim_rank" => "sp" },
                    id: @genus.id },
          session: { username: "fred",
                     user_full_name: "Fred Jones",
@@ -61,6 +59,7 @@ class GenusNameUpdateWithNoNameChangeTest < ActionController::TestCase
     assert_response :success
     sleep(2) # to allow for the asynch job
     species_afterwards = Name.find(@species.id)
+    genus_after = Name.find(@genus.id)
     assert @species.full_name == species_afterwards.full_name,
            "Genus name not changed so species's name should not change"
     subspecies_afterwards = Name.find(@subspecies.id)

--- a/test/models/name/create/author_and_ex_author_must_differ_test.rb
+++ b/test/models/name/create/author_and_ex_author_must_differ_test.rb
@@ -28,6 +28,7 @@ class AuthorExAuthorMustDifferOnCreateTest < ActiveSupport::TestCase
     @name.name_rank = name_ranks(:species)
     @name.name_status = name_statuses(:legitimate)
     @name.parent = names(:a_genus)
+    @name.name_path = 'must_not_by_empty'
     @name.created_by = "fred"
     @name.updated_by = "fred"
   end

--- a/test/models/name/create/base_author_and_ex_base_author_must_differ_test.rb
+++ b/test/models/name/create/base_author_and_ex_base_author_must_differ_test.rb
@@ -28,6 +28,7 @@ class BaseAuthorExBaseAuthorMustDifferOnCreateTest < ActiveSupport::TestCase
     @name.name_rank = name_ranks(:species)
     @name.name_status = name_statuses(:legitimate)
     @name.parent = names(:a_genus)
+    @name.name_path = 'must_not_by_empty'
     @name.created_by = "fred"
     @name.updated_by = "fred"
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,22 +17,11 @@
 #   limitations under the License.
 #
 
-# require 'simplecov'
-# SimpleCov.start
-
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
-# require File.expand_path("../../config/environment", __FILE__)
 
-require "mocha"
-# Mocha deprecation warning at /Users/gclarke/.gem/ruby/3.2.2/gems/zeitwerk-2.6.11/lib/zeitwerk/kernel.rb:38:in
-# `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
-require "mocha/api"
 require "webmock/minitest"
-
-# https://thoughtbot.com/blog/stubbing-and-setting-expectations-on-http-requests-is-now-easy-with-webmock
-include WebMock::API
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
I changed the algorithm so that children (and grandchildren, etc) are refreshed if either the simple_name or full_name of a name is altered (taking into account they are generated by calls to a service).

There will also be a message on screen to indicate such a downstream update has occurred.  

I also removed some unused testing gems while reviewing tests for this change.