### PR TITLE
Feature/flor 47 draft profile editor permissions work

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,12 +10,25 @@ class ApplicationController < ActionController::Base
   #  around_action :user_tagged_logging
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :show_login_page
-  rescue_from CanCan::AccessDenied do |_exception|
-    logger.error("Access Denied")
-    head :forbidden
+  rescue_from CanCan::AccessDenied do |ex|
+    details = "#{ex.message} #{ex.action.to_sym} #{ex.subject.class.name}"
+    logger.error("User #{@current_user.username} #{details}")
+
+    @message = "Access Denied! Please contact the admin for proper permissions."
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace("common-error-message-container", partial: "layouts/shared/message"), status: :forbidden
+      end
+      format.js { render "layouts/shared/message", status: :forbidden }
+      format.html { head :forbidden }
+    end
   end
 
+  helper_method :current_user, :current_registered_user
+
   protected
+
+  attr_reader :current_user, :current_registered_user
 
   def show_login_page
     logger.error("Invalid Authenticity Token.")
@@ -201,7 +214,7 @@ end
 class Hash
   def to_html_list
     s = '<ul>'
-    self.sort.to_h.each do |key, value| 
+    self.sort.to_h.each do |key, value|
 
       if value.nil?
       #  s += "<li>#{key}</li>"

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -35,8 +35,8 @@ class AuthorsController < ApplicationController
   # GET /authors/new_row
   def new_row
     @random_id = (Random.new.rand * 10_000_000_000).to_i
-    render :new_row, 
-       locals: {partial: 'new_row', 
+    render :new_row,
+       locals: {partial: 'new_row',
                 locals_for_partial:
            {tab_path: "#{new_author_with_random_id_path(@random_id)}",
             link_id: "link-new-author-#{@random_id}",
@@ -68,6 +68,9 @@ class AuthorsController < ApplicationController
 
   def update
     @author = Author::AsEdited.find(params[:id])
+
+    raise CanCan::AccessDenied.new("Access Denied!", :update, @author) unless can? :update, @author
+
     @message = @author.update_if_changed(author_params,
                                          typeahead_params,
                                          current_user.username)

--- a/app/controllers/profile_item_annotations_controller.rb
+++ b/app/controllers/profile_item_annotations_controller.rb
@@ -17,7 +17,11 @@
 #   limitations under the License.
 #
 class ProfileItemAnnotationsController < ApplicationController
+  skip_before_action :authorise
+
   before_action :set_profile_item_annotation, only: %i[update]
+
+  before_action :authorise_user!, except: [:create]
 
   def create
     # Check for existing ProfileAnnotation based on profile_item_id
@@ -27,6 +31,9 @@ class ProfileItemAnnotationsController < ApplicationController
         updated_by: current_user.username
       )
     )
+
+    authorise_user!
+
     if @profile_item_annotation.save!
       @message = "Saved"
       render :create
@@ -42,6 +49,10 @@ class ProfileItemAnnotationsController < ApplicationController
   end
 
   private
+
+  def authorise_user!
+    raise CanCan::AccessDenied.new("Access Denied!", :manage, @profile_item_annotation) unless can? :manage, @profile_item_annotation
+  end
 
   def set_profile_item_annotation
     @profile_item_annotation = Profile::ProfileItemAnnotation.find(params[:id])

--- a/app/controllers/profile_item_references_controller.rb
+++ b/app/controllers/profile_item_references_controller.rb
@@ -17,7 +17,11 @@
 #   limitations under the License.
 #
 class ProfileItemReferencesController < ApplicationController
+  skip_before_action :authorise
+
   before_action :set_profile_item_reference, only: %i[update destroy]
+
+  before_action :authorise_user!, except: [:create]
 
   def create
     @profile_item_reference = Profile::ProfileItemReference.new(
@@ -26,6 +30,9 @@ class ProfileItemReferencesController < ApplicationController
         updated_by: current_user.username
       )
     )
+
+    authorise_user!
+
     if @profile_item_reference.save!
       @message = "Saved"
       render :create
@@ -54,6 +61,10 @@ class ProfileItemReferencesController < ApplicationController
   end
 
   private
+
+  def authorise_user!
+    raise CanCan::AccessDenied.new("Access Denied!", :manage, @profile_item_reference) unless can? :manage, @profile_item_reference
+  end
 
   def set_profile_item_reference
     @profile_item_reference = Profile::ProfileItemReference.find_by(profile_item_id: params[:profile_item_id], reference_id: params[:reference_id])

--- a/app/controllers/profile_items_controller.rb
+++ b/app/controllers/profile_items_controller.rb
@@ -17,7 +17,12 @@
 #   limitations under the License.
 #
 class ProfileItemsController < ApplicationController
+
+  skip_before_action :authorise
+
   before_action :set_profile_item, only: %i[show tab destroy]
+
+  before_action :authorise_user!, except: [:index]
 
   # GET /profile_items/1/tab/:tab
   # Sets up RHS details panel on the search results page.
@@ -47,10 +52,18 @@ class ProfileItemsController < ApplicationController
   def index
     @instance = Instance.find_by!(id: permitted_profile_item_params[:instance_id])
     @product_configs_and_profile_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
-      .new(@current_user, @instance, permitted_profile_item_params).run_query
+      .new(
+        @current_user,
+        @instance,
+        permitted_profile_item_params
+      ).run_query
   end
 
   private
+
+  def authorise_user!
+    raise CanCan::AccessDenied.new("Access Denied!", :manage, @profile_item) unless can? :manage, @profile_item
+  end
 
   def set_profile_item
     @profile_item = Profile::ProfileItem.find(params[:id])

--- a/app/controllers/profile_texts_controller.rb
+++ b/app/controllers/profile_texts_controller.rb
@@ -18,12 +18,17 @@
 #
 class ProfileTextsController < ApplicationController
   include ApplicationHelper
-  
+
+  skip_before_action :authorise
+
   before_action :set_profile_text, :find_profile_item, only: %i[update]
+  before_action :authorise_user!, except: [:create]
 
   # POST /profile_texts
   # POST /profile_texts.json
   def create
+    raise CanCan::AccessDenied.new("Not authorized!", :create, Profile::ProfileText) unless can? :create, Profile::ProfileText
+
     @profile_item = Profile::ProfileItem.find_or_create_by(permitted_profile_item_params)
 
     raise("Profile text already exists") unless @profile_item.new_record?
@@ -59,6 +64,10 @@ class ProfileTextsController < ApplicationController
   end
 
   private
+
+  def authorise_user!
+    raise CanCan::AccessDenied.new("Access Denied!", :manage, @profile_item) unless can? :manage, @profile_item
+  end
 
   def permitted_profile_text_params
     params.require(:profile_text).permit(:value, :value_md)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,13 @@ module ApplicationHelper
   end
 
   def user_profile_tab_name
-    @current_user.profile_v2_context.product
+    if current_registered_user.is?('draft-profile-editor')
+      current_registered_user.product_roles
+        .joins(:role_type)
+        .find_by(product_role_type: {name: "draft-profile-editor"})
+        .product
+        .name
+    end
   end
 
   def increment_tab_index(increment = 1)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -54,7 +54,7 @@ class Ability
     reviewer_auth     if user.reviewer?
     batch_loader_auth if user.batch_loader?
     loader_2_tab_auth if user.loader_2_tab_loader?
-    profile_v2_auth   if user.profile_v2?
+    #profile_v2_auth   if user.profile_v2?
 
     draft_profile_editor if user.with_role?('draft-profile-editor')
     profile_editor if user.with_role?('profile-editor')

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -55,28 +55,78 @@ class Ability
     batch_loader_auth if user.batch_loader?
     loader_2_tab_auth if user.loader_2_tab_loader?
     profile_v2_auth   if user.profile_v2?
