### PR TITLE
Don't show the delete button when a profile item is cited by another item

### DIFF
--- a/app/controllers/profile_items_controller.rb
+++ b/app/controllers/profile_items_controller.rb
@@ -39,10 +39,10 @@ class ProfileItemsController < ApplicationController
   def destroy
     @product_item_config = @profile_item.product_item_config
     @instance_id = @profile_item.instance_id
-    if @profile_item.destroy!
+    if @profile_item.destroy
       @message = "Deleted profile item."
     else
-      raise("Not saved")
+      raise("Not saved: #{@profile_item.errors.full_messages.to_sentence}")
     end
   rescue StandardError => e
     @message = "Error deleting profile item: #{e.message}"

--- a/app/controllers/profile_texts_controller.rb
+++ b/app/controllers/profile_texts_controller.rb
@@ -90,7 +90,10 @@ class ProfileTextsController < ApplicationController
   end
 
   def really_update
-    if @profile_text.update(permitted_profile_text_params.merge(updated_by: current_user.username))
+    if @profile_text.update(permitted_profile_text_params.merge(
+      value: markdown_to_html(permitted_profile_text_params[:value_md].to_s),
+      updated_by: current_user.username
+    ))
       @message = "Updated"
       render :update
     else

--- a/app/helpers/profile/profile_items_helper.rb
+++ b/app/helpers/profile/profile_items_helper.rb
@@ -1,11 +1,13 @@
 # Help display profile_item information.
 module Profile::ProfileItemsHelper
-  def sourced_in_profile_items_info(profile_item)
+  def sourced_in_profile_items_info(profile_item, action: :delete)
     return unless profile_item.sourced_in_profile_items.present?
 
     count = profile_item.sourced_in_profile_items.count
+    action_message = ""
+    action_message = "You cannot delete this profile item" if action == :delete
     content_tag(:div, style: "padding: 10px;") do
-      "This item is cited by #{ActionController::Base.helpers.pluralize(count, 'other item')}."
+      "#{action_message}. This item is cited by #{ActionController::Base.helpers.pluralize(count, 'other profile item')}."
     end
   end
 end

--- a/app/helpers/profile/profile_items_helper.rb
+++ b/app/helpers/profile/profile_items_helper.rb
@@ -1,0 +1,11 @@
+# Help display profile_item information.
+module Profile::ProfileItemsHelper
+  def sourced_in_profile_items_info(profile_item)
+    return unless profile_item.sourced_in_profile_items.present?
+
+    count = profile_item.sourced_in_profile_items.count
+    content_tag(:div, style: "padding: 10px;") do
+      "This item is cited by #{ActionController::Base.helpers.pluralize(count, 'other item')}."
+    end
+  end
+end

--- a/app/models/profile/profile_item.rb
+++ b/app/models/profile/profile_item.rb
@@ -67,6 +67,10 @@ module Profile
             foreign_key: 'profile_item_id',
             dependent: :destroy
 
+    has_many :sourced_in_profile_items,
+            class_name: 'Profile::ProfileItem',
+            foreign_key: 'source_profile_item_id'
+
     validates :statement_type, presence: true
 
     before_destroy :validate_source_profile_item_id
@@ -78,9 +82,9 @@ module Profile
     end
 
     def validate_source_profile_item_id
-      cited_by_count = Profile::ProfileItem.where(source_profile_item_id: self.id).count
+      cited_by_count = self.sourced_in_profile_items.count
       if cited_by_count > 0
-        errors.add(:base, "Cannot delete profile item as it has been cited by #{cited_by_count} other items")
+        errors.add(:base, "Cannot delete profile item as it has been cited by #{ActionController::Base.helpers.pluralize(cited_by_count, 'other item')}")
         throw(:abort)
       end
     end

--- a/app/models/profile/profile_item.rb
+++ b/app/models/profile/profile_item.rb
@@ -73,20 +73,14 @@ module Profile
 
     validates :statement_type, presence: true
 
-    before_destroy :validate_source_profile_item_id
-
     default_scope { includes(:product_item_config).order("product_item_config.sort_order ASC") }
 
     def fresh?
       created_at > 1.hour.ago
     end
 
-    def validate_source_profile_item_id
-      cited_by_count = self.sourced_in_profile_items.count
-      if cited_by_count > 0
-        errors.add(:base, "Cannot delete profile item as it has been cited by #{ActionController::Base.helpers.pluralize(cited_by_count, 'other item')}")
-        throw(:abort)
-      end
+    def allow_delete?
+      self.sourced_in_profile_items.blank?
     end
   end
 end

--- a/app/views/instances/tabs/_tab_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_profile_v2.html.erb
@@ -101,7 +101,11 @@
 
         <div id="profile_item_actions_<%= product_item_config.id %>">
           <% if profile_item.persisted? %>
-            <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
+            <% if profile_item.allow_delete? %>
+              <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
+            <% else %>
+              <%= render partial: 'profile_items/no_delete_reasons', locals: {profile_item: profile_item} %>
+            <% end %>
           <% end %>
         </div>
 

