### PR TITLE
NSL-5310:  Improve the screen explanation when you cannot delete an instance due to a tree entanglement

### DIFF
--- a/app/models/concerns/instance_treeable.rb
+++ b/app/models/concerns/instance_treeable.rb
@@ -23,10 +23,6 @@ module InstanceTreeable
     accepted_tree_version_element.tree_element.excluded
   end
 
-  def in_taxo?
-    show_taxo?
-  end
-
   def in_any_tree?
     ::Tree::Element.where(instance_id: id).count > 0
   end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -671,7 +671,6 @@ class Instance < ActiveRecord::Base
       reverse_of_this_cites.blank? &&
       reverse_of_this_is_cited_by.blank? &&
       comments.blank? &&
-      !in_taxo? &&
       !in_any_tree? &&
       children.empty? &&
       not_linked_to_loader_name_matches?

--- a/app/models/tree_join_v.rb
+++ b/app/models/tree_join_v.rb
@@ -71,6 +71,8 @@ class TreeJoinV < ActiveRecord::Base
   scope :draft, -> { where("not published") }
   scope :accepted, -> { where("accepted_tree = true") }
   scope :current, -> { where("tree_version_id = current_tree_version_id") }
+  scope :current_accepted, -> { where("tree_version_id = current_tree_version_id and accepted_tree") }
+  scope :old, -> { where("tree_version_id != current_tree_version_id") }
 
   belongs_to :instance
   belongs_to :name

--- a/app/views/instances/_delete_widgets.html.erb
+++ b/app/views/instances/_delete_widgets.html.erb
@@ -6,7 +6,6 @@
                          tabindex: increment_tab_index,
                          data: {show_this_id: "confirm-or-cancel-link-container"})
 -%>
-<% if @instance.allow_delete? %>
 
   <% if @instance.this_is_cited_by&.accepted_concept? %>
     <div class="text-warning">Note: if you delete this instance you are changing the synonymy of an accepted
@@ -41,71 +40,6 @@
   -%>
   <div class="actions"> <%= delete_link.html_safe %> </div>
   <div class="width-100-percent"> <%= confirm_or_cancel_element.html_safe %> </div>
-<% else %>
-  You cannot delete this instance.
-  <br>
-  <% if @instance.in_taxo? %>
-    Instance is in the accepted classification: <%= ShardConfig.classification_tree_key %>.
-    <br>
-  <% end %>
-  <% if @instance.in_any_tree? %>
-    Instance is in: <%= @instance.tree_elements.collect {|te| te.tree_version_elements.collect {|tve| tve.tree_version.tree.name} }.flatten.uniq.join(',') %>.
-    <br>
-  <% end %>
-  <% if @instance.instance_notes.size > 0 %>
-    <span title="See the Notes tab."><%= "Instance notes: #{@instance.instance_notes.size} (see the 'Notes' tab)" %></span>
-    <br>
-  <% end %>
-  <% if @instance.reverse_of_this_cites.size > 0 %>
-    <%= link_to("Instance is cited: #{@instance.reverse_of_this_cites.size} &nbsp; #{gray_search_icon}".html_safe,
-                search_path(query_string: @instance.id.to_s,
-                            query_target: 'instance is cited'),
-                title: "Query the instances") %>
-    <br>
-  <% end %>
-  <% if @instance.reverse_of_this_is_cited_by.size > 0 %>
-    <%= link_to("Instance cited by #{citation_summary(@instance)} &nbsp; #{gray_search_icon}".html_safe,
-                search_path(query_string: @instance.id.to_s, query_target: 'instance is cited by'),
-                title: "Query the instances this is cited by.") %>
-    <br>
-  <% end %>
-  <% if @instance.comments.size > 0 %>
-    <span title="See the Adnot tab."><%= "Instance Adnot: #{@instance.comments.size} (see the 'Adnot' tab)" %></span>
-    <br>
-  <% end %>
-  <% unless @instance.children.empty? %>
-    Instance <%= @instance.id %> has children: <%= @instance.children.collect {|i| i.id}.join(',') %>
-    <br>
-    <%= link_to("See instance and children".html_safe,
-                search_path(query_string: "id: #{@instance.id},#{@instance.children.collect {|i| i.id}.join(',')}", query_target: 'instances'),
-                title: "Query the instances.") %>
-    <br> 
-  <% end %>
-
-  <%# Code should be cleaned up once loader tables are in all databases %>
-  <% if Rails.configuration.try(:batch_loader_aware) %>
-    <% if @instance.linked_to_loader_name_matches? %>
-      Instance is linked to
-      <% Loader::Name::Match.where(instance_id: @instance.id).each do |loader_name_match|%>
-        <%= link_to("#{loader_name_match.loader_name.simple_name}",
-             search_path(query_string: "id: #{loader_name_match.loader_name.id}", query_target: 'loader_name'),
-             title: "Query the loader names.") %>
-      <% end %>
-      <% Loader::Name::Match.where(standalone_instance_id: @instance.id).each do |loader_name_match|%>
-         <%= link_to("#{loader_name_match.loader_name.simple_name}",
-             search_path(query_string: "id: #{loader_name_match.loader_name.id}", query_target: 'loader_name'),
-             title: "Query the loader names.") %>
-      <% end %>
-      <% Loader::Name::Match.where(relationship_instance_id: @instance.id).each do |loader_name_match|%>
-         <%= link_to("#{loader_name_match.loader_name.simple_name}",
-             search_path(query_string: "id: #{loader_name_match.loader_name.id}", query_target: 'loader_name'),
-             title: "Query the loader names.") %>
-      <% end %> in the batch loader.<br>
-    <% end %>
-  <% end %>
-  <br>
-<% end %>
-<br>
  
 <div id="instance-delete-info-message-container" class="message-container"></div>
 <div id="instance-delete-error-message-container" class="error-container message-container"></div>