+
+    draft_profile_editor if user.with_role?('draft-profile-editor')
+    profile_editor if user.with_role?('profile-editor')
+  end
+
+  def draft_profile_editor
+    can :manage, :profile_v2
+    can :create, Profile::ProfileItem
+    can :manage, Profile::ProfileItem do |profile_item|
+      profile_item.is_draft?
+    end
+    can :manage, Profile::ProfileItemReference do |profile_item_reference|
+      profile_item_reference.profile_item.is_draft?
+    end
+    can :manage, Profile::ProfileText do |profile_text|
+      profile_text.profile_item.is_draft?
+    end
+    can :manage, Profile::ProfileItemAnnotation do |profile_item_annotation|
+      profile_item_annotation.profile_item.is_draft?
+    end
+    can "authors", :all
+    can "instances", ["tab_details", "tab_profile_v2"]
+    can "menu", "new"
+    can "profile_items", :all
+    can "profile_item_annotations", :all
+    can "profile_item_references", :all
+    can "references", :all
+
+    can [:create, :read], Author
+
+    cannot "authors", ["update", "destroy"]
+    cannot "references", ["edit", "update", "copy", "destroy"]
+  end
+
+  def profile_editor
+    can :manage, :profile_v2
+    can :manage, Profile::ProfileItem
+    can :manage, Profile::ProfileItemReference
+    can :manage, Profile::ProfileText
+    can :manage, Profile::ProfileItemAnnotation
+    can "references", "typeahead_on_citation"
+    can "profile_items", :all
+    can "profile_item_annotations", :all
+    can "profile_item_references", :all
+    can "instances", "tab_details"
+    can "instances", "tab_profile_v2"
   end
 
 
   def profile_v2_auth
     # can :manage, :all   # NOTES: This is not working. It breaks everything.
-    can "profile_items",            :all
+    can :manage, :profile_v2
+    can :manage, Profile::ProfileItem
+    can :manage, Profile::ProfileItemReference
+    can :manage, Profile::ProfileText
+    can :manage, Profile::ProfileItemAnnotation
+    can "profile_items", :all
     can "profile_item_annotations", :all
-    can "profile_item_references",  :all
-    can "profile_texts",            :all
-    can :manage,                    :profile_v2
-    can "instances",                "tab_profile_v2"
-    can "references",               "typeahead_on_citation"
-    can "instances",                "tab_copy_to_new_profile_v2"
-    can "instances",                "tab_unpublished_citation_for_profile_v2"
-    can "instances",                "copy_for_profile_v2"
-    can "instances",                "tab_details"
+    can "profile_item_references", :all
+    can "profile_texts", :all
+    can "instances", "tab_profile_v2"
+    can "references", "typeahead_on_citation"
+    can "instances", "tab_copy_to_new_profile_v2"
+    can "instances", "tab_unpublished_citation_for_profile_v2"
+    can "instances", "copy_for_profile_v2"
+    can "instances", "tab_details"
     can "names/typeaheads/for_unpub_cit", "index"
-    can "instances",                "create_cited_by"
-    can "instances",                "create_cites_and_cited_by"
-    can "instances",                "create"
-    can "instances",                "tab_synonymy_for_profile_v2"
-    can "instances",                "typeahead_for_synonymy"
+    can "instances", "create_cited_by"
+    can "instances", "create_cites_and_cited_by"
+    can "instances", "create"
+    can "instances", "tab_synonymy_for_profile_v2"
+    can "instances", "typeahead_for_synonymy"
   end
 
   def basic_auth_1

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: product(Describes a product available within the NSL infrastructure.)
+#
+#  id(A system wide unique identifier allocated to each profile product.)                            :bigint           not null, primary key
+#  api_date(The date when a script, jira or services task last changed this record.)                 :timestamptz
+#  api_name(The name of a script, jira or services task which last changed this record.)             :string(50)
+#  created_by(The user id of the person who created this data)                                       :string(50)       not null
+#  description_html(The full name for this profile product. i.e. Flora of Australia.)                :text
+#  internal_notes(Team notes about the management or maintenance of this product.)                   :text
+#  is_available(Indicates this product is publicly available.)                                       :boolean          default(FALSE), not null
+#  is_current(Indicates this product is currently being maintained and published.)                   :boolean          default(FALSE), not null
+#  is_name_index                                                                                     :boolean          default(FALSE), not null
+#  lock_version(A system field to manage row level locking.)                                         :integer          default(0), not null
+#  name(The standard acronym for this profile product. i.e. FOA, APC.)                               :text             not null
+#  source_id_string(The identifier from the source system that this profile text was imported from.) :string(100)
+#  source_system(The source system that this profile text was imported from.)                        :string(50)
+#  updated_by(The user id of the person who last updated this data)                                  :string(50)       not null
+#  created_at(The date and time this data was created.)                                              :timestamptz      not null
+#  updated_at(The date and time this data was updated.)                                              :timestamptz      not null
+#  namespace_id(The auNSL dataset that physically contains this profile text.)                       :bigint
+#  reference_id(The highest level reference for this product.)                                       :bigint
+#  source_id(The key at the source system imported on migration.)                                    :bigint
+#  tree_id(The tree (taxonomy) used for this product.)                                               :bigint
+#
+# Foreign Keys
+#
+#  product_reference_id_fkey  (reference_id => reference.id)
+#  product_tree_id_fkey       (tree_id => tree.id)
+#
 class Product < ApplicationRecord
   strip_attributes
   self.table_name = "product"

--- a/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
+++ b/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
@@ -3,9 +3,12 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
               :instance,
               :product_configs_and_profile_items
 
-  def initialize(user, instance, params = {})
-    @user = user
-    @profile_context = user.profile_v2_context
+  SUPPORTED_PRODUCTS = ["FOA"].freeze
+
+  def initialize(session_user, instance, params = {})
+    @session_user = session_user
+    @user = session_user.user
+    @profile_context = session_user.profile_v2_context
     @product = find_product_by_name(@profile_context.product)
     @product_configs_and_profile_items = []
     @instance = instance
@@ -28,8 +31,12 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
 
   private
 
+  attr_reader :user
+
   def find_product_by_name(name)
-    Profile::Product.find_by(name: name)
+    product_name = user.products.where(name: SUPPORTED_PRODUCTS).first&.name
+
+    Profile::Product.find_by(name: product_name || name)
   end
 
   def profile_v2_aware?

--- a/app/views/authors/_tab_edit.html.erb
+++ b/app/views/authors/_tab_edit.html.erb
@@ -1,5 +1,9 @@
-<% increment_tab_index(0) %>
+<% if can? :update, @author %>
+  <% increment_tab_index(0) %>
 
-<%= render 'form' %>
+  <%= render 'form' %>
+<% end %>
 
-<%= render 'delete_widgets' if @author.can_be_deleted? %>
+<% if can? :destroy, @author %>
+  <%= render 'delete_widgets' if @author.can_be_deleted? %>
+<% end %>

