### PR TITLE
NSL-5114: Loader: Move record type near top of accepted/excluded record form

### DIFF
--- a/app/javascript/fresh.js
+++ b/app/javascript/fresh.js
@@ -730,14 +730,16 @@
       if (tabWasClicked) {
         debug('tab was clicked loadStandardDetails');
         if ($('.give-me-focus')) {
-          return debug('give-me-focus ing - changed so not .give-me-focus ing because clicked a tab resulted in focus switching to the first record');
+          $('.give-me-focus').focus();
+          return;
         } else {
-          $('.give-me-focus').focus()
-          debug('just focus the tab');
           return $('li.active a.tab').focus();
         }
       } else {
-        return debug('tab was not clicked');
+        debug('tab was NOT clicked loadStandardDetails');
+        // do not switch focus - user may be just passing this record
+        // not working on it
+        return;
       }
     });
     // $('li.active a.tab').focus()   ## new

--- a/app/views/loader/names/tabs/_tab_create_misapp.html.erb
+++ b/app/views/loader/names/tabs/_tab_create_misapp.html.erb
@@ -6,7 +6,7 @@
 <% if @take_focus %>
   <script>
     $(document).ready(function () {
-      $('#loader_name_simple_name').focus();
+      $('#loader_name_full_name').focus();
     })
   </script>
 <% end %>

--- a/app/views/loader/names/tabs/_tab_create_syn.html.erb
+++ b/app/views/loader/names/tabs/_tab_create_syn.html.erb
@@ -5,7 +5,7 @@
   <%= render partial: 'loader/names/tabs/forms/form_for_synonym', locals: {loader_name: loader_name} %>
   <% if @take_focus %>
     <script>
-      $(document).ready(function () { $('#loader_name_simple_name').focus(); })
+      $(document).ready(function () { $('#loader_name_full_name').focus(); })
     </script>
   <% end %>
 <% else %>

--- a/app/views/loader/names/tabs/forms/_form_for_accepted_or_excluded.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_accepted_or_excluded.html.erb
@@ -25,6 +25,15 @@
 
     <%= render partial: "loader/names/tabs/forms/sort_key_or_seq", locals: {loader_name: loader_name, f: f} %>
 
+    <div class="form-group">
+      <label for="record_type">Record type - accepted or excluded<span class='red'>*</span></label>
+      <%= f.select :record_type, ["accepted", "excluded"], {include_blank: true},
+        class: 'form-control',
+        required: true,
+        title: 'Top level records can be accepted or excluded',
+        tabindex: increment_tab_index %>
+    </div>
+
     <%= render partial: "loader/names/tabs/forms/simple_name_full_name", locals: {loader_name: loader_name, f: f} %>
 
     <%= render partial: "loader/names/tabs/forms/name_status", locals: {f: f} %>
@@ -38,15 +47,6 @@
       <label for="family">Family<span class='red'>*</span></label>
       <%= f.text_field :family, class: 'form-control',
         required: true, title: "Enter family name", tabindex: increment_tab_index %>
-    </div>
-
-    <div class="form-group">
-      <label for="record_type">Record type - accepted or excluded<span class='red'>*</span></label>
-      <%= f.select :record_type, ["accepted", "excluded"], {include_blank: true},
-        class: 'form-control',
-        required: true,
-        title: 'Top level records can be accepted or excluded',
-        tabindex: increment_tab_index %>
     </div>
 
     <div class="form-group">

--- a/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
@@ -41,7 +41,7 @@
 
     <div class="form-group">
       <label for="family">Family*</label>
-      <%= f.text_field :family, class: 'form-control give-me-focus', required: true, title: "Enter family name", tabindex: increment_tab_index, autofocus: true %>
+      <%= f.text_field :family, class: 'form-control', required: true, title: "Enter family name", tabindex: increment_tab_index, autofocus: true %>
     </div>
 
     <div class="form-group">

--- a/app/views/loader/names/tabs/forms/_simple_name_full_name.html.erb
+++ b/app/views/loader/names/tabs/forms/_simple_name_full_name.html.erb
@@ -26,7 +26,7 @@
 
     <div class="form-group">
       <label for="simple_name">Simple Name<span class='red'>*</span></label>
-      <%= f.text_field :simple_name, class: 'form-control', required: true, title: "Enter simple name - the value of simple name, as loaded is retained in simple name as loaded", tabindex: increment_tab_index, autofocus: true %>
+      <%= f.text_field :simple_name, class: 'form-control', required: true, title: "Enter simple name - the value of simple name, as loaded is retained in simple name as loaded", tabindex: increment_tab_index %>
       <% unless loader_name.simple_name == loader_name.simple_name_as_loaded %>
         <p>As originally loaded: <%= loader_name.simple_name_as_loaded %></p>
         <p>Simple Name is used for matching with name records, so editing it will likely change the matches.</p>

--- a/app/views/loader/names/tabs/forms/_sort_key_or_seq.html.erb
+++ b/app/views/loader/names/tabs/forms/_sort_key_or_seq.html.erb
@@ -10,7 +10,7 @@
 <% else %>
    <div class="form-group">
      <label for="seq">Seq<span class='red'>*</span></label>
-        <%= f.text_field(:seq, {class: 'form-control give-me-focus',
+        <%= f.text_field(:seq, {class: 'form-control',
                                 title: 'For listing the taxon in the correct order',
                                 required: true,
                                 tabindex: increment_tab_index}) %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 26-Jun-2024
+  :jira_id: '5114'
+  :description: |-
+    Loader: Move record type near top of accepted/excluded record form; set focus on full name for synonym/misapp record forms
+- :date: 26-Jun-2024
   :jira_id: '5121'
   :description: |-
     New Record navigation: Extend fix to new Loader Name records i.e. when cursor is placed in the new Loader Name record to start with

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.0.24.4
+appversion=4.0.24.5


### PR DESCRIPTION
Also set focus on full name for synonym/misapp record forms