### PR TITLE
Product context and switching context

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,7 +15,11 @@ class ApplicationController < ActionController::Base
     head :forbidden
   end
 
+  helper_method :product_context_product_id
+
   protected
+
+  attr_reader :current_user, :current_registered_user
 
   def show_login_page
     logger.error("Invalid Authenticity Token.")
@@ -44,6 +48,19 @@ class ApplicationController < ActionController::Base
     else
       continue_user_session
     end
+  end
+
+  def set_product_context_session
+    product_context = current_registered_user.default_product_context
+    if product_context && session[:product_context_display_text].blank?
+      session[:product_context_is_default] = product_context.is_default?
+      session[:product_context_display_text] = product_context.products.map(&:name).join("/")
+      session[:product_context_product_id] = product_context.products.pluck(:id).first
+    end
+  end
+
+  def product_context_product_id
+    session[:product_context_product_id]
   end
 
   private
@@ -86,6 +103,7 @@ class ApplicationController < ActionController::Base
     @current_registered_user = @current_user.registered_user
     logger.info("User is known: #{@current_user.username}")
     set_working_draft_session
+    set_product_context_session
   end
 
   def set_working_draft_session

--- a/app/controllers/product_contexts/sessions_controller.rb
+++ b/app/controllers/product_contexts/sessions_controller.rb
@@ -1,0 +1,25 @@
+class ProductContexts::SessionsController < ApplicationController
+
+  def switch
+    product_context = current_registered_user.product_contexts.find_by(context_id: params[:context_id])
+    set_product_context(product_context)
+    redirect_to :root
+  end
+
+  def clear
+    set_product_context(current_registered_user.default_product_context)
+    redirect_to :root
+  end
+
+  private
+
+  def set_product_context(product_context = nil)
+    product_context ||= current_registered_user.default_product_context
+
+    return unless product_context
+
+    session[:product_context_is_default] = product_context.is_default?
+    session[:product_context_display_text] = product_context.products.map(&:name).join("/")
+    session[:product_context_product_id] = product_context.products.pluck(:id).first
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,6 @@
 #   limitations under the License.
 #
 class SessionsController < ApplicationController
-  skip_before_action :authenticate
 
   def new
     build_sign_in
@@ -31,7 +30,7 @@ class SessionsController < ApplicationController
 
   # Known problem: if login is rejected due to no login authority
   # entering a legit username/password into the re-rendered sign in form
-  # fails the first time.  
+  # fails the first time.
   def create
     build_sign_in
     if @sign_in.save && authorised_to_login?
@@ -93,7 +92,7 @@ class SessionsController < ApplicationController
     sign_in_params = params[:sign_in]
     sign_in_params&.permit(:username, :password)
   end
-  
+
   def authorised_to_login?
     if @sign_in.groups.include?('login')
       true

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -91,6 +91,7 @@ class Ability
     can "menu",               "user"
     can "menu",               "admin" # config is the only option
     can "admin",              "index" # allows viewing of the config
+    can "product_contexts/sessions", :all
   end
 
   def basic_auth_2

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: product(Describes a product available within the NSL infrastructure.)
+#
+#  id(A system wide unique identifier allocated to each profile product.)                            :bigint           not null, primary key
+#  api_date(The date when a script, jira or services task last changed this record.)                 :timestamptz
+#  api_name(The name of a script, jira or services task which last changed this record.)             :string(50)
+#  created_by(The user id of the person who created this data)                                       :string(50)       not null
+#  description_html(The full name for this profile product. i.e. Flora of Australia.)                :text
+#  internal_notes(Team notes about the management or maintenance of this product.)                   :text
+#  is_available(Indicates this product is publicly available.)                                       :boolean          default(FALSE), not null
+#  is_current(Indicates this product is currently being maintained and published.)                   :boolean          default(FALSE), not null
+#  is_name_index                                                                                     :boolean          default(FALSE), not null
+#  lock_version(A system field to manage row level locking.)                                         :integer          default(0), not null
+#  name(The standard acronym for this profile product. i.e. FOA, APC.)                               :text             not null
+#  source_id_string(The identifier from the source system that this profile text was imported from.) :string(100)
+#  source_system(The source system that this profile text was imported from.)                        :string(50)
+#  updated_by(The user id of the person who last updated this data)                                  :string(50)       not null
+#  created_at(The date and time this data was created.)                                              :timestamptz      not null
+#  updated_at(The date and time this data was updated.)                                              :timestamptz      not null
+#  namespace_id(The auNSL dataset that physically contains this profile text.)                       :bigint
+#  reference_id(The highest level reference for this product.)                                       :bigint
+#  source_id(The key at the source system imported on migration.)                                    :bigint
+#  tree_id(The tree (taxonomy) used for this product.)                                               :bigint
+#
+# Foreign Keys
+#
+#  product_reference_id_fkey  (reference_id => reference.id)
+#  product_tree_id_fkey       (tree_id => tree.id)
+#
 class Product < ApplicationRecord
   strip_attributes
   self.table_name = "product"
