### PR TITLE
Update permissions for foa tabs and its context

### DIFF
--- a/app/models/session_user.rb
+++ b/app/models/session_user.rb
@@ -26,10 +26,11 @@ class SessionUser < ActiveType::Object
   validates :groups, presence: true
 
   #
-  # Profile V2 
+  # Profile V2
   #
   def profile_v2?
-    groups.include?('foa') || groups.include?('apni')
+    # NOTE: we may have to change this to a different group
+    groups.include?('foa')
   end
 
   def profile_v2_context
@@ -69,5 +70,13 @@ class SessionUser < ActiveType::Object
 
   def loader_2_tab_loader?
     groups.include?("loader-2-tab")
+  end
+
+  def foa_context_group?
+    groups.include?('foa-context-group')
+  end
+
+  def v2_profile_instance_edit?
+    groups.include?('v2-profile-instance-edit')
   end
 end

--- a/app/services/users/profile_context.rb
+++ b/app/services/users/profile_context.rb
@@ -22,7 +22,7 @@ class Users::ProfileContext
   def get_user_context
     return PROFILE_CONTEXTS[:default].new(user) unless Rails.configuration.try('profile_v2_aware')
 
-    if user.groups.include?('foa') || user.groups.include?('foa-context-group')
+    if user.groups.include?('foa')
       PROFILE_CONTEXTS[:foa].new(user)
     else
       PROFILE_CONTEXTS[:apni].new(user)

--- a/app/services/users/profile_contexts/apni.rb
+++ b/app/services/users/profile_contexts/apni.rb
@@ -1,5 +1,5 @@
 class Users::ProfileContexts::Apni < Users::ProfileContexts::Base
-  
+
   def initialize(user)
     super
     @product = "APNI"
@@ -10,7 +10,7 @@ class Users::ProfileContexts::Apni < Users::ProfileContexts::Base
   end
 
   def instance_edit_allowed?
-    user.groups.include?('v2-profile-instance-edit')
+    user.v2_profile_instance_edit?
   end
 
   def copy_instance_allowed?

--- a/app/services/users/profile_contexts/foa.rb
+++ b/app/services/users/profile_contexts/foa.rb
@@ -10,15 +10,15 @@ class Users::ProfileContexts::Foa < Users::ProfileContexts::Base
   end
 
   def profile_edit_allowed?
-    user.groups.include?('foa')
+    user.profile_v2?
   end
 
   def instance_edit_allowed?
-    user.groups.include?('v2-profile-instance-edit')
+    user.v2_profile_instance_edit?
   end
 
   def draft_instance_action_allowed?
-    user.groups.include?('foa-context-group')
+    user.foa_context_group?
   end
 
   #

--- a/app/services/users/profile_contexts/foa.rb
+++ b/app/services/users/profile_contexts/foa.rb
@@ -10,30 +10,42 @@ class Users::ProfileContexts::Foa < Users::ProfileContexts::Base
   end
 
   def profile_edit_allowed?
-    instance_edit_allowed?
+    user.groups.include?('foa')
   end
 
   def instance_edit_allowed?
     user.groups.include?('v2-profile-instance-edit')
   end
 
-  def copy_instance_allowed?
-    true
+  def draft_instance_action_allowed?
+    user.groups.include?('foa-context-group')
   end
 
   #
   # Tabs
   #
   def copy_instance_tab(instance, row_type=nil)
-    "tab_copy_to_new_profile_v2" unless instance.draft
+    if draft_instance_action_allowed?
+      "tab_copy_to_new_profile_v2" unless instance.draft
+    else
+      super
+    end
   end
 
   def unpublished_citation_tab(instance)
-    "tab_unpublished_citation_for_profile_v2" if instance.draft && instance.secondary_reference?
+    if draft_instance_action_allowed?
+      "tab_unpublished_citation_for_profile_v2" if instance.draft && instance.secondary_reference?
+    else
+      super
+    end
   end
 
   def synonymy_tab(instance)