--- a/app/views/authors/_tabs.html.erb
+++ b/app/views/authors/_tabs.html.erb
@@ -1,24 +1,24 @@
 <ul class="nav nav-tabs">
   <%= render partial: 'tab', locals: {first: true,
                                       last: false,
-                                      this_tab: 'tab_show_1', 
-                                      link_text: 'Details', 
-                                      link_id: 'author-show-tab', 
+                                      this_tab: 'tab_show_1',
+                                      link_text: 'Details',
+                                      link_id: 'author-show-tab',
                                       link_title: 'View a summary',
                                       tab_index: @tab_index,
-                                      prev_tab: '.search-result.show-details', 
-                                      next_tab: '' } %> 
-  <% if can? 'authors', 'update' %>
+                                      prev_tab: '.search-result.show-details',
+                                      next_tab: '' } %>
+  <% if can? :update, @author %>
 
   <%= render partial: 'tab', locals: {first: false,
                                       last: false,
-                                      this_tab: 'tab_edit', 
-                                      link_text: 'Edit', 
-                                      link_id: 'author-edit-tab', 
+                                      this_tab: 'tab_edit',
+                                      link_text: 'Edit',
+                                      link_id: 'author-edit-tab',
                                       link_title: 'Edit author.',
                                       tab_index: increment_tab_index,
-                                      prev_tab: '', 
-                                      next_tab: '.search-result.showing-details'} %> 
+                                      prev_tab: '',
+                                      next_tab: '.search-result.showing-details'} %>
 
   <% end %>
 
@@ -26,13 +26,13 @@
 
   <%= render partial: 'tab', locals: {first: false,
                                       last: true,
-                                      this_tab: 'tab_comments', 
-                                      link_text: 'Comments', 
-                                      link_id: 'author-comments-tab', 
+                                      this_tab: 'tab_comments',
+                                      link_text: 'Comments',
+                                      link_id: 'author-comments-tab',
                                       link_title: 'Edit author comments.',
                                       tab_index: increment_tab_index,
-                                      prev_tab: '', 
-                                      next_tab: '.search-result.showing-details'} %> 
+                                      prev_tab: '',
+                                      next_tab: '.search-result.showing-details'} %>
   <% end %>
 </ul>
 

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -214,15 +214,15 @@
       <% end %>
   <% end %>
 
-  
+
 
   <% if @tabs_to_offer.include?('tab_profile_v2') %>
-    <% if @current_user.profile_v2_context.profile_edit_allowed? %>
+    <% if can?(:manage, :profile_v2) %>
       <% if Rails.configuration.try('profile_v2_aware') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_profile_v2', 
-                                        link_id: 'instance-profile-v2-tab', 
+                                        this_tab: 'tab_profile_v2',
+                                        link_id: 'instance-profile-v2-tab',
                                         link_text: "#{user_profile_tab_name} Profile".html_safe,
                                         link_title: "#{user_profile_tab_name} Profile",
                                         tab_index: increment_tab_index,

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -8,12 +8,12 @@
     <% if can? 'instances', 'tab_show_1' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: true,
                                         last: false,
-                                        this_tab: 'tab_show_1', 
+                                        this_tab: 'tab_show_1',
                                         link_text: "Details".html_safe,
-                                        link_id: 'instance-show-tab', 
+                                        link_id: 'instance-show-tab',
                                         link_title: 'Details',
                                         tab_index: @tab_index,
-                                        prev_tab: '.search-result.show-details', 
+                                        prev_tab: '.search-result.show-details',
                                         next_tab: '' } %>
     <% end %>
   <% end %>
@@ -22,9 +22,9 @@
     <% if can? 'instances', 'edit' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_edit', 
+                                        this_tab: 'tab_edit',
                                         link_text: "Edit".html_safe,
-                                        link_id: 'instance-edit-tab', 
+                                        link_id: 'instance-edit-tab',
                                         link_title: 'Edit',
                                         tab_index: increment_tab_index,
                                         prev_tab: '',
@@ -36,16 +36,16 @@
     <% if can? 'instance_notes', 'edit' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_edit_notes', 
+                                        this_tab: 'tab_edit_notes',
                                         link_text: "Notes".html_safe,
-                                        link_id: 'instance-edit-notes-tab', 
+                                        link_id: 'instance-edit-notes-tab',
                                         link_title: 'Notes',
                                         tab_index: increment_tab_index,
                                         prev_tab: '',
                                         next_tab: '' } %>
     <% end %>
   <% end %>
-  
+
   <% if @tabs_to_offer.include?('tab_synonymy') %>
     <% if can? 'instances', 'create' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
@@ -120,9 +120,9 @@
     <% if can? 'comments', 'create' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_comments', 
+                                        this_tab: 'tab_comments',
                                         link_text: "Adnot".html_safe,
-                                        link_id: 'instance-comments-tab', 
+                                        link_id: 'instance-comments-tab',
                                         link_title: 'Adnot',
                                         tab_index: increment_tab_index,
                                         prev_tab: '',
@@ -134,9 +134,9 @@
     <% if can? 'instances', 'copy_standalone' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_copy_to_new_reference', 
+                                        this_tab: 'tab_copy_to_new_reference',
                                         link_text: "Copy".html_safe,
-                                        link_id: 'instance-copy-to-new-reference-tab', 
+                                        link_id: 'instance-copy-to-new-reference-tab',
                                         link_title: 'Copy the instance',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-comments-tab',
@@ -148,9 +148,9 @@
     <% if @current_user.profile_v2_context.copy_instance_allowed? %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_copy_to_new_profile_v2', 
+                                        this_tab: 'tab_copy_to_new_profile_v2',
                                         link_text: "Copy".html_safe,
-                                        link_id: 'instance-copy-to-new-profile-v2-tab', 
+                                        link_id: 'instance-copy-to-new-profile-v2-tab',
                                         link_title: 'Copy the instance',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-comments-tab',
@@ -162,12 +162,12 @@
     <% if can? 'classification', 'place' %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: false,
-                                        this_tab: 'tab_profile_details', 
+                                        this_tab: 'tab_profile_details',
                                         link_text: "Profile".html_safe,
-                                        link_id: 'instance-profile-tab', 
+                                        link_id: 'instance-profile-tab',
                                         link_title: 'Profile details',
                                         tab_index: increment_tab_index,
-                                        prev_tab: 'instance-copy-to-new-reference-tab', 
+                                        prev_tab: 'instance-copy-to-new-reference-tab',
                                         next_tab: 'instance-edit-profile-tab' } %>
     <% end %>
   <% end %>
@@ -177,9 +177,9 @@
       <% if can? 'classification', 'place' %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_edit_profile', 
+                                        this_tab: 'tab_edit_profile',
                                         link_text: "Edit Profile".html_safe,
-                                        link_id: 'instance-edit-profile-tab', 
+                                        link_id: 'instance-edit-profile-tab',
                                         link_title: 'Edit Profile',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-profile-tab',
@@ -192,9 +192,9 @@
      <% if can?('loader/batches', 'process') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_batch_loader', 
+                                        this_tab: 'tab_batch_loader',
                                         link_text: "Loader 1".html_safe,
-                                        link_id: 'instance-batch-loader-tab', 
+                                        link_id: 'instance-batch-loader-tab',
                                         link_title: 'Batch Loader operations',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-edit-profile-tab',
@@ -203,9 +203,9 @@
      <% if can?('loader/instances-loader-2', 'use') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,
-                                        this_tab: 'tab_batch_loader_2', 
+                                        this_tab: 'tab_batch_loader_2',
                                         link_text: "Loader 2".html_safe,
-                                        link_id: 'instance-batch-loader-tab-2', 
+                                        link_id: 'instance-batch-loader-tab-2',
                                         link_title: 'More batch Loader operations',
                                         tab_index: increment_tab_index,
                                         prev_tab: 'instance-batch-tab-loader',
@@ -217,7 +217,7 @@
 
 
   <% if @tabs_to_offer.include?('tab_profile_v2') %>
-    <% if can?(:manage, :profile_v2) %>
+    <% if can?(:manage_profile, @instance) %>
       <% if Rails.configuration.try('profile_v2_aware') %>
         <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                         last: true,

