### PR TITLE
Update product role list in the menu

### DIFF
--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -35,14 +35,14 @@
     <% if @current_registered_user.present? %>
       <li role="presentation" class="divider"></li>
       <li class="dropdown-submenu">
-        <a tabindex="-1" href="#" title="#{@current_registered_user.user_name}">
+        <a tabindex="-1" href="#" title="<%= @current_registered_user.user_name %>">
           <%= @current_registered_user.user_name %>
         </a>
         <ul class="dropdown-menu">
-          <% @current_registered_user.product_roles.includes(:role_type).each do |product_role| %>
+          <% @current_registered_user.product_roles.includes(:product, :role_type).each do |product_role| %>
             <li role="presentation">
               <a title="A product role you have">
-                <%= "#{editor_icon('circle-o')} #{product_role.role_type.name}".html_safe %>
+                <%= "#{editor_icon('circle-o')} #{product_role.product.name} #{product_role.role_type.name}".html_safe %>
               </a>
           <% end %>
         </ul>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 21-Feb-2025
+  :jira_id: '42'
+  :description: |-
+    Permissions: List down the roles that a user has in the menu.
 - :date: 20-Feb-2025
   :jira_id: '5341'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.7
+appversion=4.1.6.8

--- a/spec/views/layouts/_user_menu_spec.rb
+++ b/spec/views/layouts/_user_menu_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "layouts/_user_menu.html.erb", type: :view do
         it "displays the registered user's product roles" do
           render
           expect(rendered).to have_selector("a", text: registered_user.user_name)
-          expect(rendered).to have_selector("a", text: role_type.name)
+          expect(rendered).to have_selector("a", text: "#{product.name} #{role_type.name}")
         end
       end
       context "when registered user does not have product roles" do


### PR DESCRIPTION

## Description
Update product role list in the menu to display the Product Name and Product Role Type (e.g APNI drafter) name. And also fixes the bug when hovering on the username - it was showing up a coded text rather than the actual username


## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Login -> hover on your name from the top menu -> hover on your username and you will see the list of the roles you are assigned to

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-42

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
