### PR TITLE
NSL-5148: Rails Upgrade: Fix tag insert for names 

### DIFF
--- a/app/controllers/name_tag_names_controller.rb
+++ b/app/controllers/name_tag_names_controller.rb
@@ -17,7 +17,7 @@
 #   limitations under the License.
 #
 class NameTagNamesController < ApplicationController
-  before_action :set_name_tag_name, only: %i[show edit update destroy]
+  before_action :set_name_tag_name, only: %i[show edit destroy]
 
   # GET /name_tag_names/1
   # GET /name_tag_names/1.json

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 24-Jul-2024
+  :jira_id: '5148'
+  :description: |-
+    Rails Upgrade: Fix tag insert for names due to Rails 7.1 detecting a minor code discrepancy
+- :date: 24-Jul-2024
   :jira_id: '5143'
   :description: |-
     Refactoring: Fix detail tabs not working in re-factored code

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.0.11
+appversion=4.1.0.12
 


### PR DESCRIPTION
Was due to Rails 7.1 detecting a minor code discrepancy:

`The update action could not be found for the :set_name_tag_name
callback on NameTagNamesController, but it is listed in the controller's
:only option.`

Simply removed the update action from the callback.