### PR TITLE
Fixup the undefined record method in the rescue block

### DIFF
--- a/app/controllers/profile_item_references_controller.rb
+++ b/app/controllers/profile_item_references_controller.rb
@@ -30,8 +30,9 @@ class ProfileItemReferencesController < ApplicationController
       @message = "Saved"
       render :create
     end
+
   rescue StandardError => e
-    @message = e.record.errors.full_messages.to_sentence
+    @message = "Error creating profile item reference: #{e.message}"
     render "create_failed", status: :unprocessable_entity
   end
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 24-Jan-2025
+  :jira_id: '23'
+  :jira_project: FLOR
+  :description: |-
+    FOA Profile (APNI Test only): Fixup the 500 error issue for when the app has no access to the database when adding a profile item reference.
 - :date: 20-Jan-2025
   :jira_id: '5304'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.32
+appversion=4.1.5.33

--- a/test/controllers/profile_item_references_controller_test.rb
+++ b/test/controllers/profile_item_references_controller_test.rb
@@ -20,7 +20,7 @@ require "test_helper"
 
 class ProfileItemReferencesControllerTest < ActionController::TestCase
   def setup
-    @profile_item = profile_item(:ecology_pi) 
+    @profile_item = profile_item(:ecology_pi)
     @reference = references(:section_with_heyland_author_different_from_parent)
     @valid_params = {
       profile_item_reference: {
@@ -50,7 +50,7 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
       profile_item_id: @profile_item.id
     )
 
-    post :create, 
+    post :create,
         params: {
           profile_item_reference: {
             reference_id: @reference.id,
@@ -64,6 +64,23 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
     assert_template :create_failed
   end
 
+  test "should fail to create profile item reference when there is no enough permission granted to db" do
+    Profile::ProfileItemReference.stub_any_instance(:save!, -> { raise PG::InsufficientPrivilege, "ERROR: permission denied for table \"profile_item_references\"" }) do
+      post :create,
+          params: {
+            profile_item_reference: {
+              reference_id: @reference.id,
+              annotation: '2nd Annotation',
+              profile_item_id: @profile_item.id
+            }
+          }, session: @session, xhr: true
+
+      assert_response :unprocessable_entity
+      assert_match "Error creating profile item reference: ERROR: permission denied for table \"profile_item_references\"", assigns(:message)
+      assert_template :create_failed
+    end
+  end
+
   test "should update profile item reference" do
     Profile::ProfileItemReference.create(
       reference_id: @reference.id,
@@ -75,12 +92,12 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
       profile_item_id: @profile_item.id
     )
 
-    put :update, 
+    put :update,
         params: {
           reference_id: @reference.id,
           profile_item_id: @profile_item.id,
           profile_item_reference: {
-            annotation: "Updated Annotation" 
+            annotation: "Updated Annotation"
           }
         }, session: @session, xhr: true
     assert_response :success
@@ -99,12 +116,12 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
       profile_item_id: @profile_item.id
     )
 
-    put :update, 
+    put :update,
         params: {
           reference_id: @reference.id,
           profile_item_id: @profile_item.id,
           profile_item_reference: {
-            annotation: "1st Annotation" 
+            annotation: "1st Annotation"
           }
         }, session: @session, xhr: true
 
@@ -123,7 +140,7 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
       updated_at: Time.current,
       profile_item_id: @profile_item.id
     )
-    delete :destroy, 
+    delete :destroy,
           params: {
             reference_id: @reference.id,
             profile_item_id: @profile_item.id,
@@ -134,7 +151,7 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
   end
 
   test "should handle error when destroy fails" do
-    delete :destroy, 
+    delete :destroy,
           params: {
             reference_id: @reference.id,
             profile_item_id: @profile_item.id,


### PR DESCRIPTION
# Summary
- Fixup the rescue block for the profile item reference create action that throws undefined method for :record when rescuing for a db-related error.

## Tests
- [x] Unit tests
- [x] Manual tests

## Pre-merge steps
- [x] Bump Version
- [x] Update Changelog