--- a/app/views/instances/tabs/_tab_product_config_profile_item_form.html.erb
+++ b/app/views/instances/tabs/_tab_product_config_profile_item_form.html.erb
@@ -1,5 +1,6 @@
 <div>
 
+  <div id="common-error-message-container" class="error-container"></div>
   <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
 </div>
 

--- a/app/views/instances/tabs/_tab_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_profile_v2.html.erb
@@ -30,6 +30,7 @@
     <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
     <div>
       <h4><%= product_item_config.display_html %></h4>
+      <div id="common-error-message-container" class="error-container"></div>
       <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
     </div>
 

--- a/app/views/instances/tabs/_tab_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_profile_v2.html.erb
@@ -1,109 +1,111 @@
-<% if @product_configs_and_profile_items.blank? %>
-  <div>
-    <div id="message_no_product_configs" class="message">There are no product or product configs setup yet.</div>
-  </div>
-<% end %>
-
-<% if Rails.configuration.try('profile_v2_dropdown_ui') %>
-  <%= render partial: "profile_items/product_item_config_dropdown", locals: {
-      product_configs_and_profile_items: @product_configs_and_profile_items,
-      selected_product_item_config_id: @selected_product_item_config_id,
-      instance: @instance
-    }
-  %>
-  <% if @selected_product_item_config_id.blank? %>
-    <div id="product-config-and-profile-items-container"></div>
-  <% else %>
-    <div id="product-config-and-profile-items-container">
-      <% all_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@current_user, @instance, {product_item_config_id: @selected_product_item_config_id}).run_query %>
-      <% all_items.each do |config_items| %>
-          <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
-          <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
-          <%= render partial: "instances/tabs/tab_product_config_profile_item_form",
-            locals: {product_item_config:  product_item_config, profile_item: profile_item, instance: @instance}
-          %>
-      <% end %>
+<% if can?(:manage_profile, @instance) %>
+  <% if @product_configs_and_profile_items.blank? %>
+    <div>
+      <div id="message_no_product_configs" class="message">There are no product or product configs setup yet.</div>
     </div>
   <% end %>
-<% else %>
-  <% @product_configs_and_profile_items.each do |config_items| %>
-    <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
-    <div>
-      <h4><%= product_item_config.display_html %></h4>
-      <div id="common-error-message-container" class="error-container"></div>
-      <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
-    </div>
 
-    <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
-      <!-- Profile Text Form -->
-      <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
-      <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
-      <% method = profile_text.persisted? ? :put : :post %>
-      <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;overlow:hidden;">
-        <%= render partial: "profile_texts/form",
-          locals: {
-            profile_text: profile_text,
-            url: url,
-            method: method,
-            product_item_config: product_item_config,
-            instance_id: @instance.id,
-            profile_item: profile_item,
-          }
-        %>
-      </div>
-      <div
-        id="profile_item_references_<%= product_item_config.id %>"
-        style="display: block" >
-        <%= render partial: "profile_item_references/edit_form",
-          collection: profile_item.profile_item_references,
-          locals: {profile_item: profile_item},
-          as: :profile_item_reference
-        %>
-      </div>
-
-      <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
-      <div id="add_reference_<%= product_item_config.id %>">
-        <% if profile_item.persisted? %>
-          <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
-            <label>Reference</label>
-            <div id="add_reference_form_<%= product_item_config.id %>" style="margin-bottom: 10px;">
-              <%= render partial: 'profile_item_references/form',
-                locals: {
-                  url: profile_item_references_path,
-                  method: :post,
-                  profile_item: profile_item,
-                  profile_item_reference: Profile::ProfileItemReference.new
-              } %>
-            </div>
-          </div>
+  <% if Rails.configuration.try('profile_v2_dropdown_ui') %>
+    <%= render partial: "profile_items/product_item_config_dropdown", locals: {
+        product_configs_and_profile_items: @product_configs_and_profile_items,
+        selected_product_item_config_id: @selected_product_item_config_id,
+        instance: @instance
+      }
+    %>
+    <% if @selected_product_item_config_id.blank? %>
+      <div id="product-config-and-profile-items-container"></div>
+    <% else %>
+      <div id="product-config-and-profile-items-container">
+        <% all_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@current_user, @instance, {product_item_config_id: @selected_product_item_config_id}).run_query %>
+        <% all_items.each do |config_items| %>
+            <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
+            <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
+            <%= render partial: "instances/tabs/tab_product_config_profile_item_form",
+              locals: {product_item_config:  product_item_config, profile_item: profile_item, instance: @instance}
+            %>
         <% end %>
       </div>
+    <% end %>
+  <% else %>
+    <% @product_configs_and_profile_items.each do |config_items| %>
+      <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
+      <div>
+        <h4><%= product_item_config.display_html %></h4>
+        <div id="common-error-message-container" class="error-container"></div>
+        <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+      </div>
 
-      <div style="padding: 30px 10px 10px 10px;">
-        <div id="add_annotation_form<%= product_item_config.id %>">
+      <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
+        <!-- Profile Text Form -->
+        <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
+        <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
+        <% method = profile_text.persisted? ? :put : :post %>
+        <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;overlow:hidden;">
+          <%= render partial: "profile_texts/form",
+            locals: {
+              profile_text: profile_text,
+              url: url,
+              method: method,
+              product_item_config: product_item_config,
+              instance_id: @instance.id,
+              profile_item: profile_item,
+            }
+          %>
+        </div>
+        <div
+          id="profile_item_references_<%= product_item_config.id %>"
+          style="display: block" >
+          <%= render partial: "profile_item_references/edit_form",
+            collection: profile_item.profile_item_references,
+            locals: {profile_item: profile_item},
+            as: :profile_item_reference
+          %>
+        </div>
+
+        <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+        <div id="add_reference_<%= product_item_config.id %>">
           <% if profile_item.persisted? %>
-            <!-- Profile Item Reference Form -->
-            <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
-            <label>Annotate this profile item:</label>
-            <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
-            <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
-            <% method = profile_item_annotation.persisted? ? :put : :post %>
-            <%= render partial: 'profile_item_annotations/form',
-              locals: {
-                url: url,
-                method: method,
-                profile_item_annotation: profile_item_annotation
-              } %>
+            <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
+              <label>Reference</label>
+              <div id="add_reference_form_<%= product_item_config.id %>" style="margin-bottom: 10px;">
+                <%= render partial: 'profile_item_references/form',
+                  locals: {
+                    url: profile_item_references_path,
+                    method: :post,
+                    profile_item: profile_item,
+                    profile_item_reference: Profile::ProfileItemReference.new
+                } %>
+              </div>
+            </div>
           <% end %>
         </div>
-      </div>
 
-      <div id="profile_item_actions_<%= product_item_config.id %>">
-        <% if profile_item.persisted? %>
-          <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
-        <% end %>
-      </div>
+        <div style="padding: 30px 10px 10px 10px;">
+          <div id="add_annotation_form<%= product_item_config.id %>">
+            <% if profile_item.persisted? %>
+              <!-- Profile Item Reference Form -->
+              <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
+              <label>Annotate this profile item:</label>
+              <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
+              <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
+              <% method = profile_item_annotation.persisted? ? :put : :post %>
+              <%= render partial: 'profile_item_annotations/form',
+                locals: {
+                  url: url,
+                  method: method,
+                  profile_item_annotation: profile_item_annotation
+                } %>
+            <% end %>
+          </div>
+        </div>
 
