### PR TITLE
NSL-5248: Validate the print directive

### DIFF
--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,7 @@
+- :date: 12-Nov-2024
+  :jira_id: '5248'
+  :description: |-
+    Loader: Validate the <code>print:</code> directive
 - :date: 11-Nov-2024
   :release: true
 - :date: 11-Nov-2024

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,3 +1,3 @@
-appversion=4.1.5.1
+appversion=4.1.5.2
 
 

--- a/test/models/search/loader/name/print/fail_on_duplicate_print_directive.rb
+++ b/test/models/search/loader/name/print/fail_on_duplicate_print_directive.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 #   Copyright 2015 Australian National Botanic Gardens
@@ -21,19 +22,17 @@ require "test_helper"
 load "test/models/search/users.rb"
 
 # Single Search model test.
-class SearchLoaderNameSimpleWithAnyBatchTest < ActiveSupport::TestCase
-  test "search loader name with any-batch" do
+class SearchLoaderNameAndPrintFailWithDuplicatePrintDirective < ActiveSupport::TestCase
+  test "search loader name with any-batch print print" do
     params = ActiveSupport::HashWithIndifferentAccess.new(query_target:
                                                           "loader_names",
                                                           query_string:
-                                                          "* any-batch:",
+                                                          "* any-batch: print: print:",
                                                           current_user:
                                                           build_edit_user)
-    search = Search::Base.new(params)
-    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
-           "Results should be an ActiveRecord::Relation."
-    assert_equal 1,
-                 search.executed_query.results.size,
-                 "Exactly 1 result is expected."
+    error = assert_raises(RuntimeError) do
+      search = Search::Base.new(params)
+    end
+    assert_match(/Error: more than one print directive - please review and try again/i, error.message)
   end
 end

--- a/test/models/search/loader/name/print/fail_on_print_directive_with_arg.rb
+++ b/test/models/search/loader/name/print/fail_on_print_directive_with_arg.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 #   Copyright 2015 Australian National Botanic Gardens
@@ -21,19 +22,17 @@ require "test_helper"
 load "test/models/search/users.rb"
 
 # Single Search model test.
-class SearchLoaderNameSimpleWithAnyBatchTest < ActiveSupport::TestCase
-  test "search loader name with any-batch" do
+class SearchLoaderNameAndPrintFailWithDirective < ActiveSupport::TestCase
+  test "search loader name with any-batch print print" do
     params = ActiveSupport::HashWithIndifferentAccess.new(query_target:
                                                           "loader_names",
                                                           query_string:
-                                                          "* any-batch:",
+                                                          "* any-batch: print: arg",
                                                           current_user:
                                                           build_edit_user)
-    search = Search::Base.new(params)
-    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
-           "Results should be an ActiveRecord::Relation."
-    assert_equal 1,
-                 search.executed_query.results.size,
-                 "Exactly 1 result is expected."
+    error = assert_raises(RuntimeError) do
+      search = Search::Base.new(params)
+    end
+    assert_match(/Error: the print: directive has an argument, please remove the argument/i, error.message)
   end
 end

--- a/test/models/search/loader/name/print/simple_with_any_batch_test.rb
+++ b/test/models/search/loader/name/print/simple_with_any_batch_test.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 #   Copyright 2015 Australian National Botanic Gardens
@@ -21,18 +22,18 @@ require "test_helper"
 load "test/models/search/users.rb"
 
 # Single Search model test.
-class SearchLoaderNameSimpleWithAnyBatchTest < ActiveSupport::TestCase
-  test "search loader name with any-batch" do
+class SearchLoaderNameAndPrintSimpleWithAnyBatchTest < ActiveSupport::TestCase
+  test "search loader name with any-batch print" do
     params = ActiveSupport::HashWithIndifferentAccess.new(query_target:
                                                           "loader_names",
                                                           query_string:
-                                                          "* any-batch:",
+                                                          "* any-batch: print:",
                                                           current_user:
                                                           build_edit_user)
     search = Search::Base.new(params)
-    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
-           "Results should be an ActiveRecord::Relation."
-    assert_equal 1,
+    assert search.executed_query.results.is_a?(Array),
+      "Results should be an Array."
+    assert_equal 3,
                  search.executed_query.results.size,
                  "Exactly 1 result is expected."
   end

--- a/test/models/search/loader/name/simple_with_batch_name_asterisk_test.rb
+++ b/test/models/search/loader/name/simple_with_batch_name_asterisk_test.rb
@@ -37,6 +37,6 @@ class SearchLoaderNameSimpleWithBatchNameAsteriskTest < ActiveSupport::TestCase
            "Results should be an ActiveRecord::Relation."
     assert_equal 1,
                  search.executed_query.results.size,
-                 "Exactly 0 result is expected."
+                 "Exactly 1 result is expected."
   end
 end

--- a/test/models/search/on_name/with_print_directive_test.rb
+++ b/test/models/search/on_name/with_print_directive_test.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 #   Copyright 2015 Australian National Botanic Gardens
@@ -19,21 +20,20 @@
 
 require "test_helper"
 load "test/models/search/users.rb"
+load "test/models/search/on_name/test_helper.rb"
 
 # Single Search model test.
-class SearchLoaderNameSimpleWithAnyBatchTest < ActiveSupport::TestCase
-  test "search loader name with any-batch" do
+class SearchOnNameNameWithPrintDirTest< ActiveSupport::TestCase
+  test "search on name with print directive" do
     params = ActiveSupport::HashWithIndifferentAccess.new(query_target:
-                                                          "loader_names",
+                                                          "name",
                                                           query_string:
-                                                          "* any-batch:",
+                                                          "name: angophora print:",
                                                           current_user:
                                                           build_edit_user)
-    search = Search::Base.new(params)
-    assert search.executed_query.results.is_a?(ActiveRecord::Relation),
-           "Results should be an ActiveRecord::Relation."
-    assert_equal 1,
-                 search.executed_query.results.size,
-                 "Exactly 1 result is expected."
+    error = assert_raises(RuntimeError) do
+      search = Search::Base.new(params)
+    end
+    assert_match(/Error: /i, error.message)
   end
 end


### PR DESCRIPTION
Check for argument, which is unexpected.

Check for duplicates - to make checking for argument simpler.

Check only requested for targets that expect to print - currently only loader_name.