### PR TITLE
NSL-5331:  Loader: Recent column change in Users table from name to user_name cause problems in voting tab - fixed

### DIFF
--- a/app/models/loader/batch/reviewer.rb
+++ b/app/models/loader/batch/reviewer.rb
@@ -90,7 +90,7 @@ class Loader::Batch::Reviewer < ActiveRecord::Base
   def self.batch_reviewers_for_org_username_batch_review(org, username, batch_review)
     self.where(org_id: org.id)
         .joins(:user)
-        .where(["users.name = ?", username])
+        .where(["users.user_name = ?", username])
         .joins(batch_review_period: :batch_review)
         .where(["batch_review.loader_batch_id = ?", batch_review.loader_batch_id])
         .distinct
@@ -98,7 +98,7 @@ class Loader::Batch::Reviewer < ActiveRecord::Base
 
   def self.username_to_reviewers_for_review(username, review)
     Loader::Batch::Reviewer.joins([:user, :batch_review])
-                           .where('users.name': username)
+                           .where('users.user_name': username)
                            .where('batch_review.id': review.id)
   end
 

--- a/app/models/org.rb
+++ b/app/models/org.rb
@@ -72,13 +72,13 @@ class Org < ActiveRecord::Base
 
   def self.xorgs_reviewer_can_vote_on_behalf_of_in_a_review(username, review)
     Org.joins(batch_reviewers: [:user, :batch_review_period])
-       .where('users.name': username)
+       .where('users.user_name': username)
       .where('batch_review_period.batch_review_id': review.id)
   end
 
   def self.yorgs_reviewer_can_vote_on_behalf_of_in_a_review(reviewer)
     Org.joins(batch_reviewers: [:user, :batch_review_period])
-       .where('users.name': username)
+       .where('users.user_name': username)
       .where('batch_review_period.batch_review_id': review.id)
   end
 
@@ -87,6 +87,6 @@ class Org < ActiveRecord::Base
   end
 
   def user_as_reviewer_for_review(username, review)
-    can_vote_in_review(review).where(user_id: User.where(name: 'gbentham')).first
+    can_vote_in_review(review).where(user_id: User.where(user_name: 'gbentham')).first
   end
 end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,5 +1,10 @@
 - :date: 21-Feb-2025
+  :jira_id: '5331'
+  :description: |-
+    Loader: Recent column change in Users table from name to user_name caused problems in voting tab - fixed.
+- :date: 21-Feb-2025
   :jira_id: '42'
+  :jira_project: FLOR
   :description: |-
     Permissions: List down the roles that a user has in the menu.
 - :date: 20-Feb-2025

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.8
+appversion=4.1.6.9


### PR DESCRIPTION
## Description
Missed some places the name column is referred to - found them and changed reference to user_name.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How to Test
Run through batch voting workflow


## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