@@ -6,6 +36,7 @@ class Product < ApplicationRecord
 
   belongs_to :tree, optional: true
   belongs_to :reference, optional: true
-  has_many :user_product_roles, class_name: "User::ProductRole", foreign_key: "product_id"
 
+  has_many :user_product_roles, class_name: "User::ProductRole", foreign_key: "product_id"
+  has_many :product_contexts, class_name: "Product::Context", foreign_key: "product_id"
 end

--- a/app/models/product/context.rb
+++ b/app/models/product/context.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+# == Schema Information
+#
+# Table name: product_context(The sets of products that a user can validly set a context for in the editor)
+#
+#  id(The identifier for a product context record.)                                                                                                                                                              :bigint           not null, primary key
+#  api_date(The date when a system user, script, jira or services task last changed this record.)                                                                                                                :timestamptz
+#  api_name(The name of a system user, script, jira or services task which last changed this record.)                                                                                                            :string(50)
+#  created_by(The user id of the person who created this data)                                                                                                                                                   :string(50)       not null
+#  description(A description for this context)                                                                                                                                                                   :text             default("Please describe this product context"), not null
+#  lock_version(A system field to manage row level locking.)                                                                                                                                                     :bigint           default(0), not null
+#  updated_by(The user id of the person who last updated this data)                                                                                                                                              :string(50)       not null
+#  created_at(The date and time this data was created.)                                                                                                                                                          :timestamptz      not null
+#  updated_at(The date and time this data was updated.)                                                                                                                                                          :timestamptz      not null
+#  context_id(A number that represents an available context. Only the name index and default accepted tree can share a context in each dataset ie. in vascular plants - APNI and APC can be in the same context) :bigint           not null
+#  product_id(The product for a context)                                                                                                                                                                         :bigint           not null
+#
+# Indexes
+#
+#  pc_u_product_context  (context_id,product_id) UNIQUE
+#
+# Foreign Keys
+#
+#  pc_product_fk  (product_id => product.id)
+#
+# For a product, the context in which it is used.
+class Product::Context < ApplicationRecord
+  self.table_name = "product_context"
+  self.primary_key = "id"
+
+  belongs_to :product, foreign_key: "product_id"
+
+  validates :context_id, :created_by, :updated_by, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,8 +28,8 @@
 #  family_name  :string(60)       not null
 #  given_name   :string(60)
 #  lock_version :bigint           default(0), not null
-#  user_name    :citext           not null
 #  updated_by   :string(50)       not null
+#  user_name    :string(30)       not null
 #  created_at   :timestamptz      not null
 #  updated_at   :timestamptz      not null
 #
@@ -43,11 +43,16 @@ class User < ActiveRecord::Base
   self.sequence_name = "nsl_global_seq"
 
   has_many :batch_reviewers, class_name: "Loader::Batch::Reviewer", foreign_key: :user_id
-  has_many :product_roles, class_name: "User::ProductRole"
+  has_many :product_roles, class_name: "User::ProductRole", foreign_key: :user_id
   has_many :products, through: :product_roles
