### PR TITLE
Allow a user to remove a profile item annotation

### DIFF
--- a/app/controllers/profile_item_annotations_controller.rb
+++ b/app/controllers/profile_item_annotations_controller.rb
@@ -45,6 +45,7 @@ class ProfileItemAnnotationsController < ApplicationController
 
   def update
     @message = "No change"
+    @profile_item = @profile_item_annotation.profile_item
     really_update if changed?
   end
 
@@ -63,7 +64,11 @@ class ProfileItemAnnotationsController < ApplicationController
   end
 
   def really_update
-    if @profile_item_annotation.update(permitted_params.merge(updated_by: current_user.username))
+    if permitted_params[:value].blank?
+      @profile_item_annotation.destroy!
+      @message = "Deleted"
+      render :delete
+    elsif @profile_item_annotation.update(permitted_params.merge(updated_by: current_user.username))
       @message = "Updated"
       render :update
     else

--- a/app/views/profile_item_annotations/_form.html.erb
+++ b/app/views/profile_item_annotations/_form.html.erb
@@ -4,7 +4,7 @@
     <%= hidden_field_tag "profile_item_annotation[profile_item_id]", profile_item_annotation.profile_item_id %>
 
     <!-- Text area for annotation input -->
-    <%= text_area_tag "profile_item_annotation[value]", profile_item_annotation.value, placeholder: "Enter text here...", rows: 2, required: true, style: 'flex-grow: 1; padding: 5px; border: 1px solid #ccc; border-radius: 4px; background-color: white; min-height: 50px; resize: vertical;' %>
+    <%= text_area_tag "profile_item_annotation[value]", profile_item_annotation.value, placeholder: "Enter text here...", rows: 2, style: 'flex-grow: 1; padding: 5px; border: 1px solid #ccc; border-radius: 4px; background-color: white; min-height: 50px; resize: vertical;' %>
 
     <!-- Submit button -->
     <%= f.submit 'Save', style: 'background-color: #5a5a5a; color: white; border: none; padding: 5px 10px; cursor: pointer; border-radius: 4px; margin-left: 10px;' %>

--- a/app/views/profile_item_annotations/delete.turbo_stream.erb
+++ b/app/views/profile_item_annotations/delete.turbo_stream.erb
@@ -1,0 +1,13 @@
+<%= turbo_stream.replace "add_annotation_form#{@profile_item.product_item_config_id}" do %>
+  <div id="add_annotation_form<%= @profile_item.product_item_config_id %>">
+    <div id="annotation_message_<%= @profile_item.id %>" class="message-container"><%= @message %></div>
+    <label>Annotate this profile item:</label>
+    <%= render partial: "profile_item_annotations/form",
+      locals: {
+        url: profile_item_annotations_path,
+        method: :post,
+        profile_item_annotation: @profile_item.build_profile_item_annotation
+      }
+    %>
+  </div>
+<% end %>

--- a/app/views/profile_items/index.turbo_stream.erb
+++ b/app/views/profile_items/index.turbo_stream.erb
@@ -72,18 +72,18 @@
           <div style="padding: 30px 10px 10px 10px;">
             <div id="add_annotation_form<%= product_item_config.id %>">
               <% if profile_item.persisted? %>
-              <!-- Profile Item Reference Form -->
-              <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
-              <label>Annotate this profile item:</label>
-              <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
-              <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
-              <% method = profile_item_annotation.persisted? ? :put : :post %>
-              <%= render partial: 'profile_item_annotations/form',
-                  locals: {
-                  url: url,
-                  method: method,
-                  profile_item_annotation: profile_item_annotation
-                  } %>
+                <!-- Profile Item Reference Form -->
+                <div id="annotation_message_<%= profile_item.id %>" class="message-container"></div>
+                <label>Annotate this profile item:</label>
+                <% profile_item_annotation = profile_item.profile_item_annotation || profile_item.build_profile_item_annotation %>
+                <% url = profile_item_annotation.persisted? ? profile_item_annotation_path(profile_item_annotation) : profile_item_annotations_path %>
+                <% method = profile_item_annotation.persisted? ? :put : :post %>
+                <%= render partial: 'profile_item_annotations/form',
+                    locals: {
+                    url: url,
+                    method: method,
+                    profile_item_annotation: profile_item_annotation
+                    } %>
               <% end %>
             </div>
           </div>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,8 +1,13 @@
+- :date: 21-Mar-2025
+  :jira_id: '52'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Allow user to remove a profile item annotation
 - :date: 18-Mar-2025
   :jira_id: '51'
   :jira_project: FLOR
   :description: |-
