### PR TITLE
Use assert_nil in tests

### DIFF
--- a/config/version.properties
+++ b/config/version.properties
@@ -1,3 +1,3 @@
-appversion=4.1.4.20
+appversion=4.1.4.21
 
 

--- a/test/models/profile/profile_item/defined_query/product_and_productt_item_configs_test.rb
+++ b/test/models/profile/profile_item/defined_query/product_and_productt_item_configs_test.rb
@@ -59,7 +59,7 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
     @product.update(name: "not foa")
     result = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@instance).run_query
     assert_equal result.first, []
-    assert_equal result.last, nil
+    assert_nil result.last
   end
 
   test "#run_query with feature flag off" do


### PR DESCRIPTION
Minitest is deprecating the assert_equal for nil assertions