### PR TITLE
Draft profile editor permissions for references

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -68,7 +68,7 @@ class Ability
     end
     can [:create, :read], Author
     can :update, Author do |author|
-      author.references.blank? && author.names.blank?
+      !author.referenced_in_any_instance? && author.no_other_authored_names?
     end
     can :create, Profile::ProfileItem
     can :manage, Profile::ProfileItem do |profile_item|
@@ -85,7 +85,7 @@ class Ability
     end
     can :create, Reference
     can :update, Reference do |reference|
-      !reference.instances?
+      reference.instances.blank?
     end
     can "authors", :all
     can "instances", ["tab_details", "tab_profile_v2"]
@@ -101,7 +101,8 @@ class Ability
       "create",
       "tab_edit_1",
       "tab_edit_2",
-      "tab_edit_3"
+      "tab_edit_3",
+      "update"
     ]
   end
 

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -166,6 +166,10 @@ class Author < ActiveRecord::Base
     end
   end
 
+  def referenced_in_any_instance?
+    references.joins(:instances).present?
+  end
+
   def can_be_deleted?
     references.size.zero? &&
       duplicates.size.zero? &&

--- a/app/views/references/tabs/_tab_edit_3.html.erb
+++ b/app/views/references/tabs/_tab_edit_3.html.erb
@@ -6,50 +6,52 @@
   <div id="search-result-details-error-message-container" class="message-container"></div>
 
 
-  <% if @reference.children? %>
-    You cannot delete this reference because it has one or more children.
-  <% end %>
+  <% if can? :delete, @reference %>
+    <% if @reference.children? %>
+      You cannot delete this reference because it has one or more children.
+    <% end %>
 
-  <% if @reference.instances? %>
-    You cannot delete this reference because it has one or more instances.
-  <% end %>
+    <% if @reference.instances? %>
+      You cannot delete this reference because it has one or more instances.
+    <% end %>
 
-  <% unless @reference.children? || @reference.instances? %>
+    <% unless @reference.children? || @reference.instances? %>
 
-    <% delete_link = link_to("Delete the reference...",
-                            '#',
-                            id: "reference-delete-link",
-                            title: "Delete the reference.",
-                            class: "btn btn-warning unconfirmed-delete-link pull-right",
-                            data: {show_this_id: "confirm-or-cancel-link-container"})
-    %>
-    <% confirm_delete_link = link_to("Confirm delete",
-                                    reference_path(@reference.id),
-                                    class: "btn btn-danger",
-                                    title: "Confirm you want to delete the reference.",
-                                    remote: true,
-                                    method: :delete)
-    %>
-    <% cancel_delete_link = link_to("Cancel delete",
-                                    '#',
-                                    id: "cancel-delete-link",
-                                    class: "btn btn-default cancel-link",
-                                    title: "Cancel delete dialog for the reference.",
-                                    data: {enable_this_id: 'reference-delete-link',
-                                          hide_this_id: 'confirm-or-cancel-link-container'})
-    %>
-    <% confirm_or_cancel_element = %Q(<div id="confirm-or-cancel-link-container"
-                                      class="instance-note confirm-or-cancel-delete-link pull-right hidden">
-                                      #{confirm_delete_link}
-                                      #{cancel_delete_link}</div>)
-    %>
+      <% delete_link = link_to("Delete the reference...",
+                              '#',
+                              id: "reference-delete-link",
+                              title: "Delete the reference.",
+                              class: "btn btn-warning unconfirmed-delete-link pull-right",
+                              data: {show_this_id: "confirm-or-cancel-link-container"})
+      %>
+      <% confirm_delete_link = link_to("Confirm delete",
+                                      reference_path(@reference.id),
+                                      class: "btn btn-danger",
+                                      title: "Confirm you want to delete the reference.",
+                                      remote: true,
+                                      method: :delete)
+      %>
+      <% cancel_delete_link = link_to("Cancel delete",
+                                      '#',
+                                      id: "cancel-delete-link",
+                                      class: "btn btn-default cancel-link",
+                                      title: "Cancel delete dialog for the reference.",
+                                      data: {enable_this_id: 'reference-delete-link',
+                                            hide_this_id: 'confirm-or-cancel-link-container'})
+      %>
+      <% confirm_or_cancel_element = %Q(<div id="confirm-or-cancel-link-container"
+                                        class="instance-note confirm-or-cancel-delete-link pull-right hidden">
+                                        #{confirm_delete_link}
+                                        #{cancel_delete_link}</div>)
+      %>
 
-    <%= divider %>
-    <br>
-    <div class="actions"> <%= delete_link.html_safe %> </div>
-    <div class="width-100-percent"> <%= confirm_or_cancel_element.html_safe %> </div>
+      <%= divider %>
+      <br>
+      <div class="actions"> <%= delete_link.html_safe %> </div>
+      <div class="width-100-percent"> <%= confirm_or_cancel_element.html_safe %> </div>
 
-    <div id="delete-info-message-container" class="message-container"></div>
-    <div id="delete-error-message-container" class="message-container"></div>
+      <div id="delete-info-message-container" class="message-container"></div>
+      <div id="delete-error-message-container" class="message-container"></div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/references/tabs/_tabs.html.erb
+++ b/app/views/references/tabs/_tabs.html.erb
@@ -11,7 +11,7 @@
                                           prev_tab: '',
                                           next_tab: '' } %>
 
-      <% if (can? 'references', 'edit') || (can? :update, @reference) %>
+      <% if can? :update, @reference %>
 
         <%= render partial: 'references/tabs/tab', locals: {first: false,
                                             last: false,

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 17-Mar-2025
+  :jira_id: '47'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: draft-profile-editor permissions for updating authors and references
 - :date: 14-Mar-2025
   :jira_id: '5340'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,1 @@
-appversion=4.1.6.17
-
+appversion=4.1.6.18

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Author, type: :model do
+  describe '#referenced_in_any_instance?' do
+    let(:author) { FactoryBot.create(:author) }
+    let(:reference) { FactoryBot.create(:reference, author: author) }
+
+    context 'when the author has references associated with instances' do
+      before do
+        FactoryBot.create(:instance, reference: reference)
+      end
+
+      it 'returns true' do
+        expect(author.referenced_in_any_instance?).to be true
+      end
+    end
+
+    context 'when the author has references but none are associated with instances' do
+      it 'returns false' do
+        expect(author.referenced_in_any_instance?).to be false
+      end
+    end
+
+    context 'when the author has no references' do
+      it 'returns false' do
+        expect(author.referenced_in_any_instance?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Allow draft-profile-editor to:
-  create a new reference
- to update a reference that is not used by any instances
- update an author that is not referenced in an instance nor used by any names

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-47

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