-    </div>
+        <div id="profile_item_actions_<%= product_item_config.id %>">
+          <% if profile_item.persisted? %>
+            <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
+          <% end %>
+        </div>
+
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/layouts/shared/_message.html.erb
+++ b/app/views/layouts/shared/_message.html.erb
@@ -1,0 +1,3 @@
+<div id="common-error-message-container" class="error-container">
+  <div><%= @message%></div>
+</div>

--- a/app/views/layouts/shared/message.erb
+++ b/app/views/layouts/shared/message.erb
@@ -1,0 +1,1 @@
+document.getElementById("common-error-message-container").innerHTML = "<%= j render(partial: 'layouts/shared/message') %>";

--- a/app/views/profile_items/destroy.turbo_stream.erb
+++ b/app/views/profile_items/destroy.turbo_stream.erb
@@ -21,6 +21,7 @@
 <% end %>
 
 <%= turbo_stream.replace "message_#{@product_item_config.id}" do %>
+  <div id="common-error-message-container" class="error-container"></div>
   <div id="message_<%= @product_item_config.id %>" class="message-container">
     <%= @message %>
   </div>

--- a/app/views/profile_items/index.turbo_stream.erb
+++ b/app/views/profile_items/index.turbo_stream.erb
@@ -14,7 +14,12 @@
         <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
         <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
         <div>
-            <h4><%= product_item_config.display_html %></h4>
+            <h4>
+                <%= product_item_config.display_html %>
+                <span stype="font-size: 12px"><%= profile_item.is_draft? ? " - [DRAFT]" : ""%></span>
+            </h4>
+
+            <div id="common-error-message-container" class="error-container"></div>
             <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
         </div>
 

--- a/app/views/profile_items/tabs/_tabs.html.erb
+++ b/app/views/profile_items/tabs/_tabs.html.erb
@@ -3,27 +3,27 @@
 
   <%= render partial: 'profile_items/tabs/tab', locals: {first: true,
     last: false,
-    this_tab: 'tab_show_1', 
-    link_text: 'Details', 
-    link_id: 'profile-item-edit-show-1-tab', 
+    this_tab: 'tab_show_1',
+    link_text: 'Details',
+    link_id: 'profile-item-edit-show-1-tab',
     link_title: 'View a summary',
     tab_index: increment_tab_index,
-    prev_tab: '', 
-    next_tab: '' } 
-  %> 
+    prev_tab: '',
+    next_tab: '' }
+  %>
 
 
-  <% if @current_user.profile_v2_context.profile_edit_allowed? %>
+  <% if can? :manage, Profile::ProfileItem %>
     <%= render partial: 'profile_items/tabs/tab', locals: {first: false,
       last: false,
-      this_tab: 'tab_edit', 
+      this_tab: 'tab_edit',
       link_text: 'Edit'.html_safe,
       link_id: 'profile-item-edit-tab',
       link_title: 'Main edit form for the profile item].',
       tab_index: increment_tab_index,
-      prev_tab: '', 
-      next_tab: ''} 
-    %> 
+      prev_tab: '',
+      next_tab: ''}
+    %>
   <% end %>
-    
+
 </ul>

--- a/app/views/references/tabs/_tab_edit_1.html.erb
+++ b/app/views/references/tabs/_tab_edit_1.html.erb
@@ -1,5 +1,6 @@
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
-<div class="error-message-container"></div>
-<%= render 'form' %>
-
+<% if  can? :update, @reference %>
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
+  <div class="error-message-container"></div>
+  <%= render 'form' %>
+<% end %>

--- a/app/views/references/tabs/_tab_edit_2.html.erb
+++ b/app/views/references/tabs/_tab_edit_2.html.erb
@@ -1,7 +1,8 @@
-
-<div class="error-message-container"></div>
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
-<div id="tab-form-container">
-  <%= render 'form_2' %>
-<div>
+<% if  can? :update, @reference %>
+  <div class="error-message-container"></div>
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
+  <div id="tab-form-container">
+    <%= render 'form_2' %>
+  <div>
+<% end %>

--- a/app/views/references/tabs/_tab_edit_3.html.erb
+++ b/app/views/references/tabs/_tab_edit_3.html.erb
@@ -1,53 +1,55 @@
-<%= render 'form_3' %>
-<br>
-<div class="error-message-container"></div>
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
-
-
-<% if @reference.children? %>
-  You cannot delete this reference because it has one or more children.
-<% end %>
-
-<% if @reference.instances? %>
-  You cannot delete this reference because it has one or more instances.
-<% end %>
-
-<% unless @reference.children? || @reference.instances? %>
-
-  <% delete_link = link_to("Delete the reference...",
-                           '#',
-                           id: "reference-delete-link",
-                           title: "Delete the reference.",
-                           class: "btn btn-warning unconfirmed-delete-link pull-right",
-                           data: {show_this_id: "confirm-or-cancel-link-container"})
-  %>
-  <% confirm_delete_link = link_to("Confirm delete",
-                                   reference_path(@reference.id),
-                                   class: "btn btn-danger",
-                                   title: "Confirm you want to delete the reference.",
-                                   remote: true,
-                                   method: :delete)
-  %>
-  <% cancel_delete_link = link_to("Cancel delete",
-                                  '#',
-                                  id: "cancel-delete-link",
-                                  class: "btn btn-default cancel-link",
-                                  title: "Cancel delete dialog for the reference.",
-                                  data: {enable_this_id: 'reference-delete-link',
-                                         hide_this_id: 'confirm-or-cancel-link-container'})
-  %>
-  <% confirm_or_cancel_element = %Q(<div id="confirm-or-cancel-link-container"
-                                    class="instance-note confirm-or-cancel-delete-link pull-right hidden">
-                                    #{confirm_delete_link}
-                                    #{cancel_delete_link}</div>)
-  %>
-  
-  <%= divider %>
+<% if  can? :update, @reference %>
+  <%= render 'form_3' %>
   <br>
-  <div class="actions"> <%= delete_link.html_safe %> </div>
-  <div class="width-100-percent"> <%= confirm_or_cancel_element.html_safe %> </div>
+  <div class="error-message-container"></div>
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
 
-  <div id="delete-info-message-container" class="message-container"></div>
-  <div id="delete-error-message-container" class="message-container"></div>
+
+  <% if @reference.children? %>
+    You cannot delete this reference because it has one or more children.
+  <% end %>
+
+  <% if @reference.instances? %>
+    You cannot delete this reference because it has one or more instances.
+  <% end %>
+
+  <% unless @reference.children? || @reference.instances? %>
+
+    <% delete_link = link_to("Delete the reference...",
+                            '#',
+                            id: "reference-delete-link",
+                            title: "Delete the reference.",
+                            class: "btn btn-warning unconfirmed-delete-link pull-right",
+                            data: {show_this_id: "confirm-or-cancel-link-container"})
+    %>
+    <% confirm_delete_link = link_to("Confirm delete",
+                                    reference_path(@reference.id),
+                                    class: "btn btn-danger",
+                                    title: "Confirm you want to delete the reference.",
+                                    remote: true,
+                                    method: :delete)
+    %>
+    <% cancel_delete_link = link_to("Cancel delete",
+                                    '#',
+                                    id: "cancel-delete-link",
+                                    class: "btn btn-default cancel-link",
+                                    title: "Cancel delete dialog for the reference.",
+                                    data: {enable_this_id: 'reference-delete-link',
+                                          hide_this_id: 'confirm-or-cancel-link-container'})
+    %>
+    <% confirm_or_cancel_element = %Q(<div id="confirm-or-cancel-link-container"
+                                      class="instance-note confirm-or-cancel-delete-link pull-right hidden">
+                                      #{confirm_delete_link}
+                                      #{cancel_delete_link}</div>)
+    %>
+
+    <%= divider %>
+    <br>
+    <div class="actions"> <%= delete_link.html_safe %> </div>
+    <div class="width-100-percent"> <%= confirm_or_cancel_element.html_safe %> </div>
+
+    <div id="delete-info-message-container" class="message-container"></div>
+    <div id="delete-error-message-container" class="message-container"></div>
+  <% end %>
 <% end %>

--- a/app/views/references/tabs/_tabs.html.erb
+++ b/app/views/references/tabs/_tabs.html.erb
@@ -1,28 +1,28 @@
     <ul class="nav nav-tabs">
       <% this_tab = 'tab_show_1' %>
-  
+
       <%= render partial: 'references/tabs/tab', locals: {first: true,
                                           last: false,
-                                          this_tab: 'tab_show_1', 
-                                          link_text: 'Details', 
-                                          link_id: 'reference-edit-show-1-tab', 
+                                          this_tab: 'tab_show_1',
+                                          link_text: 'Details',
+                                          link_id: 'reference-edit-show-1-tab',
                                           link_title: 'View a summary',
                                           tab_index: increment_tab_index,
-                                          prev_tab: '', 
-                                          next_tab: '' } %> 
-  
-      <% if can? 'references', 'edit' %>
-  
+                                          prev_tab: '',
+                                          next_tab: '' } %>
+
+      <% if (can? 'references', 'edit') || (can? :update, @reference) %>
+
         <%= render partial: 'references/tabs/tab', locals: {first: false,
                                             last: false,
-                                            this_tab: 'tab_edit_1', 
+                                            this_tab: 'tab_edit_1',
                                             link_text: 'Edit.'.html_safe,
                                             link_id: 'reference-edit-1-tab',
                                             link_title: 'Main edit form for the reference.',
                                             tab_index: increment_tab_index,
-                                            prev_tab: '', 
-                                            next_tab: ''} %> 
-  
+                                            prev_tab: '',
+                                            next_tab: ''} %>
+
         <%= render partial: 'references/tabs/tab', locals: {first: false,
                                             last: false,
                                             this_tab: 'tab_edit_2',
@@ -30,9 +30,9 @@
                                             link_id: 'reference-edit-2-tab',
                                             link_title: 'Second edit form for the reference.',
                                             tab_index: increment_tab_index,
-                                            prev_tab: '', 
-                                            next_tab: ''} %> 
-  
+                                            prev_tab: '',
+                                            next_tab: ''} %>
+
         <%= render partial: 'references/tabs/tab', locals: {first: false,
                                             last: false,
                                             this_tab: 'tab_edit_3',
@@ -40,9 +40,9 @@
                                             link_id: 'reference-edit-3-tab',
                                             link_title: 'Links edit form for the reference.',
                                             tab_index: increment_tab_index,
-                                            prev_tab: '', 
+                                            prev_tab: '',
                                             next_tab: ''} %>
