### PR TITLE
NSL-5340: Loader Name: Fix loss of limit directive when placed after default batch name

### DIFF
--- a/app/controllers/concerns/search/query_defaults.rb
+++ b/app/controllers/concerns/search/query_defaults.rb
@@ -50,16 +50,13 @@ module Search::QueryDefaults
 
   def remove_old_default_embedded
     # Define regex to capture "default-batch: <value>" embedded within the query string
-    regex = /default-batch:\s[^:]{1,500}\s{1,500}\w{1,500}:/
-  
-    # Substitute the pattern with an empty string if found, optimizing execution
+    regex = /default-batch:.*(?= [A-Za-z-]*:)/
     params[:query_string].sub!(regex, '') if params[:query_string].match?(regex)
   end
   
 
   def remove_old_default_at_end_of_string
     regex = /default-batch:\s[^:]{1,500}\s*$/
-    # Only perform replacement if there's a match
     params[:query_string].sub!(regex, '') if params[:query_string].match?(regex)
   end
 end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 14-Mar-2025
+  :jira_id: '5340'
+  :description: |-
+    Loader Name: Fix loss of <code>limit:</code> directive when placed after default batch name
 - :date: 12-Mar-2025
   :jira_id: '47'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,2 +1,2 @@
-appversion=4.1.6.16
+appversion=4.1.6.17
 

--- a/test/controllers/search/loader/names/any_batch_test.rb
+++ b/test/controllers/search/loader/names/any_batch_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameAnyBatchTest < ActionController::TestCase
+  tests SearchController
+
+  test "can search for loader names" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "* any-batch:" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /\b[1-9] records*\b/,
+                  "Should find at least one loader name record with any-batch wildcard search"
+  end
+end

--- a/test/controllers/search/loader/names/hardenbergia_any_batch_test.rb
+++ b/test/controllers/search/loader/names/hardenbergia_any_batch_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameHardenbergiaAnyBatchTest < ActionController::TestCase
+  tests SearchController
+
+  test "can search loader names for Hardenbergia violacea in any batch" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "Hardenbergia violacea any-batch:" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /\b1 record*\b/,
+                  "Should find one loader name record with any-batch search for Hardenbergia violacea"
+  end
+end

--- a/test/controllers/search/loader/names/hardenbergia_any_batch_with_limit_test.rb
+++ b/test/controllers/search/loader/names/hardenbergia_any_batch_with_limit_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameHardenbergiaAnyBatchWithLimitTest < ActionController::TestCase
+  tests SearchController
+
+  test "can search loader names for Hardenbergia violacea in any batch with limit on results" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "Hardenbergia violacea any-batch: limit: 100" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /\b1 record*\b/,
+                  "Should find one loader name record with any-batch search for Hardenbergia violacea"
+  end
+end

--- a/test/controllers/search/loader/names/hardenbergia_no_default_batch.rb
+++ b/test/controllers/search/loader/names/hardenbergia_no_default_batch.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameHardenbergiaNoDefaultBatchTest < ActionController::TestCase
+  tests SearchController
+
+  test "can search for loader names" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "Hardenbergia violacea:" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /Please set a default batch/,
+                  "Should be asked to set a default batch"
+  end
+end

--- a/test/controllers/search/loader/names/no_default_batch_test.rb
+++ b/test/controllers/search/loader/names/no_default_batch_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameNoDefaultBatchTest < ActionController::TestCase
+  tests SearchController
+
+  test "can search for loader names" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "*"},
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /Please set a default batch/,
+                  "Should be asked to set a default batch"
+  end
+end

--- a/test/controllers/search/loader/names/with_invalid_default_batch_and_limit_test.rb
+++ b/test/controllers/search/loader/names/with_invalid_default_batch_and_limit_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameInvalidDefaultBatchAndLimitTest < ActionController::TestCase
+  tests SearchController
+
+  test "search loader names with invalid default batch and limit gets right message" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "Hardenbergia violacea default-batch: abc limit: 10" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /Please set a default batch/,
+                  "Should be asked to set a default batch"
+    
+    qs_field_value = css_select("#query-string-field[value]")
+    assert_match /Hardenbergia violacea  limit: 10/, qs_field_value.attr('value').to_s,
+                'Query string with limit should be retained'
+    
+  end
+end

--- a/test/controllers/search/loader/names/with_invalid_default_batch_test.rb
+++ b/test/controllers/search/loader/names/with_invalid_default_batch_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchLoaderNameWithInvalidDefaultBatchTest < ActionController::TestCase
+  tests SearchController
+
+  test "search loader names for H violacea invalid default batch gets right message" do
+    get(:search,
+        params: { query_target: "loader names", query_string: "Hardenbergia violacea default-batch: abc" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [:ogin, :"atch-loader"] })
+    assert_response :success
+    assert_select "#search-results-summary",
+                  /Please set a default batch/,
+                  "Should be asked to set a default batch"
+  end
+end


### PR DESCRIPTION
## Description
Loader Name specific search bug fix - adjust regex for extracting default-batch declaration in search params.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Jira explains

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