-    "tab_synonymy_for_profile_v2" if instance.draft && instance.secondary_reference?
+    if draft_instance_action_allowed?
+      "tab_synonymy_for_profile_v2" if instance.draft && instance.secondary_reference?
+    else
+      super
+    end
   end
 
 end

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -8,12 +8,12 @@
     <% if can? 'instances', 'tab_show_1' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: true,
                                         last: false,
-                                        this_tab: 'tab_show_1', 
+                                        this_tab: 'tab_show_1',
                                         link_text: "Details".html_safe,
-                                        link_id: 'instance-show-tab', 
+                                        link_id: 'instance-show-tab',
                                         link_title: 'Details',
                                         tab_index: @tab_index,
-                                        prev_tab: '.search-result.show-details', 
+                                        prev_tab: '.search-result.show-details',
                                         next_tab: '' } %>
     <% end %>
   <% end %>
@@ -22,9 +22,9 @@
     <% if can? 'instances', 'edit' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_edit', 
+                                        this_tab: 'tab_edit',
                                         link_text: "Edit".html_safe,
-                                        link_id: 'instance-edit-tab', 
+                                        link_id: 'instance-edit-tab',
                                         link_title: 'Edit',
                                         tab_index: increment_tab_index,
                                         prev_tab: '',
@@ -36,16 +36,16 @@
     <% if can? 'instance_notes', 'edit' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_edit_notes', 
+                                        this_tab: 'tab_edit_notes',
                                         link_text: "Notes".html_safe,
-                                        link_id: 'instance-edit-notes-tab', 
+                                        link_id: 'instance-edit-notes-tab',
                                         link_title: 'Notes',
                                         tab_index: increment_tab_index,
                                         prev_tab: '',
                                         next_tab: '' } %>
     <% end %>
   <% end %>
-  
+
   <% if @tabs_to_offer.include?('tab_synonymy') %>
     <% if can? 'instances', 'create' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
@@ -120,9 +120,9 @@
     <% if can? 'comments', 'create' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_comments', 
+                                        this_tab: 'tab_comments',
                                         link_text: "Adnot".html_safe,
-                                        link_id: 'instance-comments-tab', 
+                                        link_id: 'instance-comments-tab',
                                         link_title: 'Adnot',
                                         tab_index: increment_tab_index,
                                         prev_tab: '',
@@ -134,9 +134,9 @@
     <% if can? 'instances', 'copy_standalone' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_copy_to_new_reference', 
+                                        this_tab: 'tab_copy_to_new_reference',
                                         link_text: "Copy".html_safe,
-                                        link_id: 'instance-copy-to-new-reference-tab', 
+                                        link_id: 'instance-copy-to-new-reference-tab',
                                         link_title: 'Copy the instance',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-comments-tab',
@@ -145,29 +145,27 @@
   <% end %>
 
   <% if @tabs_to_offer.include?('tab_copy_to_new_profile_v2') %>
-    <% if @current_user.profile_v2_context.copy_instance_allowed? %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: false,
-                                        this_tab: 'tab_copy_to_new_profile_v2', 
-                                        link_text: "Copy".html_safe,
-                                        link_id: 'instance-copy-to-new-profile-v2-tab', 
-                                        link_title: 'Copy the instance',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-comments-tab',
-                                        next_tab: '.search-result.show-details' } %>
-    <% end %>
+    <%= render partial: 'instances/tabs/tab', locals: {first: false,
+                                      last: false,
+                                      this_tab: 'tab_copy_to_new_profile_v2',
+                                      link_text: "Copy".html_safe,
+                                      link_id: 'instance-copy-to-new-profile-v2-tab',
+                                      link_title: 'Copy the instance',
+                                      tab_index: increment_tab_index,
+                                      prev_tab: 'instance-comments-tab',
+                                      next_tab: '.search-result.show-details' } %>
   <% end %>
 
   <% if @tabs_to_offer.include?('tab_profile_details') %>
     <% if can? 'classification', 'place' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_profile_details', 