--- a/app/views/instances/tabs/_tab_edit.html.erb
+++ b/app/views/instances/tabs/_tab_edit.html.erb
@@ -27,7 +27,11 @@
 
 <%= divider %>
 
-<%= render 'delete_widgets' %>
+<% if @instance.allow_delete? %>
+  <%= render 'delete_widgets' %>
+<% else %>
+  <%= render 'instances/widgets/no_delete_reasons' %>
+<% end %>
 
 <br>
 <br>

--- a/app/views/instances/widgets/_no_delete_reasons.html.erb
+++ b/app/views/instances/widgets/_no_delete_reasons.html.erb
@@ -1,0 +1,62 @@
+  You cannot delete this instance.
+  <br>
+  <% if @instance.tree_join_v.current_accepted.count > 0 %>
+    Instance is in the current, accepted classification: <%= ShardConfig.classification_tree_key %>.
+    <br>
+  <% end %>
+  <% if @instance.tree_join_v.old.count > 0 %>
+    Instance is in at least one old classification for: <%= @instance.tree_join_v.collect {|tjv| tjv.tree_name}.flatten.uniq.join(', ') %>.
+    <br>
+  <% end %>
+  <% if @instance.instance_notes.size > 0 %>
+    <span title="See the Notes tab."><%= "Instance notes: #{@instance.instance_notes.size} (see the 'Notes' tab)" %></span>
+    <br>
+  <% end %>
+  <% if @instance.reverse_of_this_cites.size > 0 %>
+    <%= link_to("Instance is cited: #{@instance.reverse_of_this_cites.size} &nbsp; #{gray_search_icon}".html_safe,
+                search_path(query_string: @instance.id.to_s,
+                            query_target: 'instance is cited'),
+                title: "Query the instances") %>
+    <br>
+  <% end %>
+  <% if @instance.reverse_of_this_is_cited_by.size > 0 %>
+    <%= link_to("Instance cited by #{citation_summary(@instance)} &nbsp; #{gray_search_icon}".html_safe,
+                search_path(query_string: @instance.id.to_s, query_target: 'instance is cited by'),
+                title: "Query the instances this is cited by.") %>
+    <br>
+  <% end %>
+  <% if @instance.comments.size > 0 %>
+    <span title="See the Adnot tab."><%= "Instance Adnot: #{@instance.comments.size} (see the 'Adnot' tab)" %></span>
+    <br>
+  <% end %>
+  <% unless @instance.children.empty? %>
+    Instance <%= @instance.id %> has children: <%= @instance.children.collect {|i| i.id}.join(',') %>
+    <br>
+    <%= link_to("See instance and children".html_safe,
+                search_path(query_string: "id: #{@instance.id},#{@instance.children.collect {|i| i.id}.join(',')}", query_target: 'instances'),
+                title: "Query the instances.") %>
+    <br> 
+  <% end %>
+
+  <%# Code should be cleaned up once loader tables are in all databases %>
+  <% if Rails.configuration.try(:batch_loader_aware) %>
+    <% if @instance.linked_to_loader_name_matches? %>
+      Instance is linked to
+      <% Loader::Name::Match.where(instance_id: @instance.id).each do |loader_name_match|%>
+        <%= link_to("#{loader_name_match.loader_name.simple_name}",
+             search_path(query_string: "id: #{loader_name_match.loader_name.id}", query_target: 'loader_name'),
+             title: "Query the loader names.") %>
+      <% end %>
+      <% Loader::Name::Match.where(standalone_instance_id: @instance.id).each do |loader_name_match|%>
+         <%= link_to("#{loader_name_match.loader_name.simple_name}",
+             search_path(query_string: "id: #{loader_name_match.loader_name.id}", query_target: 'loader_name'),
+             title: "Query the loader names.") %>
+      <% end %>
+      <% Loader::Name::Match.where(relationship_instance_id: @instance.id).each do |loader_name_match|%>
+         <%= link_to("#{loader_name_match.loader_name.simple_name}",
+             search_path(query_string: "id: #{loader_name_match.loader_name.id}", query_target: 'loader_name'),
+             title: "Query the loader names.") %>
+      <% end %> in the batch loader.<br>
+    <% end %>
+  <% end %>
+  <br>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 24-Jan-2025
+  :jira_id: '5310'
+  :description: |-
+    Improve the screen explanation when you cannot delete an instance due to tree entanglement
+- :date: 24-Jan-2025
   :jira_id: '23'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.33
+appversion=4.1.5.34


### PR DESCRIPTION
This follows on from NSL-5242 which mistakenly broadened the refusal to delete if the instance is on any tree, not just if it's on a current tree.

That broadened refusal is not going to be rolled back because it accidentally and controversially  matches emerging requirements.

For this change, I have also removed in_taxo? from reasons to refuse delete because it is covered by the broader test in_any_tree?.