### PR TITLE
Display profile item in search result

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -32,6 +32,7 @@
  *= require components/batch-loader
  *= require components/admin
  *= require components/jira
+ *= require components/simple-mde-wysiwyg
  *= require_self
  */
 

--- a/app/assets/stylesheets/components/simple-mde-wysiwyg.css
+++ b/app/assets/stylesheets/components/simple-mde-wysiwyg.css
@@ -1,0 +1,134 @@
+#simplemde-container .editor-preview h1,
+#simplemde-container .editor-preview-side h1 {
+  display: block;
+  font-size: 2em;
+  margin-block-start: 0.67em;
+  margin-block-end: 0.67em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}
+
+#simplemde-container .editor-preview h2,
+#simplemde-container .editor-preview-side h2 {
+  display: block;
+  font-size: 1.5em;
+  margin-block-start: 0.83em;
+  margin-block-end: 0.83em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}
+
+#simplemde-container .editor-preview h3,
+#simplemde-container .editor-preview-side h3 {
+  display: block;
+  font-size: 1.17em;
+  margin-block-start: 1em;
+  margin-block-end: 1em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}
+
+#simplemde-container .editor-preview h4,
+#simplemde-container .editor-preview-side h4 {
+  display: block;
+  font-size: 1em;
+  margin-block-start: 1.33em;
+  margin-block-end: 1.33em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}
+
+#simplemde-container .editor-preview h5,
+#simplemde-container .editor-preview-side h5 {
+  display: block;
+  font-size: 0.83em;
+  margin-block-start: 1.67em;
+  margin-block-end: 1.67em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}
+
+#simplemde-container .editor-preview h6,
+#simplemde-container .editor-preview-side h6 {
+  display: block;
+  font-size: 0.67em;
+  margin-block-start: 2.33em;
+  margin-block-end: 2.33em;
+  margin-inline-start: 0px;
+  margin-inline-end: 0px;
+  font-weight: bold;
+  unicode-bidi: isolate;
+}
+
+#simplemde-container .editor-preview p,
+#simplemde-container .editor-preview-side p {
+  font-size: 1em;
+  line-height: 1.5;
+  margin-bottom: 1em;
+}
+
+#simplemde-container .editor-preview blockquote,
+#simplemde-container .editor-preview-side blockquote {
+  font-size: 1.2em;
+  margin-left: 1.5em;
+  color: #666;
+  border-left: 4px solid #ccc;
+  padding-left: 1em;
+}
+
+#simplemde-container .editor-preview ul,
+#simplemde-container .editor-preview ol,
+#simplemde-container .editor-preview-side ul,
+#simplemde-container .editor-preview-side ol {
+  margin: 1em 0;
+  padding-left: 2em;
+}
+
+#simplemde-container .editor-preview li,
+#simplemde-container .editor-preview-side li {
+  margin-bottom: 0.5em;
+}
+
+#simplemde-container .editor-preview code,
+#simplemde-container .editor-preview-side code {
+  font-family: "Courier New", Courier, monospace;
+  background-color: #f8f8f8;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+/* Base styles for container */
+#simplemde-container {
+  font-family: Arial, sans-serif;
+  color: #333;
+  line-height: 1.5;
+}
+
+.editor-textarea {
+  display: none; /* Hide the textarea initially */
+}
+.custom-height {
+  height: 100px; /* Default height corresponding to 4 rows */
+}
+.CodeMirror {
+  min-height: 100px; /* Minimum height corresponding to 4 rows */
+}
+.message-container {
+  margin-top: 5px;
+}
+.notice {
+  color: green;
+}
+.debug {
+  color: red;
+}

--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -32,6 +32,7 @@ class InstancesController < ApplicationController
     @tab_index = (params[:tabIndex] || "1").to_i
     @tabs_to_offer = tabs_to_offer
     @row_type = params["row-type"]
+    @selected_product_item_config_id = params[:product_item_config_id]
     # Really only need to do this if the "classification" tab is chosen.
     unless @working_draft.blank?
       @tree_version_element = @working_draft.name_in_version(@instance.name)

--- a/app/controllers/profile_items_controller.rb
+++ b/app/controllers/profile_items_controller.rb
@@ -17,7 +17,19 @@
 #   limitations under the License.
 #
 class ProfileItemsController < ApplicationController
-  before_action :set_profile_item, only: %i[destroy]
+  before_action :set_profile_item, only: %i[show tab destroy]
+
+  # GET /profile_items/1/tab/:tab
+  # Sets up RHS details panel on the search results page.
+  # Displays a specified or default tab.
+  def show
+    pick_a_tab
+    pick_a_tab_index
+    @take_focus = params[:take_focus] == "true"
+    render "show", layout: false
+  end
+
+  alias tab show
 
   def destroy
     @product_item_config = @profile_item.product_item_config

--- a/app/controllers/profile_texts_controller.rb
+++ b/app/controllers/profile_texts_controller.rb
@@ -17,6 +17,8 @@
 #   limitations under the License.
 #
 class ProfileTextsController < ApplicationController
+  include ApplicationHelper
+  
   before_action :set_profile_text, :find_profile_item, only: %i[update]
 
   # POST /profile_texts
@@ -32,8 +34,8 @@ class ProfileTextsController < ApplicationController
     end
 
     @profile_text = @profile_item.build_profile_text(
-      value: permitted_profile_text_params[:value],
-      value_md: permitted_profile_text_params[:value],
+      value: markdown_to_html(permitted_profile_text_params[:value_md]),
+      value_md: permitted_profile_text_params[:value_md],
       created_by: current_user.username,
       updated_by: current_user.username
     )
@@ -59,7 +61,7 @@ class ProfileTextsController < ApplicationController
   private
 
   def permitted_profile_text_params
-    params.require(:profile_text).permit(:value)
+    params.require(:profile_text).permit(:value, :value_md)
   end
 
   def permitted_profile_item_params
@@ -75,7 +77,7 @@ class ProfileTextsController < ApplicationController
   end
 
   def changed?
-    @profile_text.value != permitted_profile_text_params[:value]
+    @profile_text.value_md != permitted_profile_text_params[:value_md]
   end
 
   def really_update

--- a/app/controllers/profile_texts_controller.rb
+++ b/app/controllers/profile_texts_controller.rb
@@ -34,7 +34,7 @@ class ProfileTextsController < ApplicationController
     end
 
     @profile_text = @profile_item.build_profile_text(
-      value: markdown_to_html(permitted_profile_text_params[:value_md]),
+      value: markdown_to_html(permitted_profile_text_params[:value_md].to_s),
       value_md: permitted_profile_text_params[:value_md],
       created_by: current_user.username,
       updated_by: current_user.username
@@ -42,7 +42,7 @@ class ProfileTextsController < ApplicationController
 
     if @profile_text.persisted?
       raise("Profile text already exists")
-    elsif @profile_item.save! && @profile_text.save!
+    elsif @profile_text.save! && @profile_item.save!
       @message = "Saved"
       render :create
     end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -70,6 +70,7 @@ class SessionsController < ApplicationController
   end
 
   def set_up_session
+    session[:product_profile] = "FOA" # NOTES: Update this once we have the attribute available from ldap
     session[:username] = sign_in_params[:username]
     session[:groups] = @sign_in.groups
     session[:user_full_name] = @sign_in.user_full_name

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,11 @@ module ApplicationHelper
     <div class='text-for-link'>#{text}</div>".html_safe
   end
 
+  def user_profile_tab_name
+    # NOTES: Set this session in the user table once we have the column added
+    session[:product_profile] || "FOA"
+  end
+
   def increment_tab_index(increment = 1)
     @tab_index ||= 1
     @tab_index += increment

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ module ApplicationHelper
     !(params[:query_on].nil? || params[:query_on].match(/\Aname\z/i))
   end
 
-  def parse_markdown(markdown)
+  def markdown_to_html(markdown)
     Kramdown::Document.new(markdown).to_html.html_safe
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -80,6 +80,13 @@ import "typeaheads_for_name_parent";
 import "typeaheads_for_name_sanctioning_author";
 import "typeaheads_for_name_second_parent";
 import "typeaheads_for_name_workspace_parent_name";
+
+import "markdown_it_sub_min";
+import "markdown_it_sup_min";
+import "markdown_it_min";
+import "simplemde_min";
+import "simple_mde_wysiwyg";
+
 import Rails from '@rails/ujs';
 
 Rails.start();

--- a/app/javascript/search_result_focus.js
+++ b/app/javascript/search_result_focus.js
@@ -117,6 +117,9 @@
     if (!!inFocus.attr('data-tree-element-previous-tve')) {
       url = url + '&tree-element-previous-tve=' + inFocus.attr('data-tree-element-previous-tve');
     }
+    if (inFocus.attr('data-product-item-config-id')) {
+      url = url + '&product_item_config_id=' + inFocus.attr('data-product-item-config-id');
+    }
     debug(`url: ${url}`);
     if (tabWasClicked) {
       url = url + '&take_focus=true';

--- a/app/javascript/simple_mde_wysiwyg.js
+++ b/app/javascript/simple_mde_wysiwyg.js
@@ -1,0 +1,204 @@
+function parameterize(string) {
+  return string.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)+/g, '');
+}
+
+// // Define the custom event
+// var simpleMDELoadedEvent = new CustomEvent('simpleMDELoaded');
+
+// // // Dispatch the custom event when SimpleMDE is loaded
+// // function onSimpleMDELoad() {
+// //   document.dispatchEvent(simpleMDELoadedEvent);
+// // }
+
+// // // Add the script load event listener
+// // //var simpleMDEScript = document.querySelector('script[src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"]');
+// // document.addEventListener('load', onSimpleMDELoad);
+
+// document.dispatchEvent(simpleMDELoadedEvent);
+
+window.renderEditor = function(textarea) {
+  debug('Initializing SimpleMDE for', textarea.id);
+  textarea.style.display = 'block'; // Show the textarea
+
+  // Check if SimpleMDE instance already exists and destroy it
+  if (textarea.simplemdeInstance) {
+    textarea.simplemdeInstance.toTextArea();
+    textarea.simplemdeInstance = null;
+  }
+
+  // Initialize SimpleMDE
+  var simplemde = new SimpleMDE({
+    element: textarea,
+    spellChecker: false,
+    forceSync: true,
+    toolbar: [
+      "bold", "italic", "heading", "|",
+      "quote", "code", "link", "image", "table", "|",
+      {
+        name: "subscript",
+        action: function customSubscriptFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('~');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-subscript",
+        title: "Insert Subscript",
+      },
+      {
+        name: "superscript",
+        action: function customSuperscriptFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('^');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-superscript",
+        title: "Insert Superscript",
+      },
+      "|",
+      {
+        name: "male",
+        action: function customSpecialCharFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('♂');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-mars",
+        title: "Insert Male Symbol",
+      },
+      {
+        name: "female",
+        action: function customSpecialCharFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('♀');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-venus",
+        title: "Insert Female Symbol",
+      },
+      {
+        name: "plus-minus",
+        action: function customSpecialCharFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('±');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-plus-minus",
+        title: "Insert Plus-Minus Symbol",
+      },
+      {
+        name: "en-dash",
+        action: function customSpecialCharFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('–');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-minus",
+        title: "Insert En Dash",
+      },
+      {
+        name: "degree",
+        action: function customSpecialCharFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('°');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-circle",
+        title: "Insert Degree Symbol",
+      },
+      {
+        name: "multiplication",
+        action: function customSpecialCharFunction(editor) {
+          var cm = editor.codemirror;
+          var cursorPos = cm.getCursor();
+          cm.replaceSelection('×');
+          cm.setCursor(cursorPos.line, cursorPos.ch + 1);
+          cm.focus();
+        },
+        className: "fa fa-times",
+        title: "Insert Multiplication Symbol",
+      },
+      "preview", "side-by-side", "fullscreen"
+    ],
+    status: ["lines", "words", "cursor"],
+    previewRender: function(plainText) {
+      var md = window.markdownit()
+                  .use(window.markdownitSub)
+                  .use(window.markdownitSup);
+      return md.render(plainText);
+    }
+  });
+
+  // Store the SimpleMDE instance on the textarea element
+  textarea.simplemdeInstance = simplemde;
+
+  // Adjust the CodeMirror instance
+  var cm = simplemde.codemirror;
+
+  // Function to adjust height based on content
+  function adjustHeight() {
+    if (simplemde.isSideBySideActive()) {
+      return; // Skip height adjustment when in side-by-side mode
+    }
+    var contentHeight = cm.getScrollerElement().querySelector('.CodeMirror-sizer').scrollHeight;
+    var padding = 10; // Add some padding to ensure no clipping
+    var newHeight = contentHeight + padding;
+    var wrapperElement = cm.getWrapperElement();
+    var scrollerElement = cm.getScrollerElement();
+
+    wrapperElement.style.height = newHeight + 'px';
+    scrollerElement.style.maxHeight = newHeight + 'px';
+    scrollerElement.style.height = newHeight + 'px';
+
+    debug('===============================');
+    debug('wrapperElement.style.height:', wrapperElement.style.height);
+    debug('scrollerElement.style.maxHeight:', scrollerElement.style.maxHeight);
+    debug('scrollerElement.style.height:', scrollerElement.style.height);
+  }
+
+  // Initial height setting based on content
+  if (simplemde.value().trim() === "") {
+    // Set initial height to 4 rows when empty
+    var initialHeight = '100px'; // 100px corresponds to 4 rows
+    var wrapperElement = cm.getWrapperElement();
+    var scrollerElement = cm.getScrollerElement();
+
+    wrapperElement.style.height = initialHeight;
+    scrollerElement.style.maxHeight = initialHeight;
+    scrollerElement.style.height = initialHeight;
+
+    debug('===============================');
+    debug('Initial empty editor height settings');
+    debug('wrapperElement.style.height:', wrapperElement.style.height);
+    debug('scrollerElement.style.maxHeight:', scrollerElement.style.maxHeight);
+    debug('scrollerElement.style.height:', scrollerElement.style.height);
+  } else {
+    // Adjust height based on content
+    adjustHeight();
+  }
+
+  // Adjust height on content change
+  cm.on('change', adjustHeight);
+
+  // Adjust height when exiting side-by-side mode
+  cm.on('modeChange', function() {
+    if (!simplemde.isSideBySideActive()) {
+      setTimeout(adjustHeight, 0);
+    }
+  });
+
+  debug('SimpleMDE initialized for', textarea.id, ':', simplemde);
+}