+                                        this_tab: 'tab_profile_details',
                                         link_text: "Profile".html_safe,
-                                        link_id: 'instance-profile-tab', 
+                                        link_id: 'instance-profile-tab',
                                         link_title: 'Profile details',
                                         tab_index: increment_tab_index,
-                                        prev_tab: 'instance-copy-to-new-reference-tab', 
+                                        prev_tab: 'instance-copy-to-new-reference-tab',
                                         next_tab: 'instance-edit-profile-tab' } %>
     <% end %>
   <% end %>
@@ -177,9 +175,9 @@
       <% if can? 'classification', 'place' %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_edit_profile', 
+                                        this_tab: 'tab_edit_profile',
                                         link_text: "Edit Profile".html_safe,
-                                        link_id: 'instance-edit-profile-tab', 
+                                        link_id: 'instance-edit-profile-tab',
                                         link_title: 'Edit Profile',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-profile-tab',
@@ -192,9 +190,9 @@
      <% if can?('loader/batches', 'process') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_batch_loader', 
+                                        this_tab: 'tab_batch_loader',
                                         link_text: "Loader 1".html_safe,
-                                        link_id: 'instance-batch-loader-tab', 
+                                        link_id: 'instance-batch-loader-tab',
                                         link_title: 'Batch Loader operations',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-edit-profile-tab',
@@ -203,9 +201,9 @@
      <% if can?('loader/instances-loader-2', 'use') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_batch_loader_2', 
+                                        this_tab: 'tab_batch_loader_2',
                                         link_text: "Loader 2".html_safe,
-                                        link_id: 'instance-batch-loader-tab-2', 
+                                        link_id: 'instance-batch-loader-tab-2',
                                         link_title: 'More batch Loader operations',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-batch-tab-loader',
@@ -214,15 +212,15 @@
       <% end %>
   <% end %>
 
-  
+
 
   <% if @tabs_to_offer.include?('tab_profile_v2') %>
     <% if @current_user.profile_v2_context.profile_edit_allowed? %>
       <% if Rails.configuration.try('profile_v2_aware') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_profile_v2', 
-                                        link_id: 'instance-profile-v2-tab', 
+                                        this_tab: 'tab_profile_v2',
+                                        link_id: 'instance-profile-v2-tab',
                                         link_text: "#{user_profile_tab_name} Profile".html_safe,
                                         link_title: "#{user_profile_tab_name} Profile",
                                         tab_index: increment_tab_index,

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 30-Jan-2025
+  :jira_id: '31'
+  :jira_project: FLOR
+  :description: |-
+    FOA Profile (APNI Test only): Fixup the existing tabs not showing up for users with foa or foa-context-group
 - :date: 24-Jan-2025
   :jira_id: '5310'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.34
+appversion=4.1.5.35

--- a/spec/models/session_user_spec.rb
+++ b/spec/models/session_user_spec.rb
@@ -88,7 +88,6 @@ RSpec.describe SessionUser, type: :model do
 
   describe "#profile_v2?" do
     include_context "#group_check?", :profile_v2?, "foa"
-    include_context "#group_check?", :profile_v2?, "apni"
   end
 
   describe "#edit?" do
@@ -117,5 +116,13 @@ RSpec.describe SessionUser, type: :model do
 
   describe "#loader_2_tab_loader?" do
     include_context "#group_check?", :loader_2_tab_loader?, "loader-2-tab"
+  end
+
+  describe "#foa_context_group?" do
+    include_context "#group_check?", :foa_context_group?, "foa-context-group"
+  end
+
+  describe "#v2_profile_instance_edit?" do
+    include_context "#group_check?", :v2_profile_instance_edit?, "v2-profile-instance-edit"
   end
 end


### PR DESCRIPTION
# Summary
There are issues with the tabs not showing up for users with certain security groups (especially when they are in `foa` or `foa-context-group`). This PR fixes this issue.

## Tests
- [x] Unit tests

## Pre-merge steps
- [x] Update version
- [x] Update changelog