+  has_many :product_contexts, class_name: "User::ProductContext", foreign_key: :user_id
 
   before_create :set_audit_fields
   before_update :set_updated_by
+
+  def is?(requested_role_type_name)
+    product_roles.joins(:role_type).select("product_role_type.name").pluck(:name).include?(requested_role_type_name)
+  end
 
   def set_audit_fields
     self.created_by = self.updated_by = @current_user&.username||'unknown'
@@ -56,7 +61,6 @@ class User < ActiveRecord::Base
   def set_updated_by
     self.updated_by = @current_user&.username||'unknown'
   end
-
 
   # Note, the PK for the users table is the id column.
   # That appears as user_id as a foreign key.
@@ -71,6 +75,10 @@ class User < ActiveRecord::Base
     raise user.errors.full_messages.first.to_s unless user.save_with_username(username)
 
     user
+  end
+
+  def default_product_context
+    product_contexts.default.first
   end
 
   def save_with_username(username)

--- a/app/models/user/product_context.rb
+++ b/app/models/user/product_context.rb
@@ -1,0 +1,37 @@
+# == Schema Information
+#
+# Table name: user_product_context(A context that a user can validly set in the editor)
+#
+#  api_date(The date when a system user, script, jira or services task last changed this record.)     :timestamptz
+#  api_name(The name of a system user, script, jira or services task which last changed this record.) :string(50)
+#  created_by(The user id of the person who created this data)                                        :string(50)       not null
+#  is_default(The default context for a user when they logon)                                         :boolean          default(FALSE), not null
+#  lock_version(A system field to manage row level locking.)                                          :bigint           default(0), not null
+#  updated_by(The user id of the person who last updated this data)                                   :string(50)       not null
+#  created_at(The date and time this data was created.)                                               :timestamptz      not null
+#  updated_at(The date and time this data was updated.)                                               :timestamptz      not null
+#  context_id(Context given to a user)                                                                :bigint           not null, primary key
+#  user_id(User given the context)                                                                    :bigint           not null, primary key
+#
+# Indexes
+#
+#  upc_user_context  (user_id,context_id) UNIQUE
+#
+# Foreign Keys
+#
+#  ucr_users_fk  (user_id => users.id)
+#
+# A context that a user can validly set in the editor
+class User::ProductContext < ApplicationRecord
+  self.table_name = "user_product_context"
+
+  belongs_to :user, foreign_key: "user_id"
+
+  scope :default, -> { where(is_default: true) }
+
+  validates :context_id, :created_by, :updated_by, presence: true
+
+  def products
+    Product.where(id: Product::Context.where(context_id: context_id).pluck(:product_id))
+  end
+end

--- a/app/views/layouts/_menu_links.html.erb
+++ b/app/views/layouts/_menu_links.html.erb
@@ -25,3 +25,14 @@
   <li> <%= render partial: 'layouts/admin_menu' %> </li>
 <% end %>
 
+<% if session[:product_context_display_text].present? %>
+  <li class="">
+    <div class="highlighted">
+      <span> | In <%= session[:product_context_display_text] %></span>
+      <% if !session[:product_context_is_default] %>
+        <%= link_to "( clear )", clear_product_contexts_path, method: :post, class: "highlighted", title: "Reset context" %>
+      <% end %>
+    </div>
+  </li>
+<% end %>
+

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -32,7 +32,18 @@
                </a>
              </li>
           <% end %>
+
           <% if @current_registered_user.present? %>
+            <% @current_registered_user.product_contexts.each_with_index do |product_context, index| %>
+              <% if index == 0 %>
+                  <li role="presentation" class="divider"></li>
+                <% end %>
+              <li role="presentation">
+                <%- product_context_display_name = product_context.products.map(&:name).join('/') %>
+                <%= link_to "#{editor_icon('shuffle')} Switch to #{product_context_display_name} context".html_safe, switch_product_contexts_path(context_id: product_context.context_id), method: :post, class: "rebeccapurple", title: "#{product_context_display_name} context switch" %>
+              </li>
+            <% end %>
+
             <% @current_registered_user.product_roles.includes(:product, :role_type).each_with_index do |product_role, index| %>
               <% if index == 0 %>
                 <li role="presentation" class="divider"></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,11 @@ Rails.application.routes.draw do
   match "/search/help/:help_id",
         as: "search_help", to: "search#help", via: :get
 