-    Foa Project: Better error message when a draft-profile-editor user tries to delete a profile item that has been linked to another profile item
+    Foa Project: Don't offer the delete button when the profile item is not deletable
 - :date: 17-Mar-2025
   :jira_id: '47'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.19
+appversion=4.1.6.20

--- a/spec/controllers/profile_item_annotations_controller_spec.rb
+++ b/spec/controllers/profile_item_annotations_controller_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe ProfileItemAnnotationsController, type: :controller do
+  let(:session_user) { FactoryBot.create(:session_user, groups: ['login']) }
+  let(:user) { FactoryBot.create(:user) }
+  let!(:profile_item) { FactoryBot.create(:profile_item) }
+
+  before do
+    session[:username] = session_user.username
+    session[:user_full_name] = session_user.full_name
+    session[:groups] = session_user.groups
+
+    allow(controller).to receive(:current_user).and_return(session_user)
+    controller.instance_variable_set(:@current_user, session_user)
+  end
+
+  describe "POST #create" do
+    let(:valid_params) do
+      { profile_item_annotation: { profile_item_id: profile_item.id, value: "Test Annotation" } }
+    end
+
+    let(:invalid_params) do
+      { profile_item_annotation: { profile_item_id: profile_item.id, value: "" } }
+    end
+
+    context "for authorized user" do
+      before do
+        allow(controller).to receive(:can?).with(:manage, instance_of(Profile::ProfileItemAnnotation)).and_return(true)
+      end
+
+      it "creates a new profile_item_annotation and renders :create" do
+        expect {
+          post :create, params: valid_params, format: :turbo_stream
+        }.to change(Profile::ProfileItemAnnotation, :count).by(1)
+
+        expect(assigns(:message)).to eq("Saved")
+        expect(response).to render_template(:create)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      end
+
+      it "fails to create a profile_item_annotation with invalid params and renders :create_failed" do
+        expect {
+          post :create, params: invalid_params, format: :turbo_stream
+        }.not_to change(Profile::ProfileItemAnnotation, :count)
+
+        expect(assigns(:message)).to include("Validation failed")
+        expect(response).to render_template("create_failed")
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "for non-authorized user" do
+      before do
+        allow(controller).to receive(:can?).with(:manage, instance_of(Profile::ProfileItemAnnotation)).and_return(false)
+      end
+
+      it "returns an error" do
+        post :create, params: valid_params, format: :turbo_stream
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    let!(:profile_item_annotation) { FactoryBot.create(:profile_item_annotation, profile_item: profile_item, value: "Initial Value") }
+
+    before do
+      allow(controller).to receive(:can?).with(:manage, profile_item_annotation).and_return(true)
+    end
+
+    context "for non-authorized user" do
+      before do
+        allow(controller).to receive(:can?).with(:manage, profile_item_annotation).and_return(false)
+      end
+
+      it "is forbidden access" do
+        put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "Updated Value" } }, format: :turbo_stream
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "when value is blank" do
+      it "destroys the profile_item_annotation and renders :delete" do
+        put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "" } }, format: :turbo_stream
+
+        expect(assigns(:message)).to eq("Deleted")
+        expect { profile_item_annotation.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(response).to render_template(:delete)
+      end
+    end
+
+    context "when value is not blank" do
+      it "updates the profile_item_annotation and renders :update" do
+        put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "Updated Value" } }, format: :turbo_stream
+
+        expect(assigns(:message)).to eq("Updated")
+        expect(profile_item_annotation.reload.value).to eq("Updated Value")
+        expect(response).to render_template(:update)
+      end
+    end
+
+    context "when value is unchanged" do
+      it "does not update the profile_item_annotation and renders :update" do
+        put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "Initial Value" } }, format: :turbo_stream
+
+        expect(assigns(:message)).to eq("No change")
+        expect(profile_item_annotation.reload.value).to eq("Initial Value")
+        expect(response).to render_template(:update)
+      end
+    end
+
+    context "when an error occurs during update" do
+      before do
+        allow_any_instance_of(Profile::ProfileItemAnnotation).to receive(:update).and_raise(StandardError, "Update failed")
+      end
+
+      it "renders :update_failed with an error message" do
+        put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "Updated Value" } }, format: :turbo_stream
+
+        expect(assigns(:message)).to eq("Update failed")
+        expect(response).to render_template(:update_failed)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Description
We are going to allow user to save a blank profile item annotation which will be considered by the system as a delete profile item annotation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Add a profile item annotation, save, and then clear the field and save again.

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-52

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
