### PR TITLE
NSL-5120: Loader: Typeahead for Taxonomy Parent on the Matched Name tab now offers scientific names only

### DIFF
--- a/app/models/loader/name/match/as_typeahead/for_intended_tree_parent_instance.rb
+++ b/app/models/loader/name/match/as_typeahead/for_intended_tree_parent_instance.rb
@@ -46,8 +46,10 @@ class Loader::Name::Match::AsTypeahead::ForIntendedTreeParentInstance
   def core_query
     Name.joins(:name_rank)
         .joins(:name_status)
+        .joins(:name_type)
         .where(['lower(f_unaccent(name.full_name)) like lower(f_unaccent(?))',
                 prepared_search_term])
+        .where("name_type.name = 'scientific'")
         .select("name.id, name.full_name, case name_status.name when 'legitimate' then null else name_status.name end as status")
         .order("name_rank.sort_order, name.full_name")
         .limit(SEARCH_LIMIT)

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 21-Jun-2024
+  :jira_id: '5120'
+  :description: |-
+    Loader: Typeahead for Taxonomy Parent on the Matched Name tab now offers scientific names only - common names are no longer offered
 - :date: 19-Jun-2024
   :jira_id: '5114'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.24.0
+appversion=4.0.24.1


### PR DESCRIPTION
Common names are no longer offered