--- a/app/models/profile/profile_item.rb
+++ b/app/models/profile/profile_item.rb
@@ -68,5 +68,9 @@ module Profile
               dependent: :destroy
 
       validates :statement_type, presence: true
+
+      def fresh?
+        created_at > 1.hour.ago
+      end
     end
   end

--- a/app/models/search/on_instance/base.rb
+++ b/app/models/search/on_instance/base.rb
@@ -63,6 +63,7 @@ class Search::OnInstance::Base
     list_query = Search::OnInstance::ListQuery.new(parsed_request)
     @relation = list_query.sql
     @results = relation.all
+    @results = include_profile_items(@results) if parsed_request.show_profile
     @limited = list_query.limited
     @info_for_display = list_query.info_for_display
     @common_and_cultivar_included = list_query.common_and_cultivar_included
@@ -81,5 +82,16 @@ class Search::OnInstance::Base
 
   def calculate_total
     @total = @relation.except(:offset, :limit, :order).count
+  end
+
+  def include_profile_items(instances)
+    results = []
+    instances.each do |instance|
+      results << instance
+      results << instance.profile_items
+      results.flatten!
+    end
+
+    results
   end
 end

--- a/app/models/search/on_instance/base.rb
+++ b/app/models/search/on_instance/base.rb
@@ -63,7 +63,7 @@ class Search::OnInstance::Base
     list_query = Search::OnInstance::ListQuery.new(parsed_request)
     @relation = list_query.sql
     @results = relation.all
-    @results = include_profile_items(@results) if parsed_request.show_profile
+    @results = include_profile_items(@results) if parsed_request.show_profiles
     @limited = list_query.limited
     @info_for_display = list_query.info_for_display
     @common_and_cultivar_included = list_query.common_and_cultivar_included
@@ -88,7 +88,7 @@ class Search::OnInstance::Base
     results = []
     instances.each do |instance|
       results << instance
-      results << instance.profile_items
+      results << instance.profile_items.where(profile_object_rdf_id: "text")
       results.flatten!
     end
 

--- a/app/models/search/on_instance/field_rule.rb
+++ b/app/models/search/on_instance/field_rule.rb
@@ -57,6 +57,15 @@ from comment where comment.instance_id = instance.id)",
     "page:" => { where_clause: " lower(page) like lower(?)" },
     "page-qualifier:" => { where_clause:
                                  " lower(page_qualifier) like lower(?)" },
+    
+    "show-profiles:" => { where_clause: " exists (select null 
+                                 from profile_item
+                                 join profile_text as pt on pt.id = profile_item.profile_text_id
+                                 where profile_item.instance_id = instance.id
+                                 and profile_item.profile_object_rdf_id = 'text'
+                                 and lower(pt.value) ilike ?) ",
+                          leading_wildcard: true,
+                          trailing_wildcard: true },
 
     "note-key:" => { where_clause: " exists (select null
                                  from instance_note

--- a/app/models/search/on_instance/list_query.rb
+++ b/app/models/search/on_instance/list_query.rb
@@ -48,7 +48,7 @@ class Search::OnInstance::ListQuery
   private
 
   def include_profiles(prepared_query)
-    return [] unless @parsed_request.show_profile
+    return [] unless @parsed_request.show_profiles
     prepared_query.joins(:profile_items)
   end
 end

--- a/app/models/search/on_instance/list_query.rb
+++ b/app/models/search/on_instance/list_query.rb
@@ -36,11 +36,19 @@ class Search::OnInstance::ListQuery
                                                          prepared_query)
     prepared_query = where_clauses.sql
     prepared_query = prepared_query.limit(@parsed_request.limit) if @parsed_request.limited
+    include_profiles(prepared_query)
     prepared_query = if @parsed_request.order_instance_query_by_page
                        prepared_query.joins(:name).ordered_by_page_only
                      else
                        prepared_query.order("instance.id")
                      end
     @sql = prepared_query
+  end
+
+  private
+
+  def include_profiles(prepared_query)
+    return [] unless @parsed_request.show_profile
+    prepared_query.joins(:profile_items)
   end
 end

--- a/app/models/search/parsed_request.rb
+++ b/app/models/search/parsed_request.rb
@@ -60,7 +60,7 @@ class Search::ParsedRequest
               :print,
               :display,
               :show_loader_name_comments,
