### PR TITLE
NSL-5216: Loader Review: Allow for comments on family records

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -49,15 +49,21 @@
    end
 %>
 
-<% if @show_family %>
+<%# final search_result is a flushing record %>
+<% if @show_family && !search_result[:flushing] %>
   <% if @add_white_space_before_family %>
   <tr class="spacer"><td colspan="4">&nbsp;</span></td></tr>
   <tr class="spacer"><td colspan="4">&nbsp;</span></td></tr>
   <tr class="spacer"><td colspan="4">&nbsp;</span></td></tr>
   <tr class="spacer"><td colspan="4">&nbsp;</span></td></tr>
 <% end %>
+  <% if search_result.rank == 'family' %><%# is it a real record or not? %>
+    <% show_details_class = 'review-result' %>
+  <% else %>
+    <% show_details_class = '' %>
+  <% end %>
   <tr id="family-of-review-result-<%= search_result.id %>"
-      class="review-result review family takes-focus show-details" tabindex="<%= increment_tab_index(100) %>"
+      class="<%= show_details_class %> review family takes-focus show-details" tabindex="<%= increment_tab_index(100) %>"
       data-edit-url="<%= loader_name_path(id: search_result[:id],tab: 'active_tab_goes_here') %>"
       data-tab-url="<%= loader_name_review_tab_path(id: search_result[:id],tab: 'active_tab_goes_here') %>"
       data-record-id="<%= search_result.id %>"
@@ -67,12 +73,21 @@
       tabindex="<%= increment_tab_index %>" 
     >
       <a class="review-show-details-link navigation-link takes-focus show-details" title='title' tabindex="<%= increment_tab_index(100) %>">
+      <% if search_result.rank == 'family' %><%# is it a real record or not? %>
         <span class="review loader-name family"><%= "#{search_result.family}" %> </span>
+      <% else %>
+        <span class="review loader-name family"><%= "[#{search_result.family}]" %> </span>
+      <% end %>
 
         <% unless search_result.higher_rank_comment.blank? %>
           <span class="review loader-name remark-to-reviewers"><%= search_result.higher_rank_comment %></span>
         <% end %>
       </a>
+      <% if search_result.rank == 'family' %><%# is it a real record or not? %>
+        <% if search_result.reviewer_comments? %>
+          <span class="reviewer-comment-tag"><%= pluralize(search_result.reviewer_comments.size, 'review comment') %></span>
+        <% end %>
+      <% end %>
     </td>
   </tr>
 <% end %>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,8 @@
 - :date: 22-Oct-2024
+  :jira_id: '5216'
+  :description: |-
+    Loader Review: Allow for comments on family records and show when a family entry is merely a heading in query results
+- :date: 22-Oct-2024
   :jira_id: '5213'
   :description: |-
     Loader Review: Improve family search including new <code>family-list:</code> directive

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,3 +1,3 @@
-appversion=4.1.4.8
+appversion=4.1.4.9
 
 


### PR DESCRIPTION
 Also show when a family entry is merely a heading in query results by wrapping it in square brackets and making it non-clickable.