+  scope :product_contexts, only: [] do
+    post :switch, as: "switch_product_contexts", to: "product_contexts/sessions#switch"
+    post :clear, as: "clear_product_contexts", to: "product_contexts/sessions#clear"
+  end
+
   resources :instance_notes,
             only: %i[show new edit create update destroy]
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1139,7 +1139,7 @@ begin
     end if;
 
 end;
-    
+
 $$;
 
 
@@ -11023,11 +11023,85 @@ ALTER TABLE ONLY public.user_product_role
     ADD CONSTRAINT upr_users_fk FOREIGN KEY (user_id) REFERENCES public.users(id);
 
 
---
--- PostgreSQL database dump complete
---
-
 SET search_path TO public,loader;
 
 
 
+drop table if exists public.product_context;
+create table if not exists public.product_context
+(
+    id           bigint primary key default nextval  ('public.nsl_global_seq'::regclass),
+    context_id   bigint not null,
+    product_id   bigint
+        constraint pc_product_fk references public.product not null,
+    description          text not null default 'Please describe this product context',
+    lock_version         bigint                   default 0     not null,
+    created_at           timestamp with time zone default now() not null,
+    created_by           varchar(50)              default USER  not null,
+    updated_at           timestamp with time zone default now() not null,
+    updated_by           varchar(50)              default USER  not null,
+    api_name             varchar(50),
+    api_date             timestamp with time zone
+)
+;
+create unique index if not exists pc_u_product_context
+    on public.product_context (context_id, product_id);
+
+comment on table product_context is 'The sets of products that a user can validly set a context for in the editor';
+
+comment on column product_context.id is 'The identifier for a product context record.';
+comment on column product_context.context_id is 'A number that represents an available context. Only the name index and default accepted tree can share a context in each dataset ie. in vascular plants - APNI and APC can be in the same context';
+comment on column product_context.product_id is 'The product for a context';
+comment on column product_context.description is 'A description for this context';
+comment on column product_context.lock_version is 'A system field to manage row level locking.';
+comment on column product_context.created_at is 'The date and time this data was created.';
+comment on column product_context.created_by is 'The user id of the person who created this data';
+comment on column product_context.updated_at is 'The date and time this data was updated.';
+comment on column product_context.updated_by is 'The user id of the person who last updated this data';
+comment on column product_context.api_name is 'The name of a system user, script, jira or services task which last changed this record.';
+comment on column product_context.api_date is 'The date when a system user, script, jira or services task last changed this record.';
+
+-----------------------------------------------------------------------------------------------------
+-- User Product Context : The product context(s) available to a user
+--
+--  25-Feb-24 [af] new table FLOR-45
+--  26-Feb-25 [af] create in prod FLOR-46
+-----------------------------------------------------------------------------------------------------
+drop table if exists public.user_product_context;
+create table public.user_product_context
+(
+    user_id              bigint                  not null
+        constraint ucr_users_fk
+            references public.users,
+    context_id           bigint                  not null,
+    is_default           boolean                  not null default false,
+    lock_version         bigint                   default 0     not null,
+    created_at           timestamp with time zone default now() not null,
+    created_by           varchar(50)              default USER  not null,
+    updated_at           timestamp with time zone default now() not null,
+    updated_by           varchar(50)              default USER  not null,
+    api_name             varchar(50),
+    api_date             timestamp with time zone,
+    primary key (user_id, context_id)
+);
+
+create unique index upc_user_context on user_product_context (user_id, context_id);
+alter table public.user_product_context
+    owner to nsl;
+
+comment on table user_product_context is 'A context that a user can validly set in the editor';
+
+comment on column user_product_context.context_id is 'Context given to a user';
+comment on column user_product_context.user_id is 'User given the context';
+comment on column user_product_context.is_default is 'The default context for a user when they logon';
+comment on column user_product_context.lock_version is 'A system field to manage row level locking.';
+comment on column user_product_context.created_at is 'The date and time this data was created.';
+comment on column user_product_context.created_by is 'The user id of the person who created this data';
+comment on column user_product_context.updated_at is 'The date and time this data was updated.';
+comment on column user_product_context.updated_by is 'The user id of the person who last updated this data';
+comment on column user_product_context.api_name is 'The name of a system user, script, jira or services task which last changed this record.';
+comment on column user_product_context.api_date is 'The date when a system user, script, jira or services task last changed this record.';
+
+--
+-- PostgreSQL database dump complete
+--

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      render plain: "Hello World"
+    end
+  end
+
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:session_user) { FactoryBot.create(:session_user, username: user.user_name, full_name: "Test User", groups: ['login','edit']) }
+  let(:product_context) { FactoryBot.create(:product_context) }
+  let(:user_product_context) { FactoryBot.create(:user_product_context, user: user, is_default: true, context_id: product_context.context_id) }
+
+  before do
+    allow(controller).to receive(:current_registered_user).and_return(user)
+    allow(user).to receive(:default_product_context).and_return(user_product_context)
+  end
+
+  describe "#continue_user_session" do
+    before do
+      allow(SessionUser).to receive(:new).and_return(session_user)
+      allow(session_user).to receive(:registered_user).and_return(user)
+    end
+
+    context 'when session variables are set' do
+      before do
+        session[:username] = session_user.username
+        session[:user_full_name] = session_user.full_name
+        session[:groups] = session_user.groups
+      end
+
+      it 'sets the current_user and current_registered_user' do
+        controller.send(:continue_user_session)
+
+        expect(controller.instance_variable_get(:@current_user)).to eq(session_user)
+        expect(controller.instance_variable_get(:@current_registered_user)).to eq(user)
+      end
+
+      it 'sets the product context session' do
+        controller.send(:continue_user_session)
+
+        expect(session[:product_context_is_default]).to eq(user_product_context.is_default?)
+        expect(session[:product_context_display_text]).to eq(user_product_context.products.map(&:name).join("/"))
+      end
+    end
+
+  end
+
+  describe "#set_product_context_session" do
+    context 'when session variables are not set' do
+      it 'sets the session variables based on the default product context' do
+        controller.send(:set_product_context_session)
+
+        expect(session[:product_context_is_default]).to eq(user_product_context.is_default)
+        expect(session[:product_context_display_text]).to eq(user_product_context.products.map(&:name).join("/"))
+      end
+    end
+
+    context 'when session variables are already set' do
+      before do
+        session[:product_context_is_default] = false
+        session[:product_context_display_text] = "Existing Context"
+      end
+
+      it 'does not overwrite the existing session variables' do
+        controller.send(:set_product_context_session)
+
+        expect(session[:product_context_is_default]).to eq(false)
+        expect(session[:product_context_display_text]).to eq("Existing Context")
+      end
+    end
+  end
+end

