### PR TITLE
WIP move the foa query in the controller to a service model

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -205,16 +205,13 @@ class InstancesController < ApplicationController
 
   def find_instance
     @instance = Instance.find(params[:id])
-    if Rails.configuration.try('foa_profile_aware')
-      # TODO: Confirm with Greg on how we are going to identify a product from the UI
-      @product = Profile::Product.find_by(name: "FOA") 
-      @product_configs_and_profile_items = find_or_initialize_profile_items(@product.id, @instance.id)
+    if params[:tab] == "tab_foa_profile"
+      @product_configs_and_profile_items, @product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@instance).run_query
     end
   rescue ActiveRecord::RecordNotFound
     flash[:alert] = "We could not find the instance."
     redirect_to instances_path
   end
-  
 
   def instance_params
     params.require(:instance).permit(:instance_type,
@@ -262,8 +259,8 @@ class InstancesController < ApplicationController
     if Rails.configuration.try('batch_loader_aware') &&
           can?('loader/names', 'update') &&
           offer_loader_tab?
-        offer << "tab_batch_loader" 
-        offer << "tab_batch_loader_2" 
+        offer << "tab_batch_loader"
+        offer << "tab_batch_loader_2"
     end
     offer
   end
@@ -346,31 +343,5 @@ class InstancesController < ApplicationController
       parent = parent.parent
     end
     @working_draft.tree_version_elements.order(tree_element_id: "asc").first
-  end
-
-  def find_or_initialize_profile_items(product_id, instance_id)
-    # TODO: Optimise this method!! 
-    # We may not even need this if we first create the profile item
-    # before adding profile texts, references, and annotations.
-
-    # Fetch all product item configs with display_html and associated ProfileItems
-    product_item_configs = Profile::ProductItemConfig
-      .where.not(display_html: nil)
-      .where(product_id: product_id)
-      .includes(:profile_items) # Eager load associated profile items
-  
-    # Fetch existing profile items for quick lookup
-    existing_profile_items = Profile::ProfileItem
-      .where(product_item_config_id: product_item_configs.pluck(:id), instance_id: instance_id)
-      .index_by(&:product_item_config_id) # Create a hash for O(1) lookup
-  
-    # Map the product item configs to their associated profile items
-    product_item_configs.map do |product_item_config|
-      # Find or initialize the associated ProfileItem
-      profile_item = existing_profile_items[product_item_config.id] || Profile::ProfileItem.new(product_item_config: product_item_config, instance_id: instance_id)
-  
-      # Return the product item config and associated or newly initialized profile item
-      { product_item_config: product_item_config, profile_item: profile_item }
-    end
   end
 end

--- a/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
+++ b/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
@@ -1,0 +1,50 @@
+class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
+  attr_reader :product,
+              :instance,
+              :product_configs_and_profile_items
+
+  def initialize(instance)
+    @product = Profile::Product.find_by(name: "FOA")
+    @instance = instance
+  end
+
+  def debug(s)
+    tag = "Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs"
+    Rails.logger.debug("#{tag}: #{s}")
+  end
+
+  def run_query
+    debug("run_query")
+    [] unless Rails.configuration.try('foa_profile_aware')
+    @product_configs_and_profile_items = find_or_initialize_profile_items
+    [product_configs_and_profile_items, product]
+  end
+
+  private
+
+  def find_or_initialize_profile_items
+    # TODO: Optimise this method!!
+    # We may not even need this if we first create the profile item
+    # before adding profile texts, references, and annotations.
+
+    # Fetch all product item configs with display_html and associated ProfileItems
+    product_item_configs = Profile::ProductItemConfig
+      .where.not(display_html: nil)
+      .where(product_id: product.id)
+      .includes(:profile_items) # Eager load associated profile items
+
+    # Fetch existing profile items for quick lookup
+    existing_profile_items = Profile::ProfileItem
+      .where(product_item_config_id: product_item_configs.pluck(:id), instance_id: instance.id)
+      .index_by(&:product_item_config_id) # Create a hash for O(1) lookup
+
+    # Map the product item configs to their associated profile items
+    product_item_configs.map do |product_item_config|
+      # Find or initialize the associated ProfileItem
+      profile_item = existing_profile_items[product_item_config.id] || Profile::ProfileItem.new(product_item_config: product_item_config, instance_id: instance.id)
+
+      # Return the product item config and associated or newly initialized profile item
+      { product_item_config: product_item_config, profile_item: profile_item }
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Move the foa query in the controller to a service model and optimise the controller action by only calling the foa query service when the foa tab is clicked

TODOs:
- add unit tests