### PR TITLE
Update unpub query to use relationship=true

### DIFF
--- a/app/models/instance_type.rb
+++ b/app/models/instance_type.rb
@@ -101,9 +101,10 @@ class InstanceType < ActiveRecord::Base
 
   # For new records: just the standard set.
   def self.unpublished_citation_options
-    where("unsourced").where.not("deprecated")
-                      .sort_by(&:name)
-                      .collect { |i| [i.name, i.id] }
+    where("relationship").where("unsourced")
+      .where.not("deprecated")
+      .sort_by(&:name)
+      .collect { |i| [i.name, i.id] }
   end
 
   # For existing records.

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -2,7 +2,7 @@
   :jira_id: '5323'
   :jira_project: NSL
   :description: |-
-    Update the instance_type query for the Synonymy to use relationship boolean rathern than citing
+    Update the instance_type query for the Synonymy and Unpub to use relationship=true
 - :date: 05-Feb-2025
   :jira_id: '39'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.38
+appversion=4.1.5.39

--- a/spec/models/instance_type_spec.rb
+++ b/spec/models/instance_type_spec.rb
@@ -40,4 +40,28 @@ RSpec.describe InstanceType, type: :model do
       ].sort_by(&:first))
     end
   end
+
+  describe '.unpublished_citation_options' do
+    let!(:instance_type1) { FactoryBot.create(:instance_type, name: 'Type A', relationship: true, unsourced: true, deprecated: false) }
+    let!(:instance_type2) { FactoryBot.create(:instance_type, name: 'Type B', relationship: true, unsourced: true, deprecated: false) }
+    let!(:instance_type3) { FactoryBot.create(:instance_type, name: 'Type C', relationship: true, unsourced: true, deprecated: true) }
+    let!(:instance_type4) { FactoryBot.create(:instance_type, name: 'Type D', relationship: true, unsourced: false, deprecated: false) }
+    let!(:instance_type5) { FactoryBot.create(:instance_type, name: 'Type E', relationship: false, unsourced: true, deprecated: false) }
+
+    it 'returns only instance types with relationship true, unsourced true, and not deprecated' do
+      result = InstanceType.unpublished_citation_options
+      expect(result).to contain_exactly(
+        [instance_type1.name, instance_type1.id],
+        [instance_type2.name, instance_type2.id]
+      )
+    end
+
+    it 'returns the instance types sorted by name' do
+      result = InstanceType.unpublished_citation_options
+      expect(result).to eq([
+        [instance_type1.name, instance_type1.id],
+        [instance_type2.name, instance_type2.id]
+      ].sort_by(&:first))
+    end
+  end
 end

--- a/test/fixtures/instance_types.yml
+++ b/test/fixtures/instance_types.yml
@@ -127,11 +127,13 @@ misapplied:
   <<: *DEFAULTS
   name: "misapplied"
   citing: true
+  relationship: true
   misapplied: true
 
 doubtful_misapplied:
   <<: *DEFAULTS
   name: "doubtful misapplied"
+  relationship: true
   citing: true
   misapplied: true
   sort_order: 8
@@ -213,6 +215,7 @@ invalid_publication:
 isonym:
   <<: *DEFAULTS
   name: "isonym"
+  relationship: true
   citing: true
 
 nom_et_stat_nov:
@@ -248,6 +251,7 @@ pro_parte_misapplied:
   name: "pro parte misapplied"
   citing: true
   misapplied: true
+  relationship: true
   sort_order: 7
 
 pro_parte_nomenclatural_synonym:
@@ -275,12 +279,14 @@ pro_parte_taxonomic_synonym:
   name: "pro parte taxonomic synonym"
   citing: true
   taxonomic: true
+  relationship: true
   sort_order: 3
 
 replaced_synonym:
   <<: *DEFAULTS
   name: replaced synonym
   citing: true
+  relationship: true
   sort_order: 1
 
 secondary_reference:
@@ -313,6 +319,7 @@ taxonomic_synonym:
 trade_name:
   <<: *DEFAULTS
   name: "trade name"
+  relationship: true
   citing: true
 
 vernacular_name:

--- a/test/fixtures/instance_types.yml
+++ b/test/fixtures/instance_types.yml
@@ -239,6 +239,7 @@ nomenclatural_synonym:
 orthographic_variant:
   <<: *DEFAULTS
   name: orthographic variant
+  relationship: true
   citing: true
   unsourced: true
 

--- a/test/models/instance_type/synonym_options_test.rb
+++ b/test/models/instance_type/synonym_options_test.rb
@@ -28,12 +28,19 @@ class InstanceTypeSynonymOptionsTest < ActiveSupport::TestCase
     @expected = [
       "alternative name",
       "basionym",
+      "doubtful misapplied",
       "doubtful pro parte misapplied",
       "doubtful pro parte taxonomic synonym",
       "doubtful taxonomic synonym",
+      "isonym",
+      "misapplied",
       "nomenclatural synonym",
+      "pro parte misapplied",
+      "pro parte taxonomic synonym",
       "pro parte nomenclatural synonym",
-      "taxonomic synonym"
+      "replaced synonym",
+      "taxonomic synonym",
+      "trade name"
     ]
   end
 


### PR DESCRIPTION
# Summary
Update the unpub options query to also include `relationship=true`. This PR also includes updates on the fixtures

## How to Test
<!-- Provide instructions for testing this PR -->

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
NSL-5323

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
