### PR TITLE
Use relationship boolean for the synonym option rather than citing

### DIFF
--- a/app/models/instance_type.rb
+++ b/app/models/instance_type.rb
@@ -93,7 +93,7 @@ class InstanceType < ActiveRecord::Base
 
   # For new records: just the standard set.
   def self.synonym_options
-    where("citing").where.not("deprecated")
+    where("relationship").where.not("deprecated")
                    .where.not("unsourced")
                    .sort_by(&:name)
                    .collect { |i| [i.name, i.id] }

--- a/app/views/profile_item_references/_edit_form.html.erb
+++ b/app/views/profile_item_references/_edit_form.html.erb
@@ -1,6 +1,6 @@
 <!-- Profile Reference List -->
 <div style="padding-top:10px;border-top:1px dashed #ddd;display:flex;column-gap:5px;align-items:center">
-  <%= raw profile_item_reference.reference.try(:citation_html).to_s %>
+  <%= sanitize(profile_item_reference.reference.try(:citation_html).to_s) %>
   <%= render partial: "profile_item_references/delete_widgets",
     locals: {
       profile_item_reference: profile_item_reference

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 10-Feb-2025
+  :jira_id: '5323'
+  :jira_project: NSL
+  :description: |-
+    Update the instance_type query for the Synonymy to use relationship boolean rathern than citing
 - :date: 05-Feb-2025
   :jira_id: '39'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.37
+appversion=4.1.5.38

--- a/spec/models/instance_type_spec.rb
+++ b/spec/models/instance_type_spec.rb
@@ -16,4 +16,28 @@ RSpec.describe InstanceType, type: :model do
       end
     end
   end
+
+  describe ".synonym_options" do
+    let!(:instance_type1) { FactoryBot.create(:instance_type, name: 'Type A', relationship: true, deprecated: false, unsourced: false) }
+    let!(:instance_type2) { FactoryBot.create(:instance_type, name: 'Type B', relationship: true, deprecated: false, unsourced: false) }
+    let!(:instance_type3) { FactoryBot.create(:instance_type, name: 'Type C', relationship: true, deprecated: true, unsourced: false) }
+    let!(:instance_type4) { FactoryBot.create(:instance_type, name: 'Type D', relationship: true, deprecated: false, unsourced: true) }
+    let!(:instance_type5) { FactoryBot.create(:instance_type, name: 'Type E', relationship: false, deprecated: false, unsourced: false) }
+
+    it 'returns only instance types with relationship true, not deprecated, and not unsourced' do
+      result = InstanceType.synonym_options
+      expect(result).to contain_exactly(
+        [instance_type1.name, instance_type1.id],
+        [instance_type2.name, instance_type2.id]
+      )
+    end
+
+    it 'returns the instance types sorted by name' do
+      result = InstanceType.synonym_options
+      expect(result).to eq([
+        [instance_type1.name, instance_type1.id],
+        [instance_type2.name, instance_type2.id]
+      ].sort_by(&:first))
+    end
+  end
 end

--- a/test/models/instance_type/synonym_options_test.rb
+++ b/test/models/instance_type/synonym_options_test.rb
@@ -25,8 +25,16 @@ class InstanceTypeSynonymOptionsTest < ActiveSupport::TestCase
     assert options.instance_of?(Array), "Should be an array."
     #assert_equal 13, options.size, "Should be 13 of them."
     @names = options.collect(&:first)
-    @expected = ["alternative name", "basionym", "doubtful misapplied", "doubtful pro parte misapplied",
-                 "doubtful pro parte taxonomic synonym", "doubtful taxonomic synonym", "isonym", "misapplied", "nomenclatural synonym", "pro parte misapplied", "pro parte taxonomic synonym", "replaced synonym", "taxonomic synonym", "trade name"]
+    @expected = [
+      "alternative name",
+      "basionym",
+      "doubtful pro parte misapplied",
+      "doubtful pro parte taxonomic synonym",
+      "doubtful taxonomic synonym",
+      "nomenclatural synonym",
+      "pro parte nomenclatural synonym",
+      "taxonomic synonym"
+    ]
   end
 
   test "instance type synonym options" do


### PR DESCRIPTION
# Summary
For the Synonym instance_type dropdown, use the `relationship` column to query for the instance type options rather than the `citing` column

## How to Test
The affected pages/sections are:
- the instance type dropdown from the synonym tab
- the form for creating synonym instance
- the form for updating a synonym instance
- the dropdown in the loader


## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
NSL-5323

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