--- a/spec/controllers/product_contexts/sessions_controller_spec.rb
+++ b/spec/controllers/product_contexts/sessions_controller_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+require 'rails_helper'
+
+RSpec.describe ProductContexts::SessionsController, type: :controller do
+
+  let!(:session_user) { FactoryBot.create(:session_user, groups: ["login", "edit"]) }
+  let!(:user) { FactoryBot.create(:user) }
+  let(:non_default_product_context) { FactoryBot.create(:user_product_context, is_default: false, user: user) }
+  let(:default_product_context) { FactoryBot.create(:user_product_context, user: user, is_default: true) }
+
+  before do
+    session[:username] = session_user.username
+    session[:user_full_name] = session_user.full_name
+    session[:groups] = session_user.groups
+
+    allow(controller).to receive(:current_registered_user).and_return(user)
+    allow(controller).to receive_message_chain(:current_registered_user, :default_product_context).and_return(default_product_context)
+    allow(controller).to receive(:can?).and_return(true)
+  end
+
+  describe 'POST #switch' do
+    context 'when the product context exists' do
+      it 'sets the product context session and redirects' do
+        post :switch, params: { context_id: non_default_product_context.context_id }
+
+        expect(session[:product_context_is_default]).to eq(non_default_product_context.is_default?)
+        expect(session[:product_context_display_text]).to eq(non_default_product_context.products.map(&:name).join("/"))
+        expect(response.status).to eq(302)
+      end
+    end
+
+    context 'when the product context does not exist' do
+      it 'sets to the default context' do
+        post :switch, params: { context_id: 'nonexistent' }
+
+        expect(session[:product_context_is_default]).to eq(default_product_context.is_default?)
+        expect(session[:product_context_display_text]).to eq(default_product_context.products.map(&:name).join("/"))
+        expect(response.status).to eq(302)
+      end
+    end
+  end
+
+  describe 'POST #clear' do
+    it 'sets the default product context session and redirects' do
+      post :clear
+
+      expect(session[:product_context_is_default]).to eq(default_product_context.is_default?)
+      expect(session[:product_context_display_text]).to eq(default_product_context.products.map(&:name).join("/"))
+      expect(response.status).to eq(302)
+    end
+  end
+end

