### PR TITLE
Added some fixtures for loader batch tables.

### DIFF
--- a/config/version.properties
+++ b/config/version.properties
@@ -1,3 +1,3 @@
-appversion=4.1.5.0
+appversion=4.1.5.1
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7230,7 +7230,7 @@ CREATE TABLE hep.tree_version_element (
 
 CREATE TABLE loader.batch_review (
     id bigint DEFAULT nextval('public.nsl_global_seq'::regclass) NOT NULL,
-    loader_batch_id bigint NOT NULL,
+    loader_batch_id bigint,
     name character varying(200) NOT NULL,
     in_progress boolean DEFAULT false NOT NULL,
     lock_version bigint DEFAULT 0 NOT NULL,
@@ -7264,7 +7264,7 @@ CREATE TABLE loader.batch_review_comment (
 
 CREATE TABLE loader.batch_review_period (
     id bigint DEFAULT nextval('public.nsl_global_seq'::regclass) NOT NULL,
-    batch_review_id bigint NOT NULL,
+    batch_review_id bigint,
     name character varying(200) NOT NULL,
     start_date date NOT NULL,
     end_date date,
@@ -7297,10 +7297,10 @@ CREATE TABLE loader.batch_review_role (
 
 CREATE TABLE loader.batch_reviewer (
     id bigint DEFAULT nextval('public.nsl_global_seq'::regclass) NOT NULL,
-    user_id bigint NOT NULL,
-    org_id bigint NOT NULL,
-    batch_review_role_id bigint NOT NULL,
-    batch_review_period_id bigint NOT NULL,
+    user_id bigint,
+    org_id bigint,
+    batch_review_role_id bigint,
+    batch_review_period_id bigint,
     active boolean DEFAULT true NOT NULL,
     lock_version bigint DEFAULT 0 NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,

--- a/test/fixtures/batch/review.yml
+++ b/test/fixtures/batch/review.yml
@@ -1,0 +1,9 @@
+  
+review_one:
+  name: "Review One"
+  loader_batch_id: :batch_one
+  in_progress: false
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/fixtures/batch/review_period.yml
+++ b/test/fixtures/batch/review_period.yml
@@ -1,0 +1,9 @@
+  
+review_period_one:
+  name: "Review Period One"
+  batch_review_id: :batch_review_one
+  start_date: <%= Date.today %>
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/fixtures/batch/review_role.yml
+++ b/test/fixtures/batch/review_role.yml
@@ -1,0 +1,16 @@
+
+DEFAULTS: &DEFAULTS
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  created_by: tester
+  updated_by: tester
+
+
+name_reviewer:
+  <<: *DEFAULTS
+  name: name reviewer
+
+compiler:
+  <<: *DEFAULTS
+  name: compiler
+

--- a/test/fixtures/batch/reviewer.yml
+++ b/test/fixtures/batch/reviewer.yml
@@ -1,0 +1,14 @@
+DEFAULTS: &DEFAULTS
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  created_by: tester
+  updated_by: tester
+
+reviewer_1:
+  <<: *DEFAULTS
+  user_id: rev1
+  org_id: state_herb_1
+  batch_review_role_id: name_reviewer
+  batch_review_period_id: review_period_1
+  active: true
+

--- a/test/fixtures/org.yml
+++ b/test/fixtures/org.yml
@@ -1,0 +1,13 @@
+DEFAULTS: &DEFAULTS
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  created_by: tester
+  updated_by: tester
+
+
+state_herb_1:
+ <<: *DEFAULTS
+ name: $LABEL 
+ abbrev: sh1
+ deprecated: false
+ no_org: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,15 @@
+_fixture:
+  model_class: UserTable
+
+DEFAULTS: &DEFAULTS
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>
+  created_by: tester
+  updated_by: tester
+
+
+user_one:
+ <<: *DEFAULTS
+ name: uone
+ given_name: user
+ family_name: One

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,6 +52,7 @@ class ActiveSupport::TestCase
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
+  # fixtures %w[users groups memberships]
 
   # Add more helper methods to be used by all tests here...
 end


### PR DESCRIPTION
Added fixture files for:

  * Batch_Review
  * Batch_Review_Period
  * Batch_Review_Role
  * Batch_Reviewer
  * Org
  * Users

Also changed:

  * structure.db - removed the `not null` constraint on several foreign key cols to allow fixtures to load. Not ideal, but better than trying to order the loading of all (?) fixtures.

  * test_helper - re-instated `fixtures :all` because not sure why it was commented out