-              :show_profile
+              :show_profiles
 
   DEFAULT_LIST_LIMIT = 100
   SIMPLE_QUERY_TARGETS = {
@@ -126,6 +126,7 @@ class Search::ParsedRequest
     "users" => "name:",
     "org" => "name_or_abbrev:",
     "bulk processing log" => "log-entry:",
+    "profile item" => "show-profiles:"
   }.freeze
 
   DEFAULT_ORDER_COLUMNS = {
@@ -234,7 +235,7 @@ class Search::ParsedRequest
     unused_qs_tokens = inflate_show_review_comments_abbrevs(unused_qs_tokens)
     unused_qs_tokens = parse_show_review_comments(unused_qs_tokens)
     unused_qs_tokens = parse_view(unused_qs_tokens)
-    unused_qs_tokens = prase_show_profile(unused_qs_tokens)
+    unused_qs_tokens = parse_show_profiles(unused_qs_tokens)
     @where_arguments = unused_qs_tokens.join(" ")
   end
 
@@ -496,12 +497,11 @@ class Search::ParsedRequest
     tokens
   end
 
-  def prase_show_profile(tokens)
-    if tokens.include?("show-profile:")
-      @show_profile = true
-      tokens.delete_if { |x| x.match(/show-profile:/) }
+  def parse_show_profiles(tokens)
+    if tokens.include?("show-profiles:")
+      @show_profiles = true
     else
-      @show_profile = false
+      @show_profiles = false
     end
     tokens
   end

--- a/app/models/search/parsed_request.rb
+++ b/app/models/search/parsed_request.rb
@@ -59,7 +59,8 @@ class Search::ParsedRequest
               :original_query_target_for_display,
               :print,
               :display,
-              :show_loader_name_comments
+              :show_loader_name_comments,
+              :show_profile
 
   DEFAULT_LIST_LIMIT = 100
   SIMPLE_QUERY_TARGETS = {
@@ -233,6 +234,7 @@ class Search::ParsedRequest
     unused_qs_tokens = inflate_show_review_comments_abbrevs(unused_qs_tokens)
     unused_qs_tokens = parse_show_review_comments(unused_qs_tokens)
     unused_qs_tokens = parse_view(unused_qs_tokens)
+    unused_qs_tokens = prase_show_profile(unused_qs_tokens)
     @where_arguments = unused_qs_tokens.join(" ")
   end
 
@@ -491,6 +493,16 @@ class Search::ParsedRequest
     @include_common_and_cultivar_session = \
       @params["include_common_and_cultivar_session"] ||
       @params["query_common_and_cultivar"] == "t"
+    tokens
+  end
+
+  def prase_show_profile(tokens)
+    if tokens.include?("show-profile:")
+      @show_profile = true
+      tokens.delete_if { |x| x.match(/show-profile:/) }
+    else
+      @show_profile = false
+    end
     tokens
   end
 

--- a/app/views/application/search_results/_profile_item_record.html.erb
+++ b/app/views/application/search_results/_profile_item_record.html.erb
@@ -9,14 +9,14 @@
       >
     <td class="takes-focus nsl-tiny-icon-container width-1-percent"><%= record_icon('instance') %></td>
     <td class="text takes-focus main-content min-width-40-percent max-width-70-percent width-60-percent <%= ' give-me-focus' if give_me_focus %>">
-      
+      <% profile_text_content = search_result.profile_text.try(:value_md).presence || search_result.profile_text.try(:value).presence || ""%>
       <a 
         id="<%= search_result.id %>"
         class="show-details-link indent-level-2"
         title="Profile item record. Select to show details."
         tabindex="<%= increment_tab_index %>"> 
         profile item: 
-        <%= truncate(search_result.profile_text.try(:value), length: 100) %>
+        <%= truncate(profile_text_content, length: 100) %>
         <strong><%= "[#{search_result.product_item_config.display_html.presence || search_result.product_item_config.profile_item_type.name.presence}]" %></strong>
       </a>
 

--- a/app/views/application/search_results/_profile_item_record.html.erb
+++ b/app/views/application/search_results/_profile_item_record.html.erb
@@ -1,26 +1,29 @@
-<tr id="search-result-<%= search_result.id %>" 
-  class="search-result"
-  data-get-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-  data-edit-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-  data-base-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-  data-tab-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-  data-record-id="<%= search_result.id %>"
-  data-record-type="name"
-  data-product-item-config-id="<%= search_result.product_item_config.id%>"
-  tabindex="<%= increment_tab_index(100) %>" 
-    >
-  <td class="takes-focus nsl-tiny-icon-container width-1-percent"><%= record_icon('instance') %></td>
-  <td class="text takes-focus main-content min-width-40-percent max-width-70-percent width-60-percent <%= ' give-me-focus' if give_me_focus %>">
-    
-    <a 
-      id="<%= search_result.id %>"
-      class="show-details-link indent-level-2"
-      title="Name record. Select to show details."
-      tabindex="<%= increment_tab_index %>"> 
-      <%= search_result.profile_text.value %>
-      <%= "[#{search_result.product_item_config.try(:display_html)}]" %>
-    </a>
+<% if can?("profile_items", :index) %>
+  <tr id="search-result-<%= search_result.id %>" 
+    class="search-result"
+    data-get-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+    data-edit-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+    data-base-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+    data-tab-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+    data-record-id="<%= search_result.id %>"
+    data-record-type="name"
+    data-product-item-config-id="<%= search_result.product_item_config.id%>"
+    tabindex="<%= increment_tab_index(100) %>" 
+      >
+    <td class="takes-focus nsl-tiny-icon-container width-1-percent"><%= record_icon('instance') %></td>
+    <td class="text takes-focus main-content min-width-40-percent max-width-70-percent width-60-percent <%= ' give-me-focus' if give_me_focus %>">
+      
+      <a 
+        id="<%= search_result.id %>"
+        class="show-details-link indent-level-2"
+        title="Name record. Select to show details."
+        tabindex="<%= increment_tab_index %>"> 
+        profile item: 
+        <%= truncate(search_result.profile_text.try(:value), length: 100) %>
+        <strong><%= "[#{search_result.product_item_config.try(:display_html)}]" %></strong>
+      </a>
 
-  </td>
-  <td class="takes-focus width-5-percent filler">&nbsp;</td>
-</tr>
+    </td>
+    <td class="takes-focus width-5-percent filler">&nbsp;</td>
+  </tr>
+<% end %>

--- a/app/views/application/search_results/_profile_item_record.html.erb
+++ b/app/views/application/search_results/_profile_item_record.html.erb
@@ -1,12 +1,9 @@
 <% if can?("profile_items", :index) %>
   <tr id="search-result-<%= search_result.id %>" 
     class="search-result show-details <%= 'fresh' if search_result.fresh? %>"
-    data-get-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-    data-edit-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-    data-base-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-    data-tab-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
-    data-record-id="<%= search_result.id %>"
-    data-record-type="name"
+    data-edit-url="<%= profile_item_path(search_result.id) %>"
+    data-tab-url="<%= profile_item_tab_path(id: search_result.id, tab: 'active_tab_goes_here') %>"
+    data-record-type="profile_item"
     data-product-item-config-id="<%= search_result.product_item_config.id%>"
     tabindex="<%= increment_tab_index(100) %>" 
       >
@@ -16,11 +13,11 @@
       <a 
         id="<%= search_result.id %>"
         class="show-details-link indent-level-2"
-        title="Name record. Select to show details."
+        title="Profile item record. Select to show details."
         tabindex="<%= increment_tab_index %>"> 
         profile item: 
         <%= truncate(search_result.profile_text.try(:value), length: 100) %>
-        <strong><%= "[#{search_result.product_item_config.try(:display_html)}]" %></strong>
+        <strong><%= "[#{search_result.product_item_config.display_html.presence || search_result.product_item_config.profile_item_type.name.presence}]" %></strong>
       </a>
 
     </td>

--- a/app/views/application/search_results/_profile_item_record.html.erb
+++ b/app/views/application/search_results/_profile_item_record.html.erb
@@ -1,6 +1,6 @@
 <% if can?("profile_items", :index) %>
   <tr id="search-result-<%= search_result.id %>" 
-    class="search-result"
+    class="search-result show-details <%= 'fresh' if search_result.fresh? %>"
     data-get-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
     data-edit-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
     data-base-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"

--- a/app/views/application/search_results/_profile_item_record.html.erb
+++ b/app/views/application/search_results/_profile_item_record.html.erb
@@ -1,0 +1,26 @@
+<tr id="search-result-<%= search_result.id %>" 
+  class="search-result"
+  data-get-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+  data-edit-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+  data-base-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+  data-tab-url="<%= instance_tab_path(id: search_result.instance_id, tab: 'tab_foa_profile') %>"
+  data-record-id="<%= search_result.id %>"
+  data-record-type="name"
+  data-product-item-config-id="<%= search_result.product_item_config.id%>"
+  tabindex="<%= increment_tab_index(100) %>" 
+    >
+  <td class="takes-focus nsl-tiny-icon-container width-1-percent"><%= record_icon('instance') %></td>
+  <td class="text takes-focus main-content min-width-40-percent max-width-70-percent width-60-percent <%= ' give-me-focus' if give_me_focus %>">
+    
+    <a 
+      id="<%= search_result.id %>"
+      class="show-details-link indent-level-2"
+      title="Name record. Select to show details."
+      tabindex="<%= increment_tab_index %>"> 
+      <%= search_result.profile_text.value %>
+      <%= "[#{search_result.product_item_config.try(:display_html)}]" %>
+    </a>
+
+  </td>
+  <td class="takes-focus width-5-percent filler">&nbsp;</td>
+</tr>

--- a/app/views/help/_index.html.erb
+++ b/app/views/help/_index.html.erb
@@ -12,7 +12,7 @@
         <%= render partial: 'search/standard/results' unless @search.executed_query.blank? || @search.executed_query.results.blank? %>
       <% end %>
       <tr><td class="width-100-percent">
-          <%= parse_markdown("
+          <%= markdown_to_html("
   
 
 #### The NSL Editor
@@ -32,7 +32,7 @@ The taxonomic information is organised within:
                    ") %>
         <%= image_tag 'synonymy-model-lego-style.svg' %>
 
-        <%= parse_markdown("
+        <%= markdown_to_html("
 Names have an **author** or **authors**, as do references.
         ") %>
 

--- a/app/views/help/_typeaheads.html.erb
+++ b/app/views/help/_typeaheads.html.erb
@@ -7,7 +7,7 @@
     <table  id="search-results-table" class="table table-condensed search-results" data-summary="Results of the latest search.">
       <tr><td>
 
-      <%= parse_markdown(%Q(
+      <%= markdown_to_html(%Q(
 
 Data entry forms in the NSL Editor often require users to identify components such as Authors, Names, References, or Instances.
 

--- a/app/views/instances/advanced_search/_field_help.html.erb
+++ b/app/views/instances/advanced_search/_field_help.html.erb
@@ -339,6 +339,7 @@ word "darwin" followed by a space, one or more other characters followed by "bar
   <% end %>
 </table>
 
+<%= render partial: 'instances/advanced_search/profile_help' %>
 <%= render partial: 'instances/advanced_search/adnot_help' %>
 <%= render partial: 'help/id_search_help' %>
 <%= render partial: 'help/case_and_wildcards_search' %>

--- a/app/views/instances/advanced_search/_profile_help.html.erb
+++ b/app/views/instances/advanced_search/_profile_help.html.erb
@@ -1,0 +1,16 @@
+<h5>Profile</h5>
+<table class="table table-striped">
+  <% [
+      {field_name: 'show-profiles:', description: "show profile item of an instance, leading and trailing wildcards added automatically **"},
+      ].each do |val| %>
+  <tr>
+    <td class="width-20-percent">
+      <a href="javascript:void(0)" class="searchable-field width-100-percent"
+         data-search-directive="<%= val[:field_name] %>" 
+         title='Add "<%= val[:field_name] %>" field to search.'>
+        <span class="blue"><%= val[:field_name] %></span></a>
+    </td>
+    <td><%= val[:description].html_safe %></td>
+  </tr>
+  <% end %>
+</table>

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -181,8 +181,8 @@
                                         last: true,
                                         this_tab: 'tab_foa_profile', 
                                         link_id: 'instance-foa-profile-tab', 
-                                        link_text: "FOA Profile".html_safe,
-                                        link_title: 'Foa',
+                                        link_text: "#{user_profile_tab_name} Profile".html_safe,
+                                        link_title: "#{user_profile_tab_name} Profile",
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-edit-profile-tab',
                                         next_tab: '.search-result.show-details' } %>

--- a/app/views/instances/tabs/_tab_foa_profile.html.erb
+++ b/app/views/instances/tabs/_tab_foa_profile.html.erb
@@ -14,7 +14,7 @@
     <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
     <div>
       <h4><%= product_item_config.display_html %></h4>
-      <div id="message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
+      <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
     </div>
 
     <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
@@ -22,7 +22,7 @@
       <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
       <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
       <% method = profile_text.persisted? ? :put : :post %>
-      <div id="profile_text_form_<%= product_item_config.display_html.parameterize %>" style="overflow: hidden; margin-bottom: 10px;">
+      <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;">
         <%= render partial: "profile_texts/form",
           locals: {
             profile_text: profile_text,
@@ -31,12 +31,11 @@
             product_item_config: product_item_config,
             instance_id: @instance.id,
             profile_item: profile_item,
-            from_search_results: true
           }
         %>
       </div>
       <div
-        id="profile_item_references_<%= product_item_config.display_html.parameterize %>"
+        id="profile_item_references_<%= product_item_config.id %>"
         style="display: block" >
         <%= render partial: "profile_item_references/edit_form",
           collection: profile_item.profile_item_references,
@@ -45,12 +44,12 @@
         %>
       </div>
 
-      <div id="add_reference_message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
-      <div id="add_reference_<%= product_item_config.display_html.parameterize %>">
+      <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+      <div id="add_reference_<%= product_item_config.id %>">
         <% if profile_item.persisted? %>
           <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
             <label>Reference</label>
-            <div id="add_reference_form_<%= product_item_config.display_html.parameterize %>" style="margin-bottom: 10px;">
+            <div id="add_reference_form_<%= product_item_config.id %>" style="margin-bottom: 10px;">
               <%= render partial: 'profile_item_references/form',
                 locals: {
                   url: profile_item_references_path,
@@ -64,7 +63,7 @@
       </div>
 
       <div style="padding: 30px 10px 10px 10px;">
-        <div id="add_annotation_form<%= product_item_config.display_html.parameterize %>">
+        <div id="add_annotation_form<%= product_item_config.id %>">
           <% if profile_item.persisted? %>
             <!-- Profile Item Reference Form -->
             <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
@@ -82,7 +81,7 @@
         </div>
       </div>
 
-      <div id="profile_item_actions_<%= product_item_config.display_html.parameterize %>">
+      <div id="profile_item_actions_<%= product_item_config.id %>">
         <% if profile_item.persisted? %>
           <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
         <% end %>
@@ -92,352 +91,3 @@
   <% end %>
 <% end %>
 
-<!-- SimpleMDE CSS -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
-<style>
-    #simplemde-container .editor-preview h1,
-    #simplemde-container .editor-preview-side h1 {
-      display: block;
-      font-size: 2em;
-      margin-block-start: 0.67em;
-      margin-block-end: 0.67em;
-      margin-inline-start: 0px;
-      margin-inline-end: 0px;
-      font-weight: bold;
-      unicode-bidi: isolate;
-    }
-
-    #simplemde-container .editor-preview h2,
-    #simplemde-container .editor-preview-side h2 {
-      display: block;
-      font-size: 1.5em;
-      margin-block-start: 0.83em;
-      margin-block-end: 0.83em;
-      margin-inline-start: 0px;
-      margin-inline-end: 0px;
-      font-weight: bold;
-      unicode-bidi: isolate;
-    }
-
-    #simplemde-container .editor-preview h3,
-    #simplemde-container .editor-preview-side h3 {
-      display: block;
-      font-size: 1.17em;
-      margin-block-start: 1em;
-      margin-block-end: 1em;
-      margin-inline-start: 0px;
-      margin-inline-end: 0px;
-      font-weight: bold;
-      unicode-bidi: isolate;
-    }
-
-    #simplemde-container .editor-preview h4,
-    #simplemde-container .editor-preview-side h4 {
-      display: block;
-      font-size: 1em;
-      margin-block-start: 1.33em;
-      margin-block-end: 1.33em;
-      margin-inline-start: 0px;
-      margin-inline-end: 0px;
-      font-weight: bold;
-      unicode-bidi: isolate;
-    }
-
-    #simplemde-container .editor-preview h5,
-    #simplemde-container .editor-preview-side h5 {
-      display: block;
-      font-size: 0.83em;
-      margin-block-start: 1.67em;
-      margin-block-end: 1.67em;
-      margin-inline-start: 0px;
-      margin-inline-end: 0px;
-      font-weight: bold;
-      unicode-bidi: isolate;
-    }
-
-    #simplemde-container .editor-preview h6,
-    #simplemde-container .editor-preview-side h6 {
-      display: block;
-      font-size: 0.67em;
-      margin-block-start: 2.33em;
-      margin-block-end: 2.33em;
-      margin-inline-start: 0px;
-      margin-inline-end: 0px;
-      font-weight: bold;
-      unicode-bidi: isolate;
-    }
-
-    #simplemde-container .editor-preview p,
-    #simplemde-container .editor-preview-side p {
-      font-size: 1em;
-      line-height: 1.5;
-      margin-bottom: 1em;
-    }
-
-    #simplemde-container .editor-preview blockquote,
-    #simplemde-container .editor-preview-side blockquote {
-      font-size: 1.2em;
-      margin-left: 1.5em;
-      color: #666;
-      border-left: 4px solid #ccc;
-      padding-left: 1em;
-    }
-
-    #simplemde-container .editor-preview ul,
-    #simplemde-container .editor-preview ol,
-    #simplemde-container .editor-preview-side ul,
-    #simplemde-container .editor-preview-side ol {
-      margin: 1em 0;
-      padding-left: 2em;
-    }
-
-    #simplemde-container .editor-preview li,
-    #simplemde-container .editor-preview-side li {
-      margin-bottom: 0.5em;
-    }
-
-    #simplemde-container .editor-preview code,
-    #simplemde-container .editor-preview-side code {
-      font-family: "Courier New", Courier, monospace;
-      background-color: #f8f8f8;
-      padding: 2px 4px;
-      border-radius: 4px;
-    }
-
-    /* Base styles for container */
-    #simplemde-container {
-      font-family: Arial, sans-serif;
-      color: #333;
-      line-height: 1.5;
-    }
-
-  .editor-textarea {
-    display: none; /* Hide the textarea initially */
-  }
-  .custom-height {
-    height: 100px; /* Default height corresponding to 4 rows */
-  }
-  .CodeMirror {
-    min-height: 100px; /* Minimum height corresponding to 4 rows */
-  }
-  .message-container {
-    margin-top: 5px;
-  }
-  .notice {
-    color: green;
-  }
-  .debug {
-    color: red;
-  }
-</style>
-
-<!-- SimpleMDE JS -->
-<script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/markdown-it-sub/dist/markdown-it-sub.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/markdown-it-sup/dist/markdown-it-sup.min.js"></script>
-
-<script>
-  function parameterize(string) {
-    return string.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)+/g, '');
-  }
-
-  // Define the custom event
-  var simpleMDELoadedEvent = new CustomEvent('simpleMDELoaded');
-
-  // Dispatch the custom event when SimpleMDE is loaded
-  function onSimpleMDELoad() {
-    document.dispatchEvent(simpleMDELoadedEvent);
-  }
-
-  // Add the script load event listener
-  var simpleMDEScript = document.querySelector('script[src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"]');
-  simpleMDEScript.addEventListener('load', onSimpleMDELoad);
-
-  function renderEditor(textarea) {
-    debug('Initializing SimpleMDE for', textarea.id);
-    textarea.style.display = 'block'; // Show the textarea
-
-    // Check if SimpleMDE instance already exists and destroy it
-    if (textarea.simplemdeInstance) {
-      textarea.simplemdeInstance.toTextArea();
-      textarea.simplemdeInstance = null;
-    }
-
-    // Initialize SimpleMDE
-    var simplemde = new SimpleMDE({
-      element: textarea,
-      spellChecker: false,
-      forceSync: true,
-      toolbar: [
-        "bold", "italic", "heading", "|",
-        "quote", "code", "link", "image", "table", "|",
-        {
-          name: "subscript",
-          action: function customSubscriptFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('~');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-subscript",
-          title: "Insert Subscript",
-        },
-        {
-          name: "superscript",
-          action: function customSuperscriptFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('^');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-superscript",
-          title: "Insert Superscript",
-        },
-        "|",
-        {
-          name: "male",
-          action: function customSpecialCharFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('♂');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-mars",
-          title: "Insert Male Symbol",
-        },
-        {
-          name: "female",
-          action: function customSpecialCharFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('♀');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-venus",
-          title: "Insert Female Symbol",
-        },
-        {
-          name: "plus-minus",
-          action: function customSpecialCharFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('±');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-plus-minus",
-          title: "Insert Plus-Minus Symbol",
-        },
-        {
-          name: "en-dash",
-          action: function customSpecialCharFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('–');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-minus",
-          title: "Insert En Dash",
-        },
-        {
-          name: "degree",
-          action: function customSpecialCharFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('°');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-circle",
-          title: "Insert Degree Symbol",
-        },
-        {
-          name: "multiplication",
-          action: function customSpecialCharFunction(editor) {
-            var cm = editor.codemirror;
-            var cursorPos = cm.getCursor();
-            cm.replaceSelection('×');
-            cm.setCursor(cursorPos.line, cursorPos.ch + 1);
-            cm.focus();
-          },
-          className: "fa fa-times",
-          title: "Insert Multiplication Symbol",
-        },
-        "preview", "side-by-side", "fullscreen"
-      ],
-      status: ["lines", "words", "cursor"],
-      previewRender: function(plainText) {
-        var md = window.markdownit()
-                    .use(window.markdownitSub)
-                    .use(window.markdownitSup);
-        return md.render(plainText);
-      }
-    });
-
-    // Store the SimpleMDE instance on the textarea element
-    textarea.simplemdeInstance = simplemde;
-
-    // Adjust the CodeMirror instance
-    var cm = simplemde.codemirror;
-
-    // Function to adjust height based on content
-    function adjustHeight() {
-      if (simplemde.isSideBySideActive()) {
-        return; // Skip height adjustment when in side-by-side mode
-      }
-      var contentHeight = cm.getScrollerElement().querySelector('.CodeMirror-sizer').scrollHeight;
-      var padding = 10; // Add some padding to ensure no clipping
-      var newHeight = contentHeight + padding;
-      var wrapperElement = cm.getWrapperElement();
-      var scrollerElement = cm.getScrollerElement();
-
-      wrapperElement.style.height = newHeight + 'px';
-      scrollerElement.style.maxHeight = newHeight + 'px';
-      scrollerElement.style.height = newHeight + 'px';
-
-      debug('===============================');
-      debug('wrapperElement.style.height:', wrapperElement.style.height);
-      debug('scrollerElement.style.maxHeight:', scrollerElement.style.maxHeight);
-      debug('scrollerElement.style.height:', scrollerElement.style.height);
-    }
-
-    // Initial height setting based on content
-    if (simplemde.value().trim() === "") {
-      // Set initial height to 4 rows when empty
-      var initialHeight = '100px'; // 100px corresponds to 4 rows
-      var wrapperElement = cm.getWrapperElement();
-      var scrollerElement = cm.getScrollerElement();
-
-      wrapperElement.style.height = initialHeight;
-      scrollerElement.style.maxHeight = initialHeight;
-      scrollerElement.style.height = initialHeight;
-
-      debug('===============================');
-      debug('Initial empty editor height settings');
-      debug('wrapperElement.style.height:', wrapperElement.style.height);
-      debug('scrollerElement.style.maxHeight:', scrollerElement.style.maxHeight);
-      debug('scrollerElement.style.height:', scrollerElement.style.height);
-    } else {
-      // Adjust height based on content
-      adjustHeight();
-    }
-
-    // Adjust height on content change
-    cm.on('change', adjustHeight);
-
-    // Adjust height when exiting side-by-side mode
-    cm.on('modeChange', function() {
-      if (!simplemde.isSideBySideActive()) {
-        setTimeout(adjustHeight, 0);
-      }
-    });
-
-    debug('SimpleMDE initialized for', textarea.id, ':', simplemde);
-  }
-</script>

