### PR TITLE
Put back the codes for the product roles in the menu

### DIFF
--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -38,6 +38,14 @@
         <a tabindex="-1" href="#" title="#{@current_registered_user.user_name}">
           <%= @current_registered_user.user_name %>
         </a>
+        <ul class="dropdown-menu">
+          <% @current_registered_user.product_roles.includes(:role_type).each do |product_role| %>
+            <li role="presentation">
+              <a title="A product role you have">
+                <%= "#{editor_icon('circle-o')} #{product_role.role_type.name}".html_safe %>
+              </a>
+          <% end %>
+        </ul>
       </li>
     <% end %>
     <li role="presentation" class="divider"></li>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 20-Feb-2025
+  :jira_id: '40'
+  :jira_project: FLOR
+  :description: |-
+    FOA Project: Adding back the user's product roles in the menu
 - :date: 19-Feb-2025
   :jira_id: '40'
   :jira_project: FLOR
@@ -14,7 +19,7 @@
 - :date: 19-Feb-2025
   :jira_id: ''
   :description: |-
-    Ruby gem patch: Dependabot upgrade Nokogiri 
+    Ruby gem patch: Dependabot upgrade Nokogiri
 - :date: 19-Feb-2025
   :jira_id: ''
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.4
+appversion=4.1.6.5

--- a/spec/views/layouts/_user_menu_spec.rb
+++ b/spec/views/layouts/_user_menu_spec.rb
@@ -1,83 +1,83 @@
-# require "rails_helper"
+require "rails_helper"
 
-# RSpec.describe "layouts/_user_menu.html.erb", type: :view do
-#   let(:user) { FactoryBot.create(:session_user) }
-#   let(:registered_user) { FactoryBot.create(:user, user_name: "Registered User") }
-#   let(:role_type) { FactoryBot.create(:role_type, name: "Role Type") }
-#   let(:product) { FactoryBot.create(:product, name: "Product") }
-#   let!(:user_product_role) { FactoryBot.create(:user_product_role, product: product, role_type: role_type, user: registered_user) }
+RSpec.describe "layouts/_user_menu.html.erb", type: :view do
+  let(:user) { FactoryBot.create(:session_user) }
+  let(:registered_user) { FactoryBot.create(:user, user_name: "Registered User") }
+  let(:role_type) { FactoryBot.create(:role_type) }
+  let(:product) { FactoryBot.create(:product, name: "Product") }
+  let!(:user_product_role) { FactoryBot.create(:user_product_role, product: product, role_type: role_type, user: registered_user) }
 
-#   before do
-#     allow(view).to receive(:editor_icon).and_return("icon")
-#     allow(view).to receive(:params).and_return(controller: "names")
+  before do
+    allow(view).to receive(:editor_icon).and_return("icon")
+    allow(view).to receive(:params).and_return(controller: "names")
 
-#     assign(:current_user, user)
-#     assign(:current_registered_user, registered_user)
-#   end
+    assign(:current_user, user)
+    assign(:current_registered_user, registered_user)
+  end
 
-#   xcontext "when user is present" do
-#     it "displays the user dropdown menu" do
-#       render
-#       expect(rendered).to have_selector("a#user-dropdown-menu-link", text: user.full_name)
-#     end
+  context "when user is present" do
+    it "displays the user dropdown menu" do
+      render
+      expect(rendered).to have_selector("a#user-dropdown-menu-link", text: user.full_name)
+    end
 
-#     context "when user has groups" do
-#       before do
-#         allow(user).to receive(:groups).and_return(["edit", "admin"])
-#       end
+    context "when user has groups" do
+      before do
+        allow(user).to receive(:groups).and_return(["edit", "admin"])
+      end
 