--- a/spec/models/product/context_spec.rb
+++ b/spec/models/product/context_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Product::Context, type: :model do
+
+  subject { described_class.new }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:product).with_foreign_key('product_id') }
+  end
+
+  describe 'validations' do
+    it "validates presence of context_id" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:context_id]).to include("can't be blank")
+    end
+
+    it "validates presence of created_by" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:created_by]).to include("can't be blank")
+    end
+
+    it "validates presence of updated_by" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:updated_by]).to include("can't be blank")
+    end
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:tree).optional }
+    it { is_expected.to belong_to(:reference).optional }
+    it { is_expected.to have_many(:user_product_roles).class_name('User::ProductRole').with_foreign_key('product_id') }
+    it { is_expected.to have_many(:product_contexts).class_name('Product::Context').with_foreign_key('product_id') }
+  end
+end

--- a/spec/models/user/product_context_spec.rb
+++ b/spec/models/user/product_context_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe User::ProductContext, type: :model do
+
+  subject { described_class.new }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:user).with_foreign_key('user_id') }
+  end
+
+  describe 'validations' do
+    it "validates presence of context_id" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:context_id]).to include("can't be blank")
+    end
+
+    it "validates presence of created_by" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:created_by]).to include("can't be blank")
+    end
+
+    it "validates presence of updated_by" do
+      expect(subject).not_to be_valid
+      expect(subject.errors.messages[:updated_by]).to include("can't be blank")
+    end
+  end
+
+  describe "#products" do
+    let(:product) { FactoryBot.create(:product) }
+    let(:product_context) { FactoryBot.create(:product_context, product: product) }
+
+    subject { FactoryBot.create(:user_product_context, is_default: true, context_id: product_context.context_id) }
+
+    it "returns the products associated to the context" do
+      expect(subject.products).to eq([product])
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+
+  describe "associations" do
+    it { is_expected.to have_many(:batch_reviewers).class_name('Loader::Batch::Reviewer').with_foreign_key('user_id') }
+    it { is_expected.to have_many(:product_roles).class_name('User::ProductRole').with_foreign_key('user_id') }
+    it { is_expected.to have_many(:products).through(:product_roles) }
+    it { is_expected.to have_many(:product_contexts).class_name('User::ProductContext').with_foreign_key('user_id') }
+  end
+
+  describe '#is?' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:role_type) { FactoryBot.create(:role_type, name: 'admin') }
+    let(:product) { FactoryBot.create(:product) }
+    let!(:product_role) { FactoryBot.create(:user_product_role, user: user, role_type: role_type, product: product) }
+
+    context 'when the user has the requested role type' do
+      it 'returns true' do
+        expect(user.is?('admin')).to be true
+      end
+    end
+
+    context 'when the user does not have the requested role type' do
+      it 'returns false' do
+        expect(user.is?('editor')).to be false
+      end
+    end
+  end
+end

