### PR TITLE
NSL-5341: Loader: Trap and decline processing when synonym has no parent record

### DIFF
--- a/app/models/loader/name/make_one_instance/make_one_synonymy_instance.rb
+++ b/app/models/loader/name/make_one_instance/make_one_synonymy_instance.rb
@@ -17,6 +17,12 @@ class Loader::Name::MakeOneInstance::MakeOneSynonymyInstance
       log_to_table(entry)
       return {declines: 1, declines_reasons: {relationship_instance_already_noted: 1}}
     end
+    if @loader_name.parent.blank?
+      entry = "#{Constants::DECLINED_INSTANCE} -: synonym has no parent"
+      entry += " #{@loader_name.simple_name} ##{@loader_name.id}"
+      log_to_table(entry)
+      return {declines: 1, declines_reasons: {synonym_has_no_parent: 1}}
+    end
     if @loader_name.parent.preferred_match.blank?
       entry = "#{Constants::DECLINED_INSTANCE} -: parent has no preferred match"
       entry += " #{@loader_name.simple_name} ##{@loader_name.id}"

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 20-Feb-2025
+  :jira_id: '5341'
+  :description: |-
+    Loader: Trap and decline processing when synonym has no parent record
+- :date: 20-Feb-2025
   :jira_id: '43'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.6
+appversion=4.1.6.7


### PR DESCRIPTION


## Description
Batch loading new trap for a decline


## How to Test
Anna will know


## Tests
- [ ] Unit tests
- [ ] Manual testing



## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
