### PR TITLE
NSL-5118:  Name Path Refresh: Prevent blank name_path being generated during refresh.

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -107,9 +107,9 @@ class NamesController < ApplicationController
                                        current_user.username)
     check_children(name_before_change) unless @message.downcase == 'no change'
     render "update"
-  rescue StandardError => e
-    @message = e.to_s
-    render "update_error", status: :unprocessable_entity
+  #rescue StandardError => e
+    #@message = e.to_s
+    #render "update_error", status: :unprocessable_entity
   end
 
   def rules

--- a/app/models/concerns/name_name_pathable.rb
+++ b/app/models/concerns/name_name_pathable.rb
@@ -7,29 +7,19 @@ module NameNamePathable
   def make_name_path
     path = ""
     path = parent.name_path if parent
-    path += "/" + name_element.strip if name_element
+    path += "/#{name_element&.strip}"
   end
 
   def build_name_path
     self.name_path = make_name_path
   end
 
-  def build_and_save_name_path
-    build_name_path
-    save!(touch: false) if changed?
-    1
-  end
-
   def refresh_name_paths
     @tally ||= 0
     build_name_path
     if changed?
-      if name_path.blank?
-        logger.error("Error refreshing name_path for #{id}: empty name_path")
-      else
-        save!(touch: false)
-        @tally += 1
-      end
+      save!(validate: false, touch: false)
+      @tally += 1
     end
     children.each do |child|
       @tally += child.refresh_name_paths

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 17-Jun-2024
+  :jira_id: '5118'
+  :description: |-
+    Name Path Refresh: Prevent blank <code>name_path</code> being generated during refresh, also prevent unrelated validation errors interrupting a refresh
+- :date: 17-Jun-2024
   :jira_id: '2494'
   :description: |-
     Name update: Ensure Name children/descendents' constructed fields are refreshed whenever a Name's simple or full name is changed (#2)

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.23.4
+appversion=4.0.23.5


### PR DESCRIPTION
Also prevent unrelated validation errors interrupting a refresh.

There was a rare case of records with null name_element exploiting a weakness in the name_path construction code leading to null name_path.

The code now properly returns a non-null name_path even for records with a null name_element.