--- a/spec/views/layouts/_menu_links_spec.rb
+++ b/spec/views/layouts/_menu_links_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "layouts/_menu_links.html.erb", type: :view do
+  let(:user) { FactoryBot.create(:session_user) }
+  let(:registered_user) { FactoryBot.create(:user, user_name: "Registered User") }
+  let(:role_type) { FactoryBot.create(:role_type) }
+  let(:product) { FactoryBot.create(:product, name: "Product") }
+  let!(:user_product_role) { FactoryBot.create(:user_product_role, product: product, role_type: role_type, user: registered_user) }
+
+  before do
+    allow(view).to receive(:can?).and_return(true)
+    allow(view).to receive(:params).and_return(controller: "any_controller")
+  end
+
+  context 'when product context display text is present' do
+    before do
+      session[:product_context_display_text] = "Test Context"
+    end
+
+    context 'when product context is not default' do
+      before do
+        session[:product_context_is_default] = false
+        render
+      end
+
+      it 'displays the product context display text' do
+        expect(rendered).to have_content("In Test Context")
+      end
+
+      it 'displays the clear link' do
+        expect(rendered).to have_link("( clear )", href: clear_product_contexts_path)
+      end
+    end
+
+    context 'when product context is default' do
+      before do
+        session[:product_context_is_default] = true
+        render
+      end
+
+      it 'displays the product context display text' do
+        expect(rendered).to have_content("In Test Context")
+      end
+
+      it 'does not display the clear link' do
+        expect(rendered).not_to have_link("( clear )", href: clear_product_contexts_path)
+      end
+    end
+  end
+
+  context 'when product context display text is not present' do
+    before do
+      session[:product_context_display_text] = nil
+      render
+    end
+
+    it 'does not display the product context display text' do
+      expect(rendered).not_to have_content("In Test Context")
+    end
+
+    it 'does not display the clear link' do
+      expect(rendered).not_to have_link("( clear )", href: clear_product_contexts_path)
+    end
+  end
+end

--- a/spec/views/layouts/_user_menu_spec.rb
+++ b/spec/views/layouts/_user_menu_spec.rb
@@ -52,6 +52,35 @@ RSpec.describe "layouts/_user_menu.html.erb", type: :view do
         end
       end
     end
+
+    context "when user has product contexts" do
+      let!(:product_context) { FactoryBot.create(:product_context) }
+      let!(:user_product_context) { FactoryBot.create(:user_product_context, user: registered_user, is_default: true, context_id: product_context.context_id) }
+
+      let!(:product_context2) { FactoryBot.create(:product_context) }
+      let!(:user_product_context2) { FactoryBot.create(:user_product_context, user: registered_user, is_default: false, context_id: product_context2.context_id) }
+
+      before do
+        allow(session_user).to receive(:groups).and_return(["login"])
+      end
+
+      it "displays the user's product contexts" do
+        render
+        expect(rendered).to have_selector("a", text: "Switch to #{user_product_context.products.map(&:name).join('/')} context")
+        expect(rendered).to have_selector("a", text: "Switch to #{user_product_context2.products.map(&:name).join('/')} context")
+      end
+    end
+
+    context "when user has no product context" do
+      before do
+        allow(session_user).to receive(:groups).and_return(["login"])
+      end
+
+      it "does not display a product context" do
+        render
+        expect(rendered).not_to have_selector("a", text: "Switch to")
+      end
+    end
   end
 
   context "when generic active directory user" do

--- a/test/factories/product_context.rb
+++ b/test/factories/product_context.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :product_context, class: "Product::Context" do
+    sequence(:context_id) {|n| n+1 }
+    created_by { "fred" }
+    updated_by { "fred" }
+
+    association :product
+  end
+end

--- a/test/factories/user_product_context.rb
+++ b/test/factories/user_product_context.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :user_product_context, class: "User::ProductContext" do
+    is_default { false }
+    created_by { "fred" }
+    updated_by { "fred" }
+    sequence(:context_id) {|n| n+1 }
+
+    association :user
+  end
+end


### PR DESCRIPTION
## Description
Using product context and user product context models and associations. Adding ability to switch between contexts through sessions.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [ ] Manual testing

## Related Issues
FLOR-45

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
