### PR TITLE
NSL-5341: Loader: Fix error handler to avoid uninitialized constant message for parenting error

### DIFF
--- a/app/models/loader/name/make_one_instance/make_one_synonymy_instance.rb
+++ b/app/models/loader/name/make_one_instance/make_one_synonymy_instance.rb
@@ -32,13 +32,13 @@ class Loader::Name::MakeOneInstance::MakeOneSynonymyInstance
     if synonym_already_attached?
       record_synonym_already_there
       entry = "#{Constants::DECLINED_INSTANCE} -: synonym already in place for "
-      entry += "#{@loader_name.simple_name} ##{@loader_name.id}"
+r     entry += "#{@loader_name.simple_name} ##{@loader_name.id}"
       log_to_table(entry)
       return {declines: 1, declines_reasons: {synonym_already_in_place: 1}}
     end
     create_relationship_instance
   rescue StandardError => e
-    entry = "#{Constants::ERROR_INSTANCE} - for #{@loader_name.simple_name} "
+    entry = "#{Constants::FAILED_INSTANCE} - for #{@loader_name.simple_name} "
     entry += "##{@loader_name.id} - error in create: #{e}"
     log_to_table(entry)
     {errors: 1, errors_reasons: {"#{e.to_s}": 1}}

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 18-Feb-2025
+  :jira_id: '5341'
+  :description: |-
+    Loader: Fix error handler to avoid <code>uninitialized constant</code> message for parenting error
+- :date: 18-Feb-2025
   :jira_id: '5331'
   :description: |-
     Rename User name to user_name and same on screen label

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.5.44
+appversion=4.1.5.45


### PR DESCRIPTION
## Description
Tiny change to refer to a constant by its correct name.

## Type of change
- [x] Bug fix


## How to Test
Run loader with a specific case of an unpainted synonym (very rare) - Anna has a case ready from reporting this error.


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
