### PR TITLE
NSL-5180:  Loader: Remove the batch drop down from Loader 2 tab

### DIFF
--- a/app/views/instances/tabs/batch_loader/_form_to_supplement_concept.html.erb
+++ b/app/views/instances/tabs/batch_loader/_form_to_supplement_concept.html.erb
@@ -4,20 +4,10 @@
 <% syn_for_copy = @instance.synonyms_for_copy_to_loader_name %>
 
 
-<h5>Add <%= loader_name.simple_name %> and its synonymy to an existing concept in a batch</h5>
+<h5>Add <%= loader_name.simple_name %> and its synonymy to an existing concept in <%= session[:default_loader_batch_name] %></h5>
 
 
 <%= form_with(model: loader_name, role: 'form', data: { turbo: false }, local: false) do |form| %>
-    <div class="form-group">
-      <label for="loader_batch_id">Batch <span class="red">*</span></label>
-      <%= form.select :loader_batch_id,
-        Loader::Batch.order(:name).map { |batch| [batch.name, batch.id] },
-        {include_blank: true},
-        class: 'form-control',
-        required: true,
-        title: 'Must be within a batch',
-        tabindex: increment_tab_index %>
-    </div>
 
     <%= form.hidden_field :simple_name %>
     <%= form.hidden_field :full_name %>
@@ -42,7 +32,7 @@
 
 
     <div class="form-group">
-      <label for="loader-name-parent-typeahead">Concept/Parent<span class="red">*</span></label>
+      <label for="loader-name-parent-typeahead">Concept/Parent from <%= session[:default_loader_batch_name] %><span class="red">*</span></label>
       <input id="loader-name-parent-typeahead"
              name="loader_name[parent_typeahead]"
              class="typeahead form-control"

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 25-Sep-2024
+  :jira_id: '5180'
+  :description: |-
+    Loader: Remove the batch drop down from Loader 2 tab because it's not honoured by the typeahead dropdown and therefore misleading
 - :date: 24-Sep-2024
   :jira_id: '5056'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.1.11
+appversion=4.1.1.12
 


### PR DESCRIPTION
The batch drop down was not being honoured by the typeahead dropdown because that typeahead is set up when the form is loaded and therefore doesn't know what batch the user could have chosen when the form is running.

This made the batch dropdown misleading and unhelpful.

I chose to simply remove the batch dropdown and not go down the path of setting up JS code to reset the typeahead
 any time a user changes the batch selection in the form.  To take the more complex approach would be a departure from the
KISS approach to forms in the Editor.  There are so many forms and the goal is to keep them generally maintainable by keeping them simple.

Also, it is very easy (two clicks) to reset the default batch from the menu.  I think that's a very easy alternative.

The users rep has allowed this approach as a trial.