--- a/app/views/instances/tabs/_tab_foa_profile.html.erb
+++ b/app/views/instances/tabs/_tab_foa_profile.html.erb
@@ -3,13 +3,12 @@
     <div id="message_no_product_configs" class="message">There are no product or product configs setup yet.</div>
   </div>
 <% end %>
-
 <% if Rails.configuration.try('foa_profile_dropdown_ui') %>
   <%= render partial: "instances/tabs/tab_foa_profile_v2", 
     locals: {
       product_configs_and_profile_items: @product_configs_and_profile_items, 
       instance: @instance,
-      selected_product_item_config_id: nil} %>
+      selected_product_item_config_id: @selected_product_item_config_id} %>
 <% else %>
   <% @product_configs_and_profile_items.each do |config_items| %>
     <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>

--- a/app/views/instances/tabs/_tab_foa_profile.html.erb
+++ b/app/views/instances/tabs/_tab_foa_profile.html.erb
@@ -30,7 +30,8 @@
             method: method,
             product_item_config: product_item_config,
             instance_id: @instance.id,
-            profile_item: profile_item
+            profile_item: profile_item,
+            from_search_results: true
           }
         %>
       </div>

--- a/app/views/instances/tabs/_tab_foa_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_foa_profile_v2.html.erb
@@ -12,84 +12,9 @@
     <% all_items.each do |config_items| %>
         <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
         <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