-  
+
       <% end %>
 
       <% if can? 'comments', 'create' %>
@@ -54,13 +54,13 @@
                                             link_id: 'reference-comments-tab',
                                             link_title: 'Edit comments.',
                                             tab_index: increment_tab_index,
-                                            prev_tab: '', 
+                                            prev_tab: '',
                                             next_tab: ''} %>
 
       <% end %>
 
       <% if can? 'instances', 'create' %>
-  
+
         <%= render partial: 'references/tabs/tab', locals: {first: false,
                                             last: false,
                                             this_tab: 'tab_new_instance',
@@ -68,12 +68,12 @@
                                             link_id: 'reference-new-instance-tab',
                                             link_title: 'New instance form for the reference.',
                                             tab_index: increment_tab_index,
-                                            prev_tab: '', 
+                                            prev_tab: '',
                                             next_tab: ''} %>
       <% end %>
 
       <% if can? 'references', 'copy' %>
-  
+
         <%= render partial: 'references/tabs/tab',
                    locals: {first: false,
                             last: true,
@@ -82,9 +82,9 @@
                             link_id: 'reference-copy-tab',
                             link_title: 'Copy the reference to a new reference ready to modify and save.',
                             tab_index: increment_tab_index,
-                            prev_tab: '', 
+                            prev_tab: '',
                             next_tab: '.search-result.showing-details'} %>
       <% end %>
-  
+
     </ul>
-  
+

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 12-Mar-2025
+  :jira_id: '47'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Permissions for draft profile editor
 - :date: 07-Mar-2025
   :jira_id:
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.6.15
+appversion=4.1.6.16
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+require 'rails_helper'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    def index
+      render plain: "Hello World"
+    end
+  end
+
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:session_user) { FactoryBot.create(:session_user, username: user.user_name, full_name: "Test User", groups: ['login','edit']) }
+
+  before do
+    allow(controller).to receive(:current_registered_user).and_return(user)
+  end
+
+  describe "#continue_user_session" do
+    before do
+      allow(SessionUser).to receive(:new).and_return(session_user)
+      allow(session_user).to receive(:registered_user).and_return(user)
+    end
+
+    context 'when session variables are set' do
+      before do
+        session[:username] = session_user.username
+        session[:user_full_name] = session_user.full_name
+        session[:groups] = session_user.groups
+      end
+
+      it 'sets the current_user and current_registered_user' do
+        controller.send(:continue_user_session)
+
+        expect(controller.instance_variable_get(:@current_user)).to eq(session_user)
+        expect(controller.instance_variable_get(:@current_registered_user)).to eq(user)
+      end
+    end
+  end
+
+  describe 'rescue_from CanCan::AccessDenied' do
+    before do
+      allow(SessionUser).to receive(:new).and_return(session_user)
+      allow(session_user).to receive(:registered_user).and_return(user)
+
+      session[:username] = session_user.username
+      session[:user_full_name] = session_user.full_name
+      session[:groups] = session_user.groups
+    end
+
+    context 'when format is turbo_stream' do
+      it 'renders the flash_message partial with status forbidden' do
+        request.headers['Accept'] = 'text/vnd.turbo-stream.html'
+        get :index, format: :turbo_stream
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include('common-error-message-container')
+      end
+    end
+
+    context 'when format is js' do
+      it 'renders the flash_message partial with status forbidden' do
+        get :index, format: :js
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response).to render_template('layouts/shared/message')
+      end
+    end
+
+    context 'when format is html' do
+      it 'redirects to the referrer or root path' do
+        request.env['HTTP_REFERER'] = root_path
+        get :index
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Ability, type: :model do
       allow(session_user).to receive(:with_role?).with('profile-editor').and_return(false)
     end
 
-    describe "#profile_v2_auth role" do
+    xdescribe "#profile_v2_auth role" do
       context "for session_user with profile_v2" do
         before { allow(session_user).to receive(:profile_v2?).and_return(true) }
         it "grants all access to profile_items" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe Ability, type: :model do
 
     subject { described_class.new(session_user) }
 
-    describe "#profile_v2_auth" do
+    before do
+      allow(session_user).to receive(:with_role?).with('draft-profile-editor').and_return(false)
+      allow(session_user).to receive(:with_role?).with('profile-editor').and_return(false)
+    end
+
+    describe "#profile_v2_auth role" do
       context "for session_user with profile_v2" do
         before { allow(session_user).to receive(:profile_v2?).and_return(true) }
         it "grants all access to profile_items" do
@@ -33,6 +38,140 @@ RSpec.describe Ability, type: :model do
         it "grants acces to typeahead citation of a reference" do
           expect(subject.can?("references", "typeahead_on_citation")).to eq true
         end