-#       it "displays the user's groups" do
-#         render
-#         expect(rendered).to have_selector("a", text: "2 Groups")
-#         expect(rendered).to have_selector("a", text: "Edit")
-#         expect(rendered).to have_selector("a", text: "Admin")
-#       end
-#     end
+      it "displays the user's groups" do
+        render
+        expect(rendered).to have_selector("a", text: "2 Groups")
+        expect(rendered).to have_selector("a", text: "Edit")
+        expect(rendered).to have_selector("a", text: "Admin")
+      end
+    end
 
-#     context "when registered user is present" do
-#       context "when registered user has product roles" do
-#         it "displays the registered user's product roles" do
-#           render
-#           expect(rendered).to have_selector("a", text: registered_user.user_name)
-#           expect(rendered).to have_selector("a", text: "Role Type")
-#         end
-#       end
-#       context "when registered user does not have product roles" do
-#         let(:registered_user_1) { FactoryBot.create(:user, user_name: "Registered User 1") }
-#         let!(:user_product_role) { FactoryBot.create(:user_product_role, product: product, role_type: role_type, user: registered_user_1) }
-#         it "does not display the registered user's product roles" do
-#           render
-#           expect(rendered).to have_selector("a", text: registered_user.user_name)
-#           expect(rendered).not_to have_selector("a", text: "Role Type")
-#         end
-#       end
-#     end
-#   end
+    context "when registered user is present" do
+      context "when registered user has product roles" do
+        it "displays the registered user's product roles" do
+          render
+          expect(rendered).to have_selector("a", text: registered_user.user_name)
+          expect(rendered).to have_selector("a", text: role_type.name)
+        end
+      end
+      context "when registered user does not have product roles" do
+        let(:registered_user_1) { FactoryBot.create(:user, user_name: "Registered User 1") }
+        let!(:user_product_role) { FactoryBot.create(:user_product_role, product: product, role_type: role_type, user: registered_user_1) }
+        it "does not display the registered user's product roles" do
+          render
+          expect(rendered).to have_selector("a", text: registered_user.user_name)
+          expect(rendered).not_to have_selector("a", text: role_type.name)
+        end
+      end
+    end
+  end
 
-#   xcontext "when generic active directory user" do
-#     before do
-#       allow(view).to receive(:session).and_return({ generic_active_directory_user: true })
-#     end
+  context "when generic active directory user" do
+    before do
+      allow(view).to receive(:session).and_return({ generic_active_directory_user: true })
+    end
 
-#     it "displays change password option as struck through" do
-#       render
-#       expect(rendered).to have_selector("span.strike-through", text: "Change Password")
-#     end
-#   end
+    it "displays change password option as struck through" do
+      render
+      expect(rendered).to have_selector("span.strike-through", text: "Change Password")
+    end
+  end
 
-#   xcontext "when not a generic active directory user" do
-#     before do
-#       allow(view).to receive(:session).and_return({ generic_active_directory_user: false })
-#     end
+  context "when not a generic active directory user" do
+    before do
+      allow(view).to receive(:session).and_return({ generic_active_directory_user: false })
+    end
 
-#     it "displays change password link" do
-#       render
-#       expect(rendered).to have_selector("a", text: "Change password")
-#     end
-#   end
+    it "displays change password link" do
+      render
+      expect(rendered).to have_selector("a", text: "Change password")
+    end
+  end
 
-#   it "displays sign out link" do
-#     render
-#     expect(rendered).to have_selector("a", text: "Sign out")
-#   end
-# end
+  it "displays sign out link" do
+    render
+    expect(rendered).to have_selector("a", text: "Sign out")
+  end
+end

--- a/test/factories/role_type.rb
+++ b/test/factories/role_type.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :role_type, class: "Product::RoleType" do
     description { "Please describe this product role type" }
-    name { "Role Type" }
+    sequence(:name) {|n| "role type #{n}" }
     created_by { "fred" }
     updated_by { "fred" }
   end


### PR DESCRIPTION
## Description
We are putting back the codes for the user's product role list in the menu. Tests are also added back and should now be passing with CI

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