-        <div>
-            <h4><%= product_item_config.display_html %></h4>
-            <div id="message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
-        </div>
-
-        <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
-            <!-- Profile Text Form -->
-            <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
-            <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
-            <% method = profile_text.persisted? ? :put : :post %>
-            <div id="profile_text_form_<%= product_item_config.display_html.parameterize %>" style="overflow: hidden; margin-bottom: 10px;">
-            <%= render partial: "profile_texts/form",
-                locals: {
-                profile_text: profile_text,
-                url: url,
-                method: method,
-                product_item_config: product_item_config,
-                instance_id: @instance.id,
-                profile_item: profile_item,
-                from_search_results: true
-                }
-            %>
-            </div>
-            <div
-            id="profile_item_references_<%= product_item_config.display_html.parameterize %>"
-            style="display: block" >
-            <%= render partial: "profile_item_references/edit_form",
-                collection: profile_item.profile_item_references,
-                locals: {profile_item: profile_item},
-                as: :profile_item_reference
-            %>
-            </div>
-
-            <div id="add_reference_message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
-            <div id="add_reference_<%= product_item_config.display_html.parameterize %>">
-            <% if profile_item.persisted? %>
-                <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
-                <label>Reference</label>
-                <div id="add_reference_form_<%= product_item_config.display_html.parameterize %>" style="margin-bottom: 10px;">
-                    <%= render partial: 'profile_item_references/form',
-                    locals: {
-                        url: profile_item_references_path,
-                        method: :post,
-                        profile_item: profile_item,
-                        profile_item_reference: Profile::ProfileItemReference.new
-                    } %>
-                </div>
-                </div>
-            <% end %>
-            </div>
-
-            <div style="padding: 30px 10px 10px 10px;">
-            <div id="add_annotation_form<%= product_item_config.display_html.parameterize %>">
-                <% if profile_item.persisted? %>
-                <!-- Profile Item Reference Form -->
-                <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
-                <label>Annotate this profile item:</label>
-                <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
-                <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
-                <% method = profile_item_annotation.persisted? ? :put : :post %>
-                <%= render partial: 'profile_item_annotations/form',
-                    locals: {
-                    url: url,
-                    method: method,
-                    profile_item_annotation: profile_item_annotation
-                    } %>
-                <% end %>
-            </div>
-            </div>
-
-            <div id="profile_item_actions_<%= product_item_config.display_html.parameterize %>">
-            <% if profile_item.persisted? %>
-                <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
-            <% end %>
-            </div>
-
-        </div>
-        </div>
+        <%= render partial: "instances/tabs/tab_product_config_profile_item_form", 
+          locals: {product_item_config:  product_item_config, profile_item: profile_item, instance: @instance}
+        %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/instances/tabs/_tab_foa_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_foa_profile_v2.html.erb
@@ -30,7 +30,8 @@
                 method: method,
                 product_item_config: product_item_config,
                 instance_id: @instance.id,
-                profile_item: profile_item
+                profile_item: profile_item,
+                from_search_results: true
                 }
             %>
             </div>

--- a/app/views/instances/tabs/_tab_foa_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_foa_profile_v2.html.erb
@@ -1,7 +1,94 @@
 <%= render partial: "profile_items/product_item_config_dropdown", locals: {
     product_configs_and_profile_items: product_configs_and_profile_items,
-    selected_product_item_config_id: nil,
+    selected_product_item_config_id: selected_product_item_config_id,
     instance: instance
   }
 %>
-<div id="product-config-and-profile-items-container"></div>
+<% if selected_product_item_config_id.blank? %>
+  <div id="product-config-and-profile-items-container"></div>
+<% else %>
+  <div id="product-config-and-profile-items-container">
+    <% all_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@instance, {product_item_config_id: selected_product_item_config_id}).run_query %>
+    <% all_items.each do |config_items| %>
+        <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
+        <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
+        <div>
+            <h4><%= product_item_config.display_html %></h4>
+            <div id="message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
+        </div>
+
+        <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
+            <!-- Profile Text Form -->
+            <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
+            <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
+            <% method = profile_text.persisted? ? :put : :post %>
+            <div id="profile_text_form_<%= product_item_config.display_html.parameterize %>" style="overflow: hidden; margin-bottom: 10px;">
+            <%= render partial: "profile_texts/form",
+                locals: {
+                profile_text: profile_text,
+                url: url,
+                method: method,
+                product_item_config: product_item_config,
+                instance_id: @instance.id,
+                profile_item: profile_item
+                }
+            %>
+            </div>
+            <div
+            id="profile_item_references_<%= product_item_config.display_html.parameterize %>"
+            style="display: block" >
+            <%= render partial: "profile_item_references/edit_form",
+                collection: profile_item.profile_item_references,
+                locals: {profile_item: profile_item},
+                as: :profile_item_reference
+            %>
+            </div>
+
+            <div id="add_reference_message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
+            <div id="add_reference_<%= product_item_config.display_html.parameterize %>">
+            <% if profile_item.persisted? %>
+                <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
+                <label>Reference</label>
+                <div id="add_reference_form_<%= product_item_config.display_html.parameterize %>" style="margin-bottom: 10px;">
+                    <%= render partial: 'profile_item_references/form',
+                    locals: {
+                        url: profile_item_references_path,
+                        method: :post,
+                        profile_item: profile_item,
+                        profile_item_reference: Profile::ProfileItemReference.new
+                    } %>
+                </div>
+                </div>
+            <% end %>
+            </div>
+
+            <div style="padding: 30px 10px 10px 10px;">
+            <div id="add_annotation_form<%= product_item_config.display_html.parameterize %>">
+                <% if profile_item.persisted? %>
+                <!-- Profile Item Reference Form -->
+                <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
+                <label>Annotate this profile item:</label>
+                <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
+                <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
+                <% method = profile_item_annotation.persisted? ? :put : :post %>
+                <%= render partial: 'profile_item_annotations/form',
+                    locals: {
+                    url: url,
+                    method: method,
+                    profile_item_annotation: profile_item_annotation
+                    } %>
+                <% end %>
+            </div>
+            </div>
+
+            <div id="profile_item_actions_<%= product_item_config.display_html.parameterize %>">
+            <% if profile_item.persisted? %>
+                <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
+            <% end %>
+            </div>
+
+        </div>
+        </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/instances/tabs/_tab_product_config_profile_item_form.html.erb
+++ b/app/views/instances/tabs/_tab_product_config_profile_item_form.html.erb
@@ -1,0 +1,73 @@
+<div>
+  
+  <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+</div>
+
+<div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
+  <!-- Profile Text Form -->
+  <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
+  <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
+  <% method = profile_text.persisted? ? :put : :post %>
+  <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;">
+    <%= render partial: "profile_texts/form",
+        locals: {
+        profile_text: profile_text,
+        url: url,
+        method: method,
+        product_item_config: product_item_config,
+        instance_id: instance.id,
+        profile_item: profile_item,
+        }
+    %>
+  </div>
+  <div id="profile_item_references_<%= product_item_config.id %>" style="display: block" >
+    <%= render partial: "profile_item_references/edit_form",
+        collection: profile_item.profile_item_references,
+        locals: {profile_item: profile_item},
+        as: :profile_item_reference
+    %>
+  </div>
+
+  <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+  <div id="add_reference_<%= product_item_config.id %>">
+    <% if profile_item.persisted? %>
+      <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
+        <label>Reference</label>
+        <div id="add_reference_form_<%= product_item_config.id %>" style="margin-bottom: 10px;">
+            <%= render partial: 'profile_item_references/form',
+            locals: {
+                url: profile_item_references_path,
+                method: :post,
+                profile_item: profile_item,
+                profile_item_reference: Profile::ProfileItemReference.new
+            } %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div style="padding: 30px 10px 10px 10px;">
+    <div id="add_annotation_form<%= product_item_config.id %>">
+      <% if profile_item.persisted? %>
+      <!-- Profile Item Reference Form -->
+      <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
+      <label>Annotate this profile item:</label>
+      <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
+      <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
+      <% method = profile_item_annotation.persisted? ? :put : :post %>
+      <%= render partial: 'profile_item_annotations/form',
+          locals: {
+          url: url,
+          method: method,
+          profile_item_annotation: profile_item_annotation
+          } %>
+      <% end %>
+    </div>
+  </div>
+
+  <div id="profile_item_actions_<%= product_item_config.id %>">
+    <% if profile_item.persisted? %>
+        <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/instances/tabs/_tab_show_1.html.erb
+++ b/app/views/instances/tabs/_tab_show_1.html.erb
@@ -60,6 +60,21 @@
   <% end %>
 <% end %>
 
+<% if @instance.profile_items.present? && can?("profile_items", :index) %>
+  <h5>FOA Profile</h5>
+  <dl class="dl-horizontal">
+    <% @instance.profile_items.each do |profile_item| %>
+      <dt><%= profile_item.product_item_config.try(:display_html) %></dt>
+      <dd>
+        <%= link_to(
+          truncate(profile_item.profile_text.value_md, length: 100), 
+          search_path(query_string: "id: #{@instance.id} show-profiles: ",focus_id: profile_item.id, query_target: 'instance'),
+          title: profile_item.product_item_config.try(:display_html)) || '' %>
+      </dd>
+    <% end %>
+  </dl>
+<% end %>
+
 <h5>Instance #<%= @instance.id %></h5>
 <br>
 <br>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= javascript_importmap_tags %>
-
+ 
     <script>
       window.relative_url_root = "<%= Rails.application.config.action_controller.relative_url_root %>";
     </script>
@@ -30,6 +30,8 @@
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" 
           integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
 