+      end
+    end
+
+    describe "#draft_profile_editor role" do
+      before do
+        allow(session_user).to receive(:with_role?).with('draft-profile-editor').and_return(true)
+      end
+
+      it 'can manage profile_v2' do
+        expect(subject.can?(:manage, :profile_v2)).to eq true
+      end
+
+      it 'can create Profile::ProfileItem' do
+        expect(subject.can?(:create, Profile::ProfileItem)).to eq true
+      end
+
+      it 'can manage draft Profile::ProfileItem' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: true)
+        expect(subject.can?(:manage, profile_item)).to eq true
+      end
+
+      it 'cannot manage non-draft Profile::ProfileItem' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: false)
+        expect(subject.can?(:manage, profile_item)).to eq false
+      end
+
+      it 'can manage draft Profile::ProfileItemReference' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: true)
+        profile_item_reference = FactoryBot.create(:profile_item_reference, profile_item: profile_item)
+        expect(subject.can?(:manage, profile_item_reference)).to eq true
+      end
+
+      it 'cannot manage non-draft Profile::ProfileItemReference' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: false)
+        profile_item_reference = FactoryBot.create(:profile_item_reference, profile_item: profile_item)
+        expect(subject.can?(:manage, profile_item_reference)).to eq false
+      end
+
+      it 'can manage draft Profile::ProfileText' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: true)
+        profile_text = FactoryBot.create(:profile_text, profile_item: profile_item)
+        expect(subject.can?(:manage, profile_text)).to eq true
+      end
+
+      it 'cannot manage non-draft Profile::ProfileText' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: false)
+        profile_text = FactoryBot.create(:profile_text, profile_item: profile_item)
+        expect(subject.can?(:manage, profile_text)).to eq false
+      end
+
+      it 'can manage draft Profile::ProfileItemAnnotation' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: true)
+        profile_item_annotation = FactoryBot.create(:profile_item_annotation, profile_item: profile_item)
+        expect(subject.can?(:manage, profile_item_annotation)).to eq true
+      end
+
+      it 'cannot manage non-draft Profile::ProfileItemAnnotation' do
+        profile_item = FactoryBot.create(:profile_item, is_draft: false)
+        profile_item_annotation = FactoryBot.create(:profile_item_annotation, profile_item: profile_item)
+        expect(subject.can?(:manage, profile_item_annotation)).to eq false
+      end
+
+      it 'can access references typeahead_on_citation' do
+        expect(subject.can?("references", "typeahead_on_citation")).to eq true
+      end
+
+      it 'can access profile_items' do
+        expect(subject.can?("profile_items", :all)).to eq true
+      end
+
+      it 'can access profile_item_annotations' do
+        expect(subject.can?("profile_item_annotations", :all)).to eq true
+      end
+
+      it 'can access profile_item_references' do
+        expect(subject.can?("profile_item_references", :all)).to eq true
+      end
+
+      it 'can access instances tab_details' do
+        expect(subject.can?("instances", "tab_details")).to eq true
+      end
+
+      it 'can access instances tab_profile_v2' do
+        expect(subject.can?("instances", "tab_profile_v2")).to eq true
+      end
+    end
+
+    describe "#profile_editor role" do
+      before do
+        allow(session_user).to receive(:with_role?).with('profile-editor').and_return(true)
+      end
+
+      it 'can manage profile_v2' do
+        expect(subject.can?(:manage, :profile_v2)).to eq true
+      end
+
+      it 'can manage Profile::ProfileItem' do
+        expect(subject.can?(:manage, Profile::ProfileItem)).to eq true
+      end
+
+      it 'can manage Profile::ProfileItemReference' do
+        expect(subject.can?(:manage, Profile::ProfileItemReference)).to eq true
+      end
+
+      it 'can manage Profile::ProfileText' do
+        expect(subject.can?(:manage, Profile::ProfileText)).to eq true
+      end
+
+      it 'can manage Profile::ProfileItemAnnotation' do
+        expect(subject.can?(:manage, Profile::ProfileItemAnnotation)).to eq true
+      end
+
+      it 'can access references typeahead_on_citation' do
+        expect(subject.can?("references", "typeahead_on_citation")).to eq true
+      end
+
+      it 'can access profile_items' do
+        expect(subject.can?("profile_items", :all)).to eq true
+      end
+
+      it 'can access profile_item_annotations' do
+        expect(subject.can?("profile_item_annotations", :all)).to eq true
+      end
+
+      it 'can access profile_item_references' do
+        expect(subject.can?("profile_item_references", :all)).to eq true
+      end
+
+      it 'can access instances tab_details' do
+        expect(subject.can?("instances", "tab_details")).to eq true
+      end
+
+      it 'can access instances tab_profile_v2' do
+        expect(subject.can?("instances", "tab_profile_v2")).to eq true
       end
     end
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Product, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:tree).optional }
+    it { is_expected.to belong_to(:reference).optional }
+    it { is_expected.to have_many(:user_product_roles).class_name('User::ProductRole').with_foreign_key('product_id') }
+  end
+end

--- a/spec/models/profile/profile_item/defined_query/product_and_product_item_configs_spec.rb
+++ b/spec/models/profile/profile_item/defined_query/product_and_product_item_configs_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs, type: :model do
   let(:session_user) { FactoryBot.create(:session_user) }
+  let!(:user) { FactoryBot.create(:user, user_name: session_user.username) }
   let(:instance) { FactoryBot.create(:instance) }
   let(:params) { {} }
 
@@ -13,7 +14,11 @@ RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs,
     it { should respond_to(:product_configs_and_profile_items) }
 
     it "has instance variable session_user" do
-      expect(subject.instance_variable_get(:@user)).to eq session_user
+      expect(subject.instance_variable_get(:@session_user)).to eq session_user
+    end
+
+    it "has instance variable user" do
+      expect(subject.instance_variable_get(:@user)).to eq user
     end
 
     it "has instance variable profile_context" do
@@ -72,6 +77,16 @@ RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs,
 
             expect(subject).to eq(result)
           end
+        end
+      end
+
+      context "when a user has a FOA product role" do
+        let(:product) { FactoryBot.create(:product, name: "FOA") }
+        let!(:role_type) { FactoryBot.create(:role_type) }
+        let!(:user_draft_profile_editor) { FactoryBot.create(:user_product_role, role_type:, user:, product:)}
+
+        it "returns the product attached to the role" do
+          expect(subject[1].id).to eq product.id
         end
       end
     end

--- a/test/controllers/profile_item_annotations_controller_test.rb
+++ b/test/controllers/profile_item_annotations_controller_test.rb
@@ -20,17 +20,18 @@ require "test_helper"
 
 class ProfileItemAnnotationsControllerTest < ActionController::TestCase
   def setup
