### PR TITLE
Pick up latest database schema changes including FOA Profile tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Developed against a Postgresql database, designed to by run as a low-privilege C
 
 ## Authentication
 
-User authentication/authorisation is via LDAP/Active Directory - originall LDAP, more recently AD.
+User authentication/authorisation is via LDAP/Active Directory - originally LDAP, more recently AD.
 
 ## Database creation
 
@@ -49,14 +49,28 @@ As above, this app doesn't carry the information necessary to create the databas
 
 ## How to run the test suite
 
-Presumes: you have a copy of an NSL database
-Preparation - run:  rails db:schema:dump to produce db/structure.sql
-Preparation - edit: db/structure.sql to remove min/max constraints on nsl_global_seq
+We use simple Rails testing with fixtures.  We mock calls out to the Services app for testing.
 
-Create a test database, load the sql structure, run tests:
-    createdb -O nsldev ned_test
-    RAILS_ENV=test rake db:structure:load
-    bundle exec rails:test
+### Grab the schema
+
+We use a `structure.sql` file extracted from a copy of an active NSL database.  When the database structure changes we need to refresh `structure.sql`.
+
+   1. Set up access to an active NSL database or a local copy of such a database with the latest schema changes.
+   2. Run `SCHEMA_FORMAT='sql' rake db:schema:dump` on command line
+   3. Edit the resulting `structure.sql` file - modify the `create sequence public.nsl_global_seq ...` statement by
+      a) setting the `start with` value to 1, and
+      b) removing the `minvalue` and `maxvalue` constraints.  
+
+      This sequence is set in very particular ways in the various active NSL databases, but we need it simple, predictable, and unconstrained for our test fixtures.
+
+### Run tests
+
+Create a test database, load the sql structure, run tests - e.g.:
+
+      createdb -O nsldev ned_test
+      RAILS_ENV=test rake db:structure:load
+      bundle exec rails:test
+
 
 ## Services and Mapper
 

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,3 +1,3 @@
-appversion=4.1.4.5
+appversion=4.1.4.6
 
 

--- a/test/fixtures/trees.yml
+++ b/test/fixtures/trees.yml
@@ -9,3 +9,4 @@ APC:
   host_name: http://localhost:7070/nsl-mapper
   link_to_home_page:
   name: APC
+  rdf_id: apc


### PR DESCRIPTION
I generated a new `structure.sql` file using the recently modified rails rake task - described in `README.md`.

I modified the `structure.sql` contents as described in `README.md`.

I added an rdf column value in the `trees` fixture file because this column is now `not null`.

I then ran all regression tests successfully against this updated database schema - but without activating the `foa_profile_aware` feature flag.