### PR TITLE
NSL-5121:  New Record navigation: Extend fix to new Loader Name records

### DIFF
--- a/app/views/loader/names/_new_row.html.erb
+++ b/app/views/loader/names/_new_row.html.erb
@@ -10,7 +10,7 @@
   tabindex="<%= increment_tab_index(100) %>"
     >
   <td class="nsl-tiny-icon-container takes-focus width-1-percent"><%= record_icon('loader_name') %></td>
-  <td class="text takes-focus name main-content min-width-40-percent max-width-100-percent width-90-percent give-me-focus" colspan="9">
+  <td class="text takes-focus loader-name main-content min-width-40-percent max-width-100-percent width-90-percent give-me-focus" colspan="9">
     <a id="<%= link_id %>" class="show-details-link" title="<%= link_title %> Select to show details" tabindex="1000">
       <%= link_text %>
     </a>
@@ -23,4 +23,3 @@
     })
   </script>
 </tr>
-

--- a/app/views/loader/names/create.js.erb
+++ b/app/views/loader/names/create.js.erb
@@ -11,4 +11,18 @@ $('.message-container').html('');
   $('tr#search-result-<%= @loader_name.id %> td.takes-focus a.show-details-link').focus();
 <% end %>
 
+// set up keydown event on the new row
+
+$(document).on('keydown', "tr.search-result td.takes-focus a", function(event){
+  return searchResultKeyNavigation(event, $(this).parent('td').parent('tr'));
+});
+
+$(document).on('keydown', "tr.search-result td.takes-focus", function(event){
+  return searchResultKeyNavigation(event, $(this).parent('tr'));
+});
+
+$(document).on('keydown', "tr.search-result", function(event){
+  return searchResultKeyNavigation(event, $(this));
+});
+
 

--- a/app/views/loader/names/create_heading.js.erb
+++ b/app/views/loader/names/create_heading.js.erb
@@ -1,1 +1,31 @@
+
+$('.message-container').html('');
 $('div#create-heading-info-message-container').html('<%= escape_javascript(@message).html_safe %>');
+<% if params[:random_id].blank? %>
+  $('#search-result-details-info-message-container').html("<%= escape_javascript(@message||'Created') %>");
+  $('#search-result-details-info-message-container2').html("<%= escape_javascript(@message||'Created') %>");
+  $('#loader-name-save').addClass('hidden');
+  $('#loader-name-save2').addClass('hidden');
+  $('#loader-name-cancel').addClass('hidden');
+  setTimeout(function(){$('#instance-batch-loader-tab').click()},1000);
+<% else %>
+  $('tr#new-loader-name-<%= params[:random_id] %>').replaceWith("<%= escape_javascript(h(render partial: 'application/search_results/loader_name_record', locals: {search_result: @loader_name, give_me_focus: true})) %>");
+  $('tr#search-result-<%= @loader_name.id %> td.takes-focus a.show-details-link').focus();
+<% end %>
+
+
+// set up keydown event on the new row
+
+$(document).on('keydown', "tr.search-result td.takes-focus a", function(event){
+  return searchResultKeyNavigation(event, $(this).parent('td').parent('tr'));
+});
+
+$(document).on('keydown', "tr.search-result td.takes-focus", function(event){
+  return searchResultKeyNavigation(event, $(this).parent('tr'));
+});
+
+$(document).on('keydown', "tr.search-result", function(event){
+  return searchResultKeyNavigation(event, $(this));
+});
+
+

--- a/app/views/loader/names/new_row_here.js.erb
+++ b/app/views/loader/names/new_row_here.js.erb
@@ -23,7 +23,6 @@ $('tr.search-result td.takes-focus').focus(function(event) {
 });
 
 $('tr.search-result td.takes-focus').click(function(event) {
-  debug('takes-focus event');
   return searchResultFocus(event, $(this).parent('tr'));
 });
 

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 26-Jun-2024
+  :jira_id: '5121'
+  :description: |-
+    New Record navigation: Extend fix to new Loader Name records i.e. when cursor is placed in the new Loader Name record to start with
 - :date: 24-Jun-2024
   :jira_id: '5122'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.24.3
+appversion=4.0.24.4


### PR DESCRIPTION
i.e. when cursor is placed in the new Loader Name record to start with, up/down key nav works as expected