-    @session = { 
-      username: "fred",
+    @user_product_role = user_product_roles(:user_one_foa_draft_profile_editor)
+    @session = {
+      username: "uone",
       user_full_name: "Fred Jones",
-      groups: ["edit", "foa"] 
+      groups: ["edit", "foa"]
     }
   end
 
   test "should create a profile item annotation" do
     assert_difference('Profile::ProfileItemAnnotation.count', 1) do
       profile_item = profile_item(:notes_pi)
-      post :create, 
+      post :create,
           params: {
             profile_item_annotation: {
               profile_item_id: profile_item.id,
@@ -56,7 +57,7 @@ class ProfileItemAnnotationsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal profile_item_annotation.id, assigns(:profile_item_annotation).id
-    assert_equal "Updated", assigns(:message)  
+    assert_equal "Updated", assigns(:message)
     assert_equal "Updated Annotation", profile_item_annotation.reload.value
     assert_template :update
   end

--- a/test/controllers/profile_item_references_controller_test.rb
+++ b/test/controllers/profile_item_references_controller_test.rb
@@ -22,6 +22,7 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
   def setup
     @profile_item = profile_item(:ecology_pi)
     @reference = references(:section_with_heyland_author_different_from_parent)
+    @user_product_role = user_product_roles(:user_one_foa_draft_profile_editor)
     @valid_params = {
       profile_item_reference: {
         reference_id: @reference.id,
@@ -29,7 +30,7 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
         profile_item_id: @profile_item.id
       }
     }
-    @session = { username: "fred", user_full_name: "Fred Jones", groups: ["edit", "foa"] }
+    @session = { username: "uone", user_full_name: "Fred Jones", groups: ["edit", "foa"] }
   end
 
   test "should create profile item reference successfully" do

--- a/test/controllers/profile_item_references_controller_test.rb
+++ b/test/controllers/profile_item_references_controller_test.rb
@@ -151,13 +151,24 @@ class ProfileItemReferencesControllerTest < ActionController::TestCase
   end
 
   test "should handle error when destroy fails" do
-    delete :destroy,
+    Profile::ProfileItemReference.create(
+      reference_id: @reference.id,
+      annotation: '1st Annotation',
+      created_by: "tester",
+      created_at: Time.current,
+      updated_by: "tester",
+      updated_at: Time.current,
+      profile_item_id: @profile_item.id
+    )
+
+    Profile::ProfileItemReference.stub_any_instance(:destroy, false) do
+      delete :destroy,
           params: {
             reference_id: @reference.id,
             profile_item_id: @profile_item.id,
           }, session: @session, xhr: true
-    assert_response :unprocessable_entity
-    assert_equal "Error deleting profile item reference: undefined method `profile_item' for nil", assigns(:message)
-    assert_template :destroy_failed
+      assert_response :unprocessable_entity
+      assert_template :destroy_failed
+    end
   end
 end

--- a/test/controllers/profile_items_controller_test.rb
+++ b/test/controllers/profile_items_controller_test.rb
@@ -19,10 +19,11 @@
 require "test_helper"
 
 class ProfileItemsControllerTest < ActionController::TestCase
-  
+
   def setup
     @profile_item = profile_item(:ecology_pi)
-    @session = { username: "fred", user_full_name: "Fred Jones", groups: ["edit", "foa"] }
+    @user_product_role = user_product_roles(:user_one_foa_draft_profile_editor)
+    @session = { username: "uone", user_full_name: "Fred Jones", groups: ["edit", "foa"] }
   end
 
   test "should destroy profile item and set message" do

--- a/test/controllers/profile_texts_controller_test.rb
+++ b/test/controllers/profile_texts_controller_test.rb
@@ -21,8 +21,9 @@ require "test_helper"
 class ProfileTextsControllerTest < ActionController::TestCase
   def setup
     @instance = instances(:gaertner_created_metrosideros_costata)
-    
-    @session = { username: "fred", user_full_name: "Fred Jones", groups: ["edit", "foa"] }
+    @user_product_role = user_product_roles(:user_one_foa_draft_profile_editor)
+
+    @session = { username: "uone", user_full_name: "Fred Jones", groups: ["edit", "foa"] }
   end
 
   test "should create profile text" do
@@ -75,7 +76,7 @@ class ProfileTextsControllerTest < ActionController::TestCase
   test "should update profile text" do
     profile_item = profile_item(:ecology_pi)
     profile_text = profile_item.profile_text
-    put :update, 
+    put :update,
           params: {
             id: profile_text.id,
             profile_text: {value_md: "Updated profile text value"},
@@ -94,7 +95,7 @@ class ProfileTextsControllerTest < ActionController::TestCase
     profile_text = profile_item.profile_text
 
     Profile::ProfileText.stub_any_instance(:update, false) do
-      put :update, 
+      put :update,
           params: {
             id: profile_text.id,
             profile_text: {value_md: "Updated profile text value"},

--- a/test/factories/profile_item_reference.rb
+++ b/test/factories/profile_item_reference.rb
@@ -28,5 +28,7 @@ FactoryBot.define do
     lock_version { 1 }
     api_name { "Sample Api name" }
     api_date { Time.current }
+
+    association :reference
   end
 end

--- a/test/fixtures/product_role_types.yml
+++ b/test/fixtures/product_role_types.yml
@@ -1,0 +1,8 @@
+_fixture:
+  model_class: Product::RoleType
+
+foa_draft_profile_editor:
+  name: "draft-profile-editor"
+  description: "Can manage draft profile"
+  updated_by: tester
+  created_by: tester

--- a/test/fixtures/user_product_roles.yml
+++ b/test/fixtures/user_product_roles.yml
@@ -1,0 +1,9 @@
+_fixture:
+  model_class: User::ProductRole
+
+user_one_foa_draft_profile_editor:
+  user: user_one
+  product: foa
+  role_type: foa_draft_profile_editor
+  updated_by: tester
+  created_by: tester

--- a/test/models/profile/profile_item/defined_query/product_and_productt_item_configs_test.rb
+++ b/test/models/profile/profile_item/defined_query/product_and_productt_item_configs_test.rb
@@ -25,12 +25,15 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
     @product = @profile_item.product
     @product_item_config = @profile_item.product_item_config
     @product_item_config2 = product_item_config(:habitat_pic)
-    @user = SessionUser.new
+    @session_user = SessionUser.new(username: "testuser")
+
+    @user = users(:user_one)
+    @user.update(user_name: @session_user.username)
 
     Rails.configuration.profile_v2_aware = true
 
     SessionUser.stub_any_instance(:groups, ["foa"]) do
-      @query = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@user, @instance)
+      @query = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@session_user, @instance)
     end
   end
 
@@ -55,7 +58,7 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
   test "#run_query with feature flag on and with product_item_config_id param" do
     param = {product_item_config_id: @product_item_config.id}
     SessionUser.stub_any_instance(:groups, ["foa"]) do
-      product_configs_and_profile_items, product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@user, @instance, param).run_query
+      product_configs_and_profile_items, product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@session_user, @instance, param).run_query
       assert_equal 1, product_configs_and_profile_items.size
       assert_equal @product, product
 
@@ -69,7 +72,7 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
 
   test "#run_query to return an empty profile itme when instance is nil" do
     SessionUser.stub_any_instance(:groups, ["foa"]) do
-      result = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@user, nil).run_query
+      result = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@session_user, nil).run_query
       assert_equal result.first, []
       assert_equal result.last, @product
     end
@@ -78,7 +81,7 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
   test "#run_query to return an empty profile itme when product is nil" do
     @product.update(name: "not foa")
     SessionUser.stub_any_instance(:groups, ["foa"]) do
-      result = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@user, @instance).run_query
+      result = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@session_user, @instance).run_query
       assert_equal result.first, []
       assert_nil result.last
     end
@@ -96,7 +99,7 @@ class ProductAndProductItemConfigsTest < ActiveSupport::TestCase
   test "#run_query with rdf_id=reference params" do
     profile_item = profile_item(:ecology_pi_ref)
     SessionUser.stub_any_instance(:groups, ["foa"]) do
-      product_configs_and_profile_items, product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@user, @instance, {rdf_id: "reference"}).run_query
+      product_configs_and_profile_items, product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@session_user, @instance, {rdf_id: "reference"}).run_query
       assert_equal 1, product_configs_and_profile_items.size
       profile_item_type = product_configs_and_profile_items.first[:product_item_config].profile_item_type
       assert_equal profile_item_type.rdf_id, "ecology.reference"


### PR DESCRIPTION
## Description
- Permissions for draft profile editor
- Modified the cancan access denied response

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
When a user's role is set to `draft-profile-editor`, he can only CRUD "draft" profile items

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-47

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