--- a/app/views/profile_item_annotations/create.turbo_stream.erb
+++ b/app/views/profile_item_annotations/create.turbo_stream.erb
@@ -1,6 +1,6 @@
 <% profile_item = @profile_item_annotation.profile_item %>
-<%= turbo_stream.replace "add_annotation_form#{@profile_item_annotation.product_item_config.display_html.parameterize}" do %>
-  <div id="add_annotation_form<%= @profile_item_annotation.product_item_config.display_html.parameterize %>" >
+<%= turbo_stream.replace "add_annotation_form#{@profile_item_annotation.product_item_config.id}" do %>
+  <div id="add_annotation_form<%= @profile_item_annotation.product_item_config.id %>" >
     <div id="annotation_message_<%= profile_item.id %>" class="message-container"><%= @message %></div>
     <label>Annotate this profile item:</label>
     <%= render partial: "profile_item_annotations/form",

--- a/app/views/profile_item_references/create.turbo_stream.erb
+++ b/app/views/profile_item_references/create.turbo_stream.erb
@@ -1,13 +1,13 @@
 <% profile_item = @profile_item_reference.profile_item %>
 
-<%= turbo_stream.replace "add_reference_message_#{profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="add_reference_message_<%= @profile_item_reference.profile_item.product_item_config.display_html.parameterize %>" class="message-container">
+<%= turbo_stream.replace "add_reference_message_#{profile_item.product_item_config.id}" do %>
+  <div id="add_reference_message_<%= @profile_item_reference.profile_item.product_item_config.id %>" class="message-container">
     <%= @message %>
   </div>
 <% end %>
 
-<%= turbo_stream.replace "profile_item_references_#{profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="profile_item_references_<%= profile_item.product_item_config.display_html.parameterize %>"
+<%= turbo_stream.replace "profile_item_references_#{profile_item.product_item_config.id}" do %>
+  <div id="profile_item_references_<%= profile_item.product_item_config.id %>"
     style="display: block"
   >
     <%= render partial: 'profile_item_references/edit_form',
@@ -18,11 +18,11 @@
   </div>
 <% end %>
 
-<%= turbo_stream.replace "add_reference_#{profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="add_reference_<%= profile_item.product_item_config.display_html.parameterize %>">
+<%= turbo_stream.replace "add_reference_#{profile_item.product_item_config.id}" do %>
+  <div id="add_reference_<%= profile_item.product_item_config.id %>">
     <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;">
       <label>Reference</label>
