### PR TITLE
FLOR-43: FOA Project: Make the Users table search target available…

### DIFF
--- a/app/views/search/search_targets/_standard_targets.html.erb
+++ b/app/views/search/search_targets/_standard_targets.html.erb
@@ -124,7 +124,9 @@
                 >Bulk processing logs</a>
             </li>
             <li role="separator" class="divider"></li>
+          <% end %>
 
+           <% if can? 'users', 'select' %>
             <li><a id="search-target-item-user" 
                    href="#" 
                    title="Search Users" 
@@ -132,7 +134,9 @@
                    data-examples="user-search-examples"
                 >Users</a>
             </li>
+          <% end %>
 
+          <% if Rails.configuration.try(:batch_loader_aware) %>
             <li><a id="search-target-item-org" 
                    href="#" 
                    title="Search Organisations" 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 20-Feb-2025
+  :jira_id: '43'
+  :jira_project: FLOR
+  :description: |-
+    FOA Project: Make the Users table search target available outside the batch aware context to users authorised to see user data
+- :date: 20-Feb-2025
   :jira_id: '40'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.5
+appversion=4.1.6.6


### PR DESCRIPTION
…outside the batch aware context to users authorised to see user data

## Description
Stop hiding the Users search target behind a feature flag for batch work and offer it to authorised users.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## How to Test
Admin users should be able to search users.  Non-admin users should not.


## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
