### PR TITLE
Update stubbed requests in controller tests

### DIFF
--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.4.3
+appversion=4.1.4.5
 

--- a/test/controllers/names/create/by_editor_test.rb
+++ b/test/controllers/names/create/by_editor_test.rb
@@ -44,8 +44,7 @@ class NamesCreateByEditorTest < ActionController::TestCase
 
   def stub_it
     stub_request(:get, %r{#{a}.nsl/services.rest.name.apni.[0-9][0-9]*.api.#{b}})
-      .with(headers: { "Accept" => "text/json", "Accept-Encoding" => /.*/,
-                       "User-Agent" => /rest-client.*ruby.*/ })
+      .with(headers: { "Accept" => "text/json", "Accept-Encoding" => /.*/})
       .to_return(status: 200, body: %({ "class": "silly name class",
       "_links": { "permalink": [ ] }, "name_element":
       "redundant name element for id 91755", "action": "unnecessary action",

--- a/test/controllers/names_deletes/confirm/for_editor/simple_test.rb
+++ b/test/controllers/names_deletes/confirm/for_editor/simple_test.rb
@@ -41,8 +41,7 @@ class NamesDeleteConfirmForEditorSimpleTest < ActionController::TestCase
     stub_request(:delete, "#{a}#{b}")
       .with(headers: { "Accept" => "application/json",
                        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-                       "Host" => "localhost:9090",
-                       "User-Agent" => /ruby/ })
+                       "Host" => "localhost:9090"})
       .to_return(status: 200, body: "", headers: {})
   end
 

--- a/test/controllers/references/create/simple_test.rb
+++ b/test/controllers/references/create/simple_test.rb
@@ -55,8 +55,7 @@ class ReferencesesCreateSimpleTest < ActionController::TestCase
     stub_request(:get, %r{http://#{host}/#{path}/\d+/api/citation-strings})
       .with(
         headers: { "Accept" => "text/json",
-                   "Accept-Encoding" => encoding,
-                   "User-Agent" => /rest-client.*ruby.*/ }
+                   "Accept-Encoding" => encoding }
       )
       .to_return(status: 200, body: body, headers: {})
   end

--- a/test/controllers/references/edit/iso_publication_date/partial_date/month_and_year_test.rb
+++ b/test/controllers/references/edit/iso_publication_date/partial_date/month_and_year_test.rb
@@ -55,8 +55,7 @@ class ReferencesesUpdateIsoPartialMonthAndYearTest < ActionController::TestCase
     stub_request(:get, %r{http://#{host}/#{path}/\d+/api/citation-strings})
       .with(
         headers: { "Accept" => "text/json",
-                   "Accept-Encoding" => encoding,
-                   "User-Agent" => /rest-client.*ruby.*/ }
+                   "Accept-Encoding" => encoding }
       )
       .to_return(status: 200, body: body, headers: {})
   end

--- a/test/controllers/workspace/placement/create_test.rb
+++ b/test/controllers/workspace/placement/create_test.rb
@@ -38,8 +38,7 @@ class TreePlacementCreateTest < ActionController::TestCase
       .with(headers: { "Accept" => "application/json",
                        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
                        "Content-Type" => "application/json",
-                       "Host" => "localhost:9090",
-                       "User-Agent" => /ruby/ })
+                       "Host" => "localhost:9090"})
       .to_return(status: 200, body: '{"payload": {"message":"Placed"}}', headers: {})
   end
 
@@ -51,8 +50,7 @@ class TreePlacementCreateTest < ActionController::TestCase
                        "Content-Type" => "application/json",
                        "Host" => Rails.configuration.nsl_linker
                                           .sub(%r{^http://}, "")
-                                          .split(%r{/})[0],
-                       "User-Agent" => /ruby/ })
+                                          .split(%r{/})[0]})
       .to_return(status: 200, body: %({"link":"#{Rails.configuration.nsl_linker}instance/apni/481811"}), headers: {})
   end
 

--- a/test/controllers/workspace/placement/remove_test.rb
+++ b/test/controllers/workspace/placement/remove_test.rb
@@ -40,8 +40,7 @@ class TreePlacementRemoveTest < ActionController::TestCase
                        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
                        "Content-Length" => "27",
                        "Content-Type" => "application/json",
-                       "Host" => "localhost:9090",
-                       "User-Agent" => /ruby/ })
+                       "Host" => "localhost:9090" })
       .to_return(status: 200, body: '{"payload": {"message":"Removed"}}', headers: {})
   end
 


### PR DESCRIPTION
The external requests in docker have different user-agent (rest-client/2.1.0 (linux aarch64) ruby/3.3.3p89) which causes the tests to fail as it has not been stubbed in the codes.

## Changes
Updated the stubbed requests in the controller tests by removing the user-agent header.