### PR TITLE
NSL-5175: Loader: Display taxonomy comment for reviewer where it wasn't showing up.

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -1,7 +1,7 @@
 
 <% if @previous_record_type.blank? then %>
    <% @previous_record_type = search_result.record_type %>
-   <% if search_result.record_type == 'accepted' then %>
+   <% if search_result.record_type == 'accepted' or search_result.record_type == 'excluded' then %>
      <%  @stored_distribution = search_result.distribution %>
      <%  @stored_comment = search_result.comment %>
      <%  @stored_id = search_result.id %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 16-Sep-2024
+  :jira_id: '5175'
+  :description: |-
+    Loader: Display taxonomy comment for reviewer where it wasn't showing up - in first name of a result set if it was excluded
+- :date: 16-Sep-2024
   :jira_id: '5179'
   :description: |-
     Loader: Fix problem creating loader-name synonym which was a side-effect of NSL-5056

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.1.6
+appversion=4.1.1.7
 


### PR DESCRIPTION
First name of a result set if it was excluded wouldn't show comment or distribution.