### PR TITLE
NSL-5139: Reviewer tab click: Stop rogue navigation to another record

### DIFF
--- a/app/javascript/fresh.js
+++ b/app/javascript/fresh.js
@@ -728,9 +728,8 @@
     $('#search-result-details').load(url, function() {
       recordCurrentActiveTab(record_type);
       if (tabWasClicked) {
-        debug('tab was clicked loadStandardDetails');
-        if ($('.give-me-focus')) {
-          $('.give-me-focus').focus();
+        if ($('.focus-details .give-me-focus')) {
+          $('.focus-details .give-me-focus').focus();
           return;
         } else {
           return $('li.active a.tab').focus();

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 05-Jul-2024
+  :jira_id: '5139'
+  :description: |-
+    Reviewer tab click: Stop rogue navigation to another record
+- :date: 05-Jul-2024
   :jira_id: '5134'
   :description: |-
     Editor: Fixes for Rails 7.1.3.4 upgrade

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.0.1
+appversion=4.1.0.3


### PR DESCRIPTION
Refine the way JS code sets focus inside a RHS tab.