--- a/app/views/profile_items/_no_delete_reasons.html.erb
+++ b/app/views/profile_items/_no_delete_reasons.html.erb
@@ -1,0 +1,3 @@
+<% if profile_item.present? %>
+  <%= sourced_in_profile_items_info(profile_item) %>
+<% end %>

--- a/app/views/profile_items/index.turbo_stream.erb
+++ b/app/views/profile_items/index.turbo_stream.erb
@@ -11,90 +11,94 @@
 <%= turbo_stream.replace "product-config-and-profile-items-container" do %>
   <div id="product-config-and-profile-items-container">
     <% @product_configs_and_profile_items.each do |config_items| %>
-        <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
-        <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
-        <div>
-            <h4>
-                <%= product_item_config.display_html %>
-                <span stype="font-size: 12px"><%= profile_item.is_draft? ? " - [DRAFT]" : ""%></span>
-            </h4>
+      <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
+      <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
+      <div>
+          <h4>
+              <%= product_item_config.display_html %>
+              <span stype="font-size: 12px"><%= profile_item.is_draft? ? " - [DRAFT]" : ""%></span>
+          </h4>
 
-            <div id="common-error-message-container" class="error-container"></div>
-            <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+          <div id="common-error-message-container" class="error-container"></div>
+          <div id="message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+      </div>
+
+      <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
+        <!-- Profile Text Form -->
+        <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
+        <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
+        <% method = profile_text.persisted? ? :put : :post %>
+        <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;overflow:hidden;">
+          <%= render partial: "profile_texts/form",
+              locals: {
+              profile_text: profile_text,
+              url: url,
+              method: method,
+              product_item_config: product_item_config,
+              instance_id: @instance.id,
+              profile_item: profile_item
+              }
+          %>
         </div>
 
-        <div style="padding: 10px;margin: 5px 0 30px 0px;background-color: white;border: 1px solid #afafaf;">
-            <!-- Profile Text Form -->
-            <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
-            <% url = profile_text.persisted? ? profile_text_path(id: profile_text.id) : profile_texts_path %>
-            <% method = profile_text.persisted? ? :put : :post %>
-            <div id="profile_text_form_<%= product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;overflow:hidden;">
-            <%= render partial: "profile_texts/form",
-                locals: {
-                profile_text: profile_text,
-                url: url,
-                method: method,
-                product_item_config: product_item_config,
-                instance_id: @instance.id,
-                profile_item: profile_item
-                }
-            %>
-            </div>
-            <div
-            id="profile_item_references_<%= product_item_config.id %>"
-            style="display: block" >
-            <%= render partial: "profile_item_references/edit_form",
-                collection: profile_item.profile_item_references,
-                locals: {profile_item: profile_item},
-                as: :profile_item_reference
-            %>
-            </div>
+        <div
+          id="profile_item_references_<%= product_item_config.id %>"
+          style="display: block">
+          <%= render partial: "profile_item_references/edit_form",
+              collection: profile_item.profile_item_references,
+              locals: {profile_item: profile_item},
+              as: :profile_item_reference
+          %>
+        </div>
 
-            <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
-            <div id="add_reference_<%= product_item_config.id %>">
+        <div id="add_reference_message_<%= product_item_config.id %>" class="message-container"></div> <!-- Message container -->
+          <div id="add_reference_<%= product_item_config.id %>">
             <% if profile_item.persisted? %>
-                <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
+              <div style="padding: 30px 10px 40px 10px;border: 1px solid #ddd;margin-top:30px;">
                 <label>Reference</label>
                 <div id="add_reference_form_<%= product_item_config.id %>" style="margin-bottom: 10px;">
-                    <%= render partial: 'profile_item_references/form',
+                  <%= render partial: 'profile_item_references/form',
                     locals: {
                         url: profile_item_references_path,
                         method: :post,
                         profile_item: profile_item,
                         profile_item_reference: Profile::ProfileItemReference.new
-                    } %>
+                  } %>
                 </div>
-                </div>
+              </div>
             <% end %>
-            </div>
+          </div>
 
-            <div style="padding: 30px 10px 10px 10px;">
+          <div style="padding: 30px 10px 10px 10px;">
             <div id="add_annotation_form<%= product_item_config.id %>">
-                <% if profile_item.persisted? %>
-                <!-- Profile Item Reference Form -->
-                <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
-                <label>Annotate this profile item:</label>
-                <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
-                <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
-                <% method = profile_item_annotation.persisted? ? :put : :post %>
-                <%= render partial: 'profile_item_annotations/form',
-                    locals: {
-                    url: url,
-                    method: method,
-                    profile_item_annotation: profile_item_annotation
-                    } %>
-                <% end %>
+              <% if profile_item.persisted? %>
+              <!-- Profile Item Reference Form -->
+              <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
+              <label>Annotate this profile item:</label>
+              <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
+              <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
+              <% method = profile_item_annotation.persisted? ? :put : :post %>
+              <%= render partial: 'profile_item_annotations/form',
+                  locals: {
+                  url: url,
+                  method: method,
+                  profile_item_annotation: profile_item_annotation
+                  } %>
+              <% end %>
             </div>
-            </div>
+          </div>
 
-            <div id="profile_item_actions_<%= product_item_config.id %>">
+          <div id="profile_item_actions_<%= product_item_config.id %>">
             <% if profile_item.persisted? %>
+              <% if profile_item.allow_delete?%>
                 <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
+              <% else %>
+                <%= render partial: 'profile_items/no_delete_reasons', locals: {profile_item: profile_item} %>
+              <% end %>
             <% end %>
-            </div>
-
+          </div>
         </div>
-        </div>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 18-Mar-2025
+  :jira_id: '51'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Better error message when a draft-profile-editor user tries to delete a profile item that has been linked to another profile item
 - :date: 17-Mar-2025
   :jira_id: '47'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.18
+appversion=4.1.6.19

--- a/spec/models/profile/profile_item_spec.rb
+++ b/spec/models/profile/profile_item_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Profile::ProfileItem, type: :model do
 
       it 'does not allow the profile item to be destroyed' do
         expect { profile_item.destroy }.not_to change(Profile::ProfileItem, :count)
-        expect(profile_item.errors[:base]).to include("Cannot delete profile item as it has been cited by 1 other items")
+        expect(profile_item.errors[:base]).to include("Cannot delete profile item as it has been cited by 1 other item")
       end
     end
 

--- a/spec/models/profile/profile_item_spec.rb
+++ b/spec/models/profile/profile_item_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Profile::ProfileItem, type: :model do
+  describe 'before_destroy callback: validate_source_profile_item_id' do
+    let!(:profile_item) { FactoryBot.create(:profile_item) }
+
+    context 'when the profile item is not cited by other items' do
+      it 'allows the profile item to be destroyed' do
+        expect { profile_item.destroy }.to change(Profile::ProfileItem, :count).by(-1)
+      end
+    end
+
+    context 'when the profile item is cited by other items' do
+      before do
+        allow_any_instance_of(Name).to receive(:name_type_must_match_category).and_return(true)
+        FactoryBot.create(:profile_item, source_profile_item_id: profile_item.id, profile_object_rdf_id: profile_item.profile_object_rdf_id, product_item_config: profile_item.product_item_config)
+      end
+
+      it 'does not allow the profile item to be destroyed' do
+        expect { profile_item.destroy }.not_to change(Profile::ProfileItem, :count)
+        expect(profile_item.errors[:base]).to include("Cannot delete profile item as it has been cited by 1 other items")
+      end
+    end
+
+    context 'when the profile item is cited by multiple items' do
+      before do
+        allow_any_instance_of(Name).to receive(:name_type_must_match_category).and_return(true)
+      end
+
+      it 'does not allow the profile item to be destroyed and shows the correct error message' do
+        other_profile_item_1 = FactoryBot.create(:profile_item, source_profile_item_id: profile_item.id, profile_object_rdf_id: profile_item.profile_object_rdf_id, product_item_config: profile_item.product_item_config)
+        other_profile_item_2 = FactoryBot.create(:profile_item, source_profile_item_id: profile_item.id, profile_object_rdf_id: profile_item.profile_object_rdf_id, product_item_config: profile_item.product_item_config)
+
+        expect { profile_item.destroy }.not_to change(Profile::ProfileItem, :count)
+        expect(profile_item.errors[:base]).to include("Cannot delete profile item as it has been cited by 2 other items")
+      end
+    end
+  end
+end

--- a/test/controllers/profile_items_controller_test.rb
+++ b/test/controllers/profile_items_controller_test.rb
@@ -47,10 +47,10 @@ class ProfileItemsControllerTest < ActionController::TestCase
   end
 
   test "should handle error when destroy fails" do
-    Profile::ProfileItem.stub_any_instance(:destroy!, false) do
+    Profile::ProfileItem.stub_any_instance(:destroy, false) do
       delete :destroy, params: { id: @profile_item.id }, session: @session, xhr: true
-      assert_equal @profile_item.destroy!, false
-      assert_equal "Error deleting profile item: Not saved", assigns(:message)
+      assert_equal @profile_item.destroy, false
+      assert_equal "Error deleting profile item: Not saved: #{@profile_item.errors.full_messages.to_sentence}", assigns(:message)
       assert_response :unprocessable_entity
       assert_template :destroy_failed
     end

--- a/test/factories/profile_item.rb
+++ b/test/factories/profile_item.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
   factory :profile_item, class: "Profile::ProfileItem" do
     instance_id { 1 }
     product_item_config_id { 1 }
-    profile_object_rdf_id { "Sample Profile object rdf" }
+    sequence(:profile_object_rdf_id) {|n| "Sample Profile object rdf #{n}" }
     is_draft { true }
     published_date { Time.current }
     end_date { Time.current }


### PR DESCRIPTION
## Description
- We don't show the delete button when the profile item is cited in other profile items
-  Fixed up the bug around profile text update. Couldn't update a profile text due to `value` field not set

<img width="739" alt="image" src="https://github.com/user-attachments/assets/84981ef8-66ab-4d13-b4ec-155e8662673e" />


## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)



## How to Test
Delete a profile item (for a draft instance) that is cited by another profile item

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-51

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