-      <div id="add_reference_form_<%= profile_item.product_item_config.display_html.parameterize %>" style="margin-bottom: 10px;">
+      <div id="add_reference_form_<%= profile_item.product_item_config.id %>" style="margin-bottom: 10px;">
         <%= render partial: 'profile_item_references/form',
           locals: {
             url: profile_item_references_path,

--- a/app/views/profile_item_references/create_failed.turbo_stream.erb
+++ b/app/views/profile_item_references/create_failed.turbo_stream.erb
@@ -1,5 +1,5 @@
-<%= turbo_stream.replace "add_reference_message_#{@profile_item_reference.profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="add_reference_message_<%= @profile_item_reference.profile_item.product_item_config.display_html.parameterize %>" class="error-container">
+<%= turbo_stream.replace "add_reference_message_#{@profile_item_reference.profile_item.product_item_config.id}" do %>
+  <div id="add_reference_message_<%= @profile_item_reference.profile_item.product_item_config.id %>" class="error-container">
     <%= @message %>
   </div>
 <% end %>

--- a/app/views/profile_item_references/destroy.turbo_stream.erb
+++ b/app/views/profile_item_references/destroy.turbo_stream.erb
@@ -1,5 +1,5 @@
-<%= turbo_stream.replace "profile_item_references_#{@profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="profile_item_references_<%= @profile_item.product_item_config.display_html.parameterize %>"
+<%= turbo_stream.replace "profile_item_references_#{@profile_item.product_item_config.id}" do %>
+  <div id="profile_item_references_<%= @profile_item.product_item_config.id %>"
     style="display: block"
   >
     <%= render partial: 'profile_item_references/edit_form',

--- a/app/views/profile_items/destroy.turbo_stream.erb
+++ b/app/views/profile_items/destroy.turbo_stream.erb
@@ -20,14 +20,14 @@
   <% end %>
 <% end %>
 
-<%= turbo_stream.replace "message_#{@product_item_config.display_html.parameterize}" do %>
-  <div id="message_<%= @product_item_config.display_html.parameterize %>" class="message-container">
+<%= turbo_stream.replace "message_#{@product_item_config.id}" do %>
+  <div id="message_<%= @product_item_config.id %>" class="message-container">
     <%= @message %>
   </div>
 <% end %>
 
-<%= turbo_stream.replace "profile_text_form_#{@product_item_config.display_html.parameterize}" do %>
-  <div id="profile_text_form_<%= @product_item_config.display_html.parameterize %>" style="overflow: hidden; margin-bottom: 10px;">
+<%= turbo_stream.replace "profile_text_form_#{@product_item_config.id}" do %>
+  <div id="profile_text_form_<%= @product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;">
     <%= render partial: "profile_texts/form",
       locals: {
         profile_text: profile_text,
@@ -41,24 +41,24 @@
   </div>
 
   <script>
-    renderEditor(document.getElementById("editor_<%= @product_item_config.display_html.parameterize %><%= profile_item.id%>"));
+    renderEditor(document.getElementById("editor_<%= @product_item_config.id %><%= profile_item.id%>"));
   </script>
 <% end %>
 
-<%= turbo_stream.replace "profile_item_references_#{@product_item_config.display_html.parameterize}" do %>
-  <div id="profile_item_references_<%= @product_item_config.display_html.parameterize %>">
+<%= turbo_stream.replace "profile_item_references_#{@product_item_config.id}" do %>
+  <div id="profile_item_references_<%= @product_item_config.id %>">
   </div>
 <% end %>
 
-<%= turbo_stream.replace "add_reference_#{@product_item_config.display_html.parameterize}" do %>
-  <div id="add_reference_<%= @product_item_config.display_html.parameterize %>">
+<%= turbo_stream.replace "add_reference_#{@product_item_config.id}" do %>
+  <div id="add_reference_<%= @product_item_config.id %>">
   </div>
 <% end %>
 
-<%= turbo_stream.replace "add_annotation_form#{@product_item_config.display_html.parameterize}" do %>
-  <div id="add_annotation_form<%= @product_item_config.display_html.parameterize %>"></div>
+<%= turbo_stream.replace "add_annotation_form#{@product_item_config.id}" do %>
+  <div id="add_annotation_form<%= @product_item_config.id %>"></div>
 <% end %>
 
-<%= turbo_stream.replace "profile_item_actions_#{@product_item_config.display_html.parameterize}" do %>
-  <div id="profile_item_actions_<%= @product_item_config.display_html.parameterize %>"></div>
+<%= turbo_stream.replace "profile_item_actions_#{@product_item_config.id}" do %>
+  <div id="profile_item_actions_<%= @product_item_config.id %>"></div>
 <% end %>

--- a/app/views/profile_items/index.turbo_stream.erb
+++ b/app/views/profile_items/index.turbo_stream.erb
@@ -15,7 +15,7 @@
         <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
         <div>
             <h4><%= product_item_config.display_html %></h4>
-            <div id="message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
+            <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
         </div>
 
         <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
@@ -23,7 +23,7 @@
             <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
             <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
             <% method = profile_text.persisted? ? :put : :post %>
-            <div id="profile_text_form_<%= product_item_config.display_html.parameterize %>" style="overflow: hidden; margin-bottom: 10px;">
+            <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;">
             <%= render partial: "profile_texts/form",
                 locals: {
                 profile_text: profile_text,
@@ -36,7 +36,7 @@
             %>
             </div>
             <div
-            id="profile_item_references_<%= product_item_config.display_html.parameterize %>"
+            id="profile_item_references_<%= product_item_config.id %>"
             style="display: block" >
             <%= render partial: "profile_item_references/edit_form",
                 collection: profile_item.profile_item_references,
@@ -45,12 +45,12 @@
             %>
             </div>
 
-            <div id="add_reference_message_<%= product_item_config.display_html.parameterize %>" class="message-container"></div> <!-- Message container -->
-            <div id="add_reference_<%= product_item_config.display_html.parameterize %>">
+            <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+            <div id="add_reference_<%= product_item_config.id %>">
             <% if profile_item.persisted? %>
                 <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
                 <label>Reference</label>
-                <div id="add_reference_form_<%= product_item_config.display_html.parameterize %>" style="margin-bottom: 10px;">
+                <div id="add_reference_form_<%= product_item_config.id %>" style="margin-bottom: 10px;">
                     <%= render partial: 'profile_item_references/form',
                     locals: {
                         url: profile_item_references_path,
@@ -64,7 +64,7 @@
             </div>
 
             <div style="padding: 30px 10px 10px 10px;">
-            <div id="add_annotation_form<%= product_item_config.display_html.parameterize %>">
+            <div id="add_annotation_form<%= product_item_config.id %>">
                 <% if profile_item.persisted? %>
                 <!-- Profile Item Reference Form -->
                 <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
@@ -82,7 +82,7 @@
             </div>
             </div>
 
-            <div id="profile_item_actions_<%= product_item_config.display_html.parameterize %>">
+            <div id="profile_item_actions_<%= product_item_config.id %>">
             <% if profile_item.persisted? %>
                 <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
             <% end %>

--- a/app/views/profile_items/show.html.erb
+++ b/app/views/profile_items/show.html.erb
@@ -1,0 +1,15 @@
+<div class="focus-details 
+            <%= 'freshly-created' if Time.now.strftime("%Y%m%d") == @profile_item.created_at.strftime("%Y%m%d") &&  (@profile_item.created_at - @profile_item.updated_at).abs < 10 %>">
+  <% if notice %>
+    <p id="notice"><%= notice %></p>
+  <% end %>
+  
+  <div class="inner">
+    <h3 class="hide-overflow">
+      <%= @profile_item.product_item_config.display_html.presence || @profile_item.product_item_config.profile_item_type.name.presence %>
+    </h3>
+    <%= render partial: 'profile_items/tabs/tabs' %>
+    <%= render partial: "profile_items/tabs/#{@tab}" %>
+    
+  </div><!-- /end .inner -->
+</div><!-- /end .focus-details -->

--- a/app/views/profile_items/tabs/_tab.html.erb
+++ b/app/views/profile_items/tabs/_tab.html.erb
@@ -1,0 +1,18 @@
+<% this_tab_re = Regexp.new(this_tab) %>
+
+<% data = Hash.new %>
+<% data['edit-url'] = profile_item_tab_path(@profile_item,tab:"#{this_tab}") %>
+<% data['tab-url']  = profile_item_tab_path(id:@profile_item,tab:"#{this_tab}") %>
+<% data['prev-tab'] = prev_tab unless prev_tab.blank? %>
+<% data['tab-name'] = this_tab %>
+
+<li class='first <%= @tab.match(this_tab_re) ? "active" : "non-active" %>'>
+ <%= link_to link_text,
+             '#',
+             id: link_id,
+             class: 'tab edit-details-tab', 
+             title: link_title,
+             tabindex: tab_index,
+             data: data %>
+</li>
+

--- a/app/views/profile_items/tabs/_tab_edit.html.erb
+++ b/app/views/profile_items/tabs/_tab_edit.html.erb
@@ -1,0 +1,7 @@
+<div id="search-result-details-info-message-container" class="message-container"></div>
+<div id="search-result-details-error-message-container" class="message-container"></div>
+<div class="error-message-container"></div>
+
+<%= render partial: "instances/tabs/tab_product_config_profile_item_form", 
+  locals: {product_item_config:  @profile_item.product_item_config, profile_item: @profile_item, instance: @profile_item.instance}
+%>

--- a/app/views/profile_items/tabs/_tab_show_1.html.erb
+++ b/app/views/profile_items/tabs/_tab_show_1.html.erb
@@ -1,0 +1,42 @@
+<br>
+<span class='server-response-time'><%= "(#{(Time.now - @start_time).round(2)}s)" if @start_time %></span>
+<%= link_to("#{@profile_item.instance.name.try('full_name')} #{search_icon_on_tab}".html_safe,
+        search_path(query_target: 'name',
+                    query_string: "id: #{@profile_item.instance.name_id} show-instances:"),
+        title: 'Search for the name with its instances',
+        class: 'name') %>
+<br><br>
+<%= markdown_to_html(@profile_item.profile_text.value_md.to_s) %>
+
+<% if @profile_item.profile_item_references.present? %>
+  <p>
+    <br>
+    <strong>References</strong>
+    <br>
+    <% @profile_item.profile_item_references.each do |pir| %>
+      <%= link_to("#{pir.reference.citation}#{display_pages(pir.reference.pages)}" || '[No citation found.]', 
+                  search_path(query_string: %Q(id:#{pir.reference.id}), query_target: 'reference'), 
+                  id: 'tab-heading', 
+                  title: "Query this reference.",
+                  tabindex: increment_tab_index )%>
+                <span class="pull-right"><%= mapper_link('reference', pir.reference.id)%></span>
+      <p><%= pir.annotation %></p>
+
+    <% end %>
+  </p>
+<% end %>
+
+<% if @profile_item.profile_item_annotation.present? %>
+  <p>
+    <br>
+    <strong>Annotations</strong>
+    <br>
+    <%= @profile_item.profile_item_annotation.value %>
+  </p>
+<% end %>
+
+<br>
+<%= divider %>
+<h5>Profile item: #<%= @profile_item.id %></h5>
+<%= created_by_whom_and_when(@profile_item).html_safe %>
+<br>

--- a/app/views/profile_items/tabs/_tabs.html.erb
+++ b/app/views/profile_items/tabs/_tabs.html.erb
@@ -1,0 +1,29 @@
+<ul class="nav nav-tabs">
+  <% this_tab = 'tab_show_1' %>
+
+  <%= render partial: 'profile_items/tabs/tab', locals: {first: true,
+    last: false,
+    this_tab: 'tab_show_1', 
+    link_text: 'Details', 
+    link_id: 'profile-item-edit-show-1-tab', 
+    link_title: 'View a summary',
+    tab_index: increment_tab_index,
+    prev_tab: '', 
+    next_tab: '' } 
+  %> 
+
+
+  <% if can? 'profile_items', 'edit' %>
+    <%= render partial: 'profile_items/tabs/tab', locals: {first: false,
+      last: false,
+      this_tab: 'tab_edit', 
+      link_text: 'Edit'.html_safe,
+      link_id: 'profile-item-edit-tab',
+      link_title: 'Main edit form for the profile item].',
+      tab_index: increment_tab_index,
+      prev_tab: '', 
+      next_tab: ''} 
+    %> 
+  <% end %>
+    
+</ul>

--- a/app/views/profile_texts/_form.html.erb
+++ b/app/views/profile_texts/_form.html.erb
@@ -17,7 +17,14 @@
       required: true
     %>
 
-    <% if Rails.configuration.try('foa_profile_dropdown_ui') %>
+    <% if local_assigns[:from_search_results] %>
+      <%= javascript_tag do %>
+        document.addEventListener('simpleMDELoaded', function() {
+          textarea = document.getElementById("editor_<%=product_item_config.display_html.parameterize %><%= profile_text.id %>");
+          renderEditor(textarea)
+        })
+      <% end %>
+    <% elsif Rails.configuration.try('foa_profile_dropdown_ui') %>
       <%= javascript_tag do %>
         textarea = document.getElementById("editor_<%=product_item_config.display_html.parameterize %><%= profile_text.id %>");
         renderEditor(textarea)

--- a/app/views/profile_texts/_form.html.erb
+++ b/app/views/profile_texts/_form.html.erb
@@ -4,7 +4,7 @@
   <%= hidden_field_tag "profile_item[id]", profile_item.id %>
   <%= hidden_field_tag "profile_item[instance_id]", instance_id %>
   <%= hidden_field_tag "profile_item[product_item_config_id]", product_item_config.id %>
-  <%= hidden_field_tag "profile_item[profile_object_rdf_id]", product_item_config.profile_item_type.rdf_id %>
+  <%= hidden_field_tag "profile_item[profile_object_rdf_id]", product_item_config.profile_item_type.profile_object_type.rdf_id %>
   <%= hidden_field_tag "id", profile_text.id %>
 
   <div id="simplemde-container">

--- a/app/views/profile_texts/_form.html.erb
+++ b/app/views/profile_texts/_form.html.erb
@@ -8,31 +8,25 @@
   <%= hidden_field_tag "id", profile_text.id %>
 
   <div id="simplemde-container">
-    <%= text_area_tag "profile_text[value]", profile_item.profile_text.try(:value).to_s, 
+    <% profile_text_value = profile_item.profile_text.try(:value_md).presence || profile_item.profile_text.try(:value).presence %>
+    <%= text_area_tag "profile_text[value_md]", profile_text_value.to_s, 
       class: "form-control editor-textarea-version2 custom-height",
       title: "Enter verbatim name",
       rows: 4,
       tabindex: 1112,
-      id: "editor_#{product_item_config.display_html.parameterize}#{profile_text.id}",
+      id: "editor_#{product_item_config.id}#{profile_text.id}",
       required: true
     %>
 
-    <% if local_assigns[:from_search_results] %>
+    <% if Rails.configuration.try('foa_profile_dropdown_ui') %>
       <%= javascript_tag do %>
-        document.addEventListener('simpleMDELoaded', function() {
-          textarea = document.getElementById("editor_<%=product_item_config.display_html.parameterize %><%= profile_text.id %>");
-          renderEditor(textarea)
-        })
-      <% end %>
-    <% elsif Rails.configuration.try('foa_profile_dropdown_ui') %>
-      <%= javascript_tag do %>
-        textarea = document.getElementById("editor_<%=product_item_config.display_html.parameterize %><%= profile_text.id %>");
+        textarea = document.getElementById("editor_<%=product_item_config.id %><%= profile_text.id %>");
         renderEditor(textarea)
       <% end %>
     <% else %>
       <%= javascript_tag do %>
         document.addEventListener('simpleMDELoaded', function() {
-          textarea = document.getElementById("editor_<%=product_item_config.display_html.parameterize %><%= profile_text.id %>");
+          textarea = document.getElementById("editor_<%=product_item_config.id %><%= profile_text.id %>");
           renderEditor(textarea)
         })
       <% end %>

--- a/app/views/profile_texts/create.turbo_stream.erb
+++ b/app/views/profile_texts/create.turbo_stream.erb
@@ -11,14 +11,14 @@
   <% end %>
 <% end %>
 
-<%= turbo_stream.replace "message_#{@profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="message_<%= @profile_item.product_item_config.display_html.parameterize %>" class="message-container">
+<%= turbo_stream.replace "message_#{@profile_item.product_item_config.id}" do %>
+  <div id="message_<%= @profile_item.product_item_config.id %>" class="message-container">
     <%= @message %>
   </div>
 <% end %>
 
-<%= turbo_stream.replace "profile_text_form_#{@profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="profile_text_form_<%= @profile_item.product_item_config.display_html.parameterize %>" >
+<%= turbo_stream.replace "profile_text_form_#{@profile_item.product_item_config.id}" do %>
+  <div id="profile_text_form_<%= @profile_item.product_item_config.id %>" >
     <%= render partial: "profile_texts/form",
       locals: {
         profile_text: @profile_text,
@@ -31,7 +31,7 @@
     %>
   </div>
   <script>
-    element_id = "editor_<%= @profile_text.product_item_config.display_html.parameterize %><%= @profile_text.id %>"
+    element_id = "editor_<%= @profile_text.product_item_config.id %><%= @profile_text.id %>"
     elem = document.getElementById(element_id);
     if (elem) {
       renderEditor(elem);
@@ -39,8 +39,8 @@
   </script>
 <% end %>
 
-<%= turbo_stream.replace "profile_item_references_#{@profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="profile_item_references_<%= @profile_item.product_item_config.display_html.parameterize %>"
+<%= turbo_stream.replace "profile_item_references_#{@profile_item.product_item_config.id}" do %>
+  <div id="profile_item_references_<%= @profile_item.product_item_config.id %>"
     style="display: block"
   >
     <%= render partial: 'profile_item_references/edit_form',
@@ -51,10 +51,10 @@
   </div>
 <% end %>
 
-<%= turbo_stream.append "add_reference_#{@profile_item.product_item_config.display_html.parameterize}" do %>
+<%= turbo_stream.append "add_reference_#{@profile_item.product_item_config.id}" do %>
   <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;">
     <label>Reference</label>
-    <div id="add_reference_form_<%= @profile_item.product_item_config.display_html.parameterize %>" style="margin-bottom: 10px;">
+    <div id="add_reference_form_<%= @profile_item.product_item_config.id %>" style="margin-bottom: 10px;">
       <%= render partial: 'profile_item_references/form',
         locals: {
           url: profile_item_references_path,
@@ -66,7 +66,7 @@
   </div>
 <% end %>
 
-<%= turbo_stream.append "add_annotation_form#{@profile_item.product_item_config.display_html.parameterize}" do %>
+<%= turbo_stream.append "add_annotation_form#{@profile_item.product_item_config.id}" do %>
   <div id="annotation_message_<%= @profile_item.id %>" class="message-container"></div>
   <label>Annotate this profile item:</label>
   <%= render partial: 'profile_item_annotations/form',
@@ -78,6 +78,6 @@
   %>
 <% end %>
 
-<%= turbo_stream.append "profile_item_actions_#{@profile_item.product_item_config.display_html.parameterize}" do %>
+<%= turbo_stream.append "profile_item_actions_#{@profile_item.product_item_config.id}" do %>
   <%= render partial: "profile_items/delete_widgets", locals: {profile_item: @profile_item} %>
 <% end %>

--- a/app/views/profile_texts/create_failed.turbo_stream.erb
+++ b/app/views/profile_texts/create_failed.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "message_#{@profile_item.product_item_config.display_html.parameterize}" do %>
+<%= turbo_stream.replace "message_#{@profile_item.product_item_config.id}" do %>
   <span class="error-container"><%= @message %></span>
 <% end %>

--- a/app/views/profile_texts/update.turbo_stream.erb
+++ b/app/views/profile_texts/update.turbo_stream.erb
@@ -1,5 +1,5 @@
-<%= turbo_stream.replace "message_#{@profile_item.product_item_config.display_html.parameterize}" do %>
-  <div id="message_<%= @profile_item.product_item_config.display_html.parameterize %>" class="message-container">
+<%= turbo_stream.replace "message_#{@profile_item.product_item_config.id}" do %>
+  <div id="message_<%= @profile_item.product_item_config.id %>" class="message-container">
     <%= @message %>
   </div>
 <% end %>

--- a/app/views/profile_texts/update_failed.turbo_stream.erb
+++ b/app/views/profile_texts/update_failed.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace "message_#{@profile_text.product_item_config.display_html.parameterize}" do %>
+<%= turbo_stream.replace "message_#{@profile_text.product_item_config.id}" do %>
   <%= @message %>
 <% end %>

--- a/app/views/search/standard/_results.html.erb
+++ b/app/views/search/standard/_results.html.erb
@@ -107,6 +107,9 @@
       <% when 'Name Review Comment' %>  
         <%= render partial: "#{partials}/main/loader/name/review/comment_record", 
           locals: {search_result: record, give_me_focus: give_me_focus} %>
+      <% when 'Profile::ProfileItem' %>  
+        <%= render partial: "#{partials}/profile_item_record", 
+          locals: {search_result: record, give_me_focus: give_me_focus} %>
       <% else %>
         <tr>
           <td class="width-1-percent"></td>

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -15,6 +15,7 @@
   :jira_id: '5245'
   :description: |-
     Loader: Correctly identify preferred match for misapplieds copied from name data
+- :date: 13-Nov-2024
   :jira_id: '30'
   :jira_project: FLOR
   :description: |-

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,3 +1,8 @@
+- :date: 25-Nov-2024
+  :jira_id: '32'
+  :jira_project: FLOR
+  :description: |-
+    Profile Item: Added a <code>show-profiles:</code> directive into the instance search
 - :date: 22-Nov-2024
   :jira_id: '5254'
   :description: |-

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -1,4 +1,4 @@
-- :date: 25-Nov-2024
+- :date: 29-Nov-2024
   :jira_id: '32'
   :jira_project: FLOR
   :description: |-

--- a/config/history/changes-2024.yml
+++ b/config/history/changes-2024.yml
@@ -2,7 +2,7 @@
   :jira_id: '32'
   :jira_project: FLOR
   :description: |-
-    Profile Item: Added a <code>show-profiles:</code> directive into the instance search
+    FOA Profile: This is a large set of changes covering profile item query, search, display items, etc.
 - :date: 22-Nov-2024
   :jira_id: '5254'
   :description: |-
@@ -19,7 +19,7 @@
   :jira_id: '30'
   :jira_project: FLOR
   :description: |-
-    APC Workflow: Only Product Item Config of object type text should be displayed for now
+    FOA Profile: Only Product Item Config of object type text should be displayed for now
 - :date: 12-Nov-2024
   :jira_id: '5248'
   :description: |-
@@ -38,7 +38,7 @@
   :jira_id: '30'
   :jira_project: FLOR
   :description: |-
-    APC Workflow: Add a dropdown to the FOA profile editor
+    FOA Profile: Add a dropdown to the FOA profile editor
 - :date: 05-Nov-2024
   :jira_id: '5234'
   :description: |-

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -85,4 +85,11 @@ pin "typeaheads_for_name_parent", to: "typeaheads/for_name/parent.js"
 pin "typeaheads_for_name_sanctioning_author", to: "typeaheads/for_name/sanctioning_author.js"
 pin "typeaheads_for_name_second_parent", to: "typeaheads/for_name/second_parent.js"
 pin "typeaheads_for_name_workspace_parent_name", to: "typeaheads/for_name/workspace_parent_name.js"
+
+pin "markdown_it_sub_min", to: "https://cdn.jsdelivr.net/npm/markdown-it-sub/dist/markdown-it-sub.min.js"
+pin "markdown_it_sup_min", to: "https://cdn.jsdelivr.net/npm/markdown-it-sup/dist/markdown-it-sup.min.js"
+pin "markdown_it_min", to: "https://cdn.jsdelivr.net/npm/markdown-it/dist/markdown-it.min.js"
+pin "simplemde_min", to: "https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"
+pin "simple_mde_wysiwyg", preload: true
+
 pin "@rails/ujs", to: "https://ga.jspm.io/npm:@rails/ujs@7.0.4-3/lib/assets/compiled/rails-ujs.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,16 @@
 #
 Rails.application.routes.draw do
   resources :profile_items, only: %i[destroy index]
+  match "profile_items/:id",
+        as: "profile_items_show",
+        to: "profile_items#show",
+        via: :get, defaults: { tab: "tab_show_1" }
+  match "profile_items/:id/tab/:tab",
+        as: "profile_item_tab",
+        to: "profile_items#tab",
+        via: :get,
+        defaults: { tab: "tab_show_1" }
+
   resources :profile_texts, only: %i[create update]
   resources :profile_item_annotations, only: %i[create update]
   resources :profile_item_references, only: %i[create]

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.7
+appversion=4.1.5.8

--- a/test/controllers/profile_texts_controller_test.rb
+++ b/test/controllers/profile_texts_controller_test.rb
@@ -27,16 +27,21 @@ class ProfileTextsControllerTest < ActionController::TestCase
 
   test "should create profile text" do
     product_item_config = product_item_config(:ecology_pic)
+
+    profile_items = Profile::ProfileItem.where(profile_object_rdf_id: "text", product_item_config_id: product_item_config.id)
+    profile_items.destroy_all if profile_items
+
     assert_difference "Profile::ProfileItem.count", 1 do
       assert_difference "Profile::ProfileText.count", 1 do
         post :create, params: {
           profile_item: {
             instance_id: @instance.id,
             product_item_config_id: product_item_config.id,
-            profile_object_rdf_id: nil
+            profile_object_rdf_id: product_item_config.profile_item_type.profile_object_type.rdf_id
           },
           profile_text: {
-            value: "New profile text"
+            value: "New profile text",
+            value_md: "New profile text"
           }
         }, session: @session, xhr: true
       end
@@ -54,10 +59,11 @@ class ProfileTextsControllerTest < ActionController::TestCase
       profile_item: {
         instance_id: @instance.id,
         product_item_config_id: product_item_config.id,
-        profile_object_rdf_id: product_item_config.profile_item_type.rdf_id
+        profile_object_rdf_id: product_item_config.profile_item_type.profile_object_type.rdf_id
       },
       profile_text: {
-        value: "Existing profile text"
+        value: "Existing profile text",
+        value_md: "Existing profile text"
       }
     }, session: @session, xhr: true
 
@@ -72,13 +78,13 @@ class ProfileTextsControllerTest < ActionController::TestCase
     put :update, 
           params: {
             id: profile_text.id,
-            profile_text: {value: "Updated profile text value"},
+            profile_text: {value_md: "Updated profile text value"},
             profile_item: {id: profile_item.id}
           }, session: @session, xhr: true
 
     assert_response :success
     assert_equal "Updated", assigns(:message)
-    assert_equal profile_text.reload.value, assigns(:profile_text).value
+    assert_equal profile_text.reload.value_md, assigns(:profile_text).value_md
     assert_equal profile_item, assigns(:profile_item)
     assert_template :update
   end
@@ -91,7 +97,7 @@ class ProfileTextsControllerTest < ActionController::TestCase
       put :update, 
           params: {
             id: profile_text.id,
-            profile_text: {value: "Updated profile text value"},
+            profile_text: {value_md: "Updated profile text value"},
             profile_item: {id: profile_item.id}
           }, session: @session, xhr: true
     end

--- a/test/fixtures/profile_item_type.yml
+++ b/test/fixtures/profile_item_type.yml
@@ -9,7 +9,7 @@ ecology_pit:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
   profile_object_type: profile_text_pot
-  rdf_id: "text"
+  rdf_id: "ecology.text"
 
 habitat_pit:
   name: "Habitat"
@@ -19,7 +19,7 @@ habitat_pit:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
   profile_object_type: profile_text_pot
-  rdf_id: "text2"
+  rdf_id: "habitat.text"
 
 ecology_pit_ref:
   name: "Ecology Ref"
@@ -29,4 +29,4 @@ ecology_pit_ref:
   created_at: <%= Time.now %>
   updated_at: <%= Time.now %>
   profile_object_type: profile_reference_list_pot
-  rdf_id: "reference"
+  rdf_id: "ecology.reference"

--- a/test/models/profile/profile_item/defined_query/product_and_productt_item_configs_test.rb
+++ b/test/models/profile/profile_item/defined_query/product_and_productt_item_configs_test.rb
@@ -91,6 +91,6 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
     assert_equal 1, product_configs_and_profile_items.size
 
     profile_item_type = product_configs_and_profile_items.first[:product_item_config].profile_item_type
-    assert_equal profile_item_type.rdf_id, "reference"
+    assert_equal profile_item_type.rdf_id, "ecology.reference"
   end
 end

--- a/test/models/search/on_instance/profile/simple_test.rb
+++ b/test/models/search/on_instance/profile/simple_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test on Instance search.
+class SearchOnInstanceProfileSimpleTest < ActiveSupport::TestCase
+  test "search on instance profile simple" do
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: "show-profiles: some",
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?,
+           "Instances with matching profile item expected."
+  end
+
+  test "search on instance without profile result" do
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: "show-profiles: idontexist",
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    assert search.executed_query.results.empty?,
+           "No profile item result"
+  end
+
+  test "search on instance profile default result" do
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: "show-profiles:",
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?,
+           "Instances with profile items return by default."
+  end
+
+  test "search on instance id and profile result" do
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "instance",
+      query_string: "id: #{Profile::ProfileText.last.profile_item.instance_id} show-profiles:",
+      current_user: build_edit_user
+    )
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?,
+           "Instances with matching profile item expected."
+  end
+end


### PR DESCRIPTION
# Summary

[x] Adding an ability to display the associated profile of an instance in the instance search results using the `show-profile:` directive
[x] Display foa tab and the correct form when a profile item from the search is clicked
[x] Add a link to the search query of a profile item in the instance details tab
[x] Add an ability to filter/search for profile using the `show-profiles:` directive
[x] Consider permissions in the search

## Tests
[x] Unit tests
[x] Frontend manual tests

## Pre-merge steps
[x] Update changelog
[x] Bump versions (4.1.5.8)