### PR TITLE
Trigger gh ci when .erb files are updated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
       - '.ruby-version'
       - 'config/brakeman.ignore'
       - '**/*.rb'
+      - '**/*.erb'
       - '**/*.rake'
       - '.github/workflows/lint-ruby.yml'
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 07-Mar-2025
+  :jira_id:
+  :description: |-
+    CI: Trigger github workflow tests for .erb file changes
+- :date: 07-Mar-2025
   :jira_id: '5330'
   :description: |-
     Loader Batch Review Voting: Tidy up the Reviewers Vote tab
@@ -7,7 +11,7 @@
   :description: |-
     Loader: Batch Review search results now include the Batch name; revert recent nokogiri patch upgrade
 - :date: 06-Mar-2025
-  :jira_id: 
+  :jira_id:
   :description: |-
     Security: Upgrade rack
 - :date: 05-Mar-2025

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.6.14
+appversion=4.1.6.15
 


### PR DESCRIPTION
## Description

Update the  Github workflow so that tests will trigger when .erb files are changed

## How to Test
Open a PR with .erb file change


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
