### PR TITLE
Only show the copy tab to standalone & non-draft instance

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -260,7 +260,7 @@ class InstancesController < ApplicationController
     end
     offer << "tab_comments"
     offer << "tab_copy_to_new_reference" if @instance.standalone? && params["row-type"] == "instance_as_part_of_concept_record"
-    offer << "tab_copy_to_new_profile_v2" unless @instance.draft?
+    offer << "tab_copy_to_new_profile_v2" if @instance.copy_with_product_reference_allowed?
     if Rails.configuration.try('batch_loader_aware') &&
           can?('loader/names', 'update') &&
           offer_loader_tab?

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -538,6 +538,10 @@ class Instance < ActiveRecord::Base
     standalone? && reverse_of_this_is_cited_by.blank?
   end
 
+  def copy_with_product_reference_allowed?
+    standalone? && !draft?
+  end
+
   def relationship_ref_must_match_cited_by_instance_ref
     return unless relationship? &&
                   !(reference.id == this_is_cited_by.reference.id)

--- a/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
@@ -27,7 +27,7 @@ The copied instance will remain attached to:
              method: :post) do |f| %>
 
   <br>
-  The copied instance will be attached to the <%= @current_user.profile_v2_context.product %> product reference:<br>
+  The copied instance will be attached to the <%= @current_registered_user.available_product_from_roles&.name %> product reference:<br>
   <h6>&mdash; <%= product_reference.citation %></h6>
   <br>
   <label for="instance_type_id">Instance type:</label>

--- a/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
@@ -1,115 +1,119 @@
-<% product_reference = Profile::Product.find_by(name: @current_registered_user.available_product_from_roles&.name).reference %>
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
-<% increment_tab_index(0) %>
-
-<h5>
-<% if @instance.citations.size == 0 %>
-  Copy the instance
-<% elsif @instance.citations.size == 1 %>
-  Copy the instance and its <%= @instance.citations.first.instance_type.name %>
+<% if @current_registered_user.available_product_from_roles.reference.blank? %>
+  <div id="search-result-details-error-message-container" class="message-container">
+    You do not have a product reference. Please contact your administrator.
+  </div>
 <% else %>
-  Copy the instance and its <%= citation_summary(@instance) %>.
-<% end %>
-</h5>
+  <% product_reference = Profile::Product.find_by(name: @current_registered_user.available_product_from_roles&.name).reference %>
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
+  <% increment_tab_index(0) %>
 
-<br>
-The copied instance will remain attached to:
-<br>
-<h6>&mdash; <%= @instance.name.full_name %></h6>
-
-<% @instance.instance_type_id = InstanceType.secondary_reference.id %>
-<%= form_for(@instance,
-             url: { action: "copy_for_profile_v2",
-             format: 'js'},
-             id: "copy-instance-for-name-form",
-             remote: true,
-             method: :post) do |f| %>
+  <h5>
+  <% if @instance.citations.size == 0 %>
+    Copy the instance
+  <% elsif @instance.citations.size == 1 %>
+    Copy the instance and its <%= @instance.citations.first.instance_type.name %>
+  <% else %>
+    Copy the instance and its <%= citation_summary(@instance) %>.
+  <% end %>
+  </h5>
 
   <br>
-  The copied instance will be attached to the <%= @current_registered_user.available_product_from_roles&.name %> product reference:<br>
-  <h6>&mdash; <%= product_reference.citation %></h6>
+  The copied instance will remain attached to:
   <br>
-  <label for="instance_type_id">Instance type:</label>
-  <br>
-  <h6>&mdash; <%= @instance.instance_type.name %></h6>
-  <%= f.hidden_field :instance_type_id, value: @instance.instance_type_id %>
+  <h6>&mdash; <%= @instance.name.full_name %></h6>
 
-  <script> setUpInstanceReferenceExcludingCurrent(); </script>
-  <%= f.hidden_field :reference_id, value: product_reference.id %>
-  <br>
-  <%= render partial: "instances/widgets/as_a_draft", locals: {f: f} %>
-  <% if Rails.configuration.try("draft_instances")  %>
-    <%= f.hidden_field :draft, value: true %>
+  <% @instance.instance_type_id = InstanceType.secondary_reference.id %>
+  <%= form_for(@instance,
+              url: { action: "copy_for_profile_v2",
+              format: 'js'},
+              id: "copy-instance-for-name-form",
+              remote: true,
+              method: :post) do |f| %>
+
+    <br>
+    The copied instance will be attached to the <%= @current_registered_user.available_product_from_roles&.name %> product reference:<br>
+    <h6>&mdash; <%= product_reference.citation %></h6>
+    <br>
+    <label for="instance_type_id">Instance type:</label>
+    <br>
+    <h6>&mdash; <%= @instance.instance_type.name %></h6>
+    <%= f.hidden_field :instance_type_id, value: @instance.instance_type_id %>
+    <script> setUpInstanceReferenceExcludingCurrent(); </script>
+    <%= f.hidden_field :reference_id, value: product_reference.id %>
+    <br>
+    <%= render partial: "instances/widgets/as_a_draft", locals: {f: f} %>
+    <% if Rails.configuration.try("draft_instances")  %>
+      <%= f.hidden_field :draft, value: true %>
+    <% end %>
+
+    <br>
+  <div class="width-100-percent">
+
+    <%= link_to("Copy",
+              "javascript:void(0);",
+              id: "copy-instance-link",
+              class: "btn btn-warning pull-right",
+              title: "Copy the instance - you will be asked to confirm.",
+              tabindex: increment_tab_index,
+              data: {show_this_id: "confirm-or-cancel-copy-instance-link-container",
+                      must_have_value: "instance_reference_id"})
+    %>
+    <div id="pre-submit-error-message" class="error-message red hidden">Please fill out all the fields</div>
+    <div id="confirm-or-cancel-copy-instance-link-container"
+        class="confirm-or-cancel-container pull-right hidden">
+
+      <%= f.submit "Confirm", id: 'create-copy-of-instance', class: 'btn btn-primary width-7em', title: 'Really copy the instance', tabindex: increment_tab_index %>
+      <%= link_to("Cancel",
+                  '#',
+                  id: "cancel-copy-instance-link",
+                  class: "btn btn-default cancel-link",
+                  title: "Do not copy the instance.",
+                  tabindex: increment_tab_index,
+                  data: {enable_this_id: 'copy-instance-link',
+                  hide_this_id: "confirm-or-cancel-copy-instance-link-container"})
+      %>
+    </div>
+    <div class="layout-artifact">&nbsp;</div>
+    <div id="copy-instance-info-message-container" class="message-container hidden"></div>
+    <div id="copy-instance-error-message-container" class="error-container hidden"></div>
+    <div id="search-result-details-error-message-container-0" class="error-container"></div>
+    <div id="search-result-details-error-message-container-1" class="error-container"></div>
+    <div id="search-result-details-error-message-container-2" class="error-container"></div>
+    <div id="search-result-details-error-message-container-3" class="error-container"></div>
+
+
+      <br>
+      <div id="multiple-primary-override" class="hidden form-check override-container">
+        <br>
+        <label class="green form-check-label">
+        <%= f.check_box(:multiple_primary_override,{title: "Override the warning message"}) %>
+          Ignore the warning and create the extra primary instance.
+        </label>
+      </div>
+      <div id="duplicate-instance-override" class="hidden form-check override-container">
+        <br>
+        <label class="green form-check-label">
+        <%= f.check_box(:duplicate_instance_override,{title: "Override the duplicate instance error message"}) %>
+          Ignore the error and create a duplicate instance.
+        </label>
+      </div>
   <% end %>
 
   <br>
-<div class="width-100-percent">
-
-  <%= link_to("Copy",
-             "javascript:void(0);",
-             id: "copy-instance-link",
-             class: "btn btn-warning pull-right",
-             title: "Copy the instance - you will be asked to confirm.",
-             tabindex: increment_tab_index,
-             data: {show_this_id: "confirm-or-cancel-copy-instance-link-container",
-                    must_have_value: "instance_reference_id"})
+  <br>
+  <%= link_to("Refresh page",
+              '#',
+              id: "refresh-page-after-copy-link",
+              class: "btn btn-default hidden refresh-page-link",
+              title: "Refresh page")
   %>
-  <div id="pre-submit-error-message" class="error-message red hidden">Please fill out all the fields</div>
-  <div id="confirm-or-cancel-copy-instance-link-container"
-       class="confirm-or-cancel-container pull-right hidden">
 
-    <%= f.submit "Confirm", id: 'create-copy-of-instance', class: 'btn btn-primary width-7em', title: 'Really copy the instance', tabindex: increment_tab_index %>
-    <%= link_to("Cancel",
-                '#',
-                id: "cancel-copy-instance-link",
-                class: "btn btn-default cancel-link",
-                title: "Do not copy the instance.",
-                tabindex: increment_tab_index,
-                data: {enable_this_id: 'copy-instance-link',
-                hide_this_id: "confirm-or-cancel-copy-instance-link-container"})
-    %>
-  </div>
-  <div class="layout-artifact">&nbsp;</div>
-  <div id="copy-instance-info-message-container" class="message-container hidden"></div>
-  <div id="copy-instance-error-message-container" class="error-container hidden"></div>
-  <div id="search-result-details-error-message-container-0" class="error-container"></div>
-  <div id="search-result-details-error-message-container-1" class="error-container"></div>
-  <div id="search-result-details-error-message-container-2" class="error-container"></div>
-  <div id="search-result-details-error-message-container-3" class="error-container"></div>
-
-
-    <br>
-    <div id="multiple-primary-override" class="hidden form-check override-container">
-      <br>
-      <label class="green form-check-label">
-      <%= f.check_box(:multiple_primary_override,{title: "Override the warning message"}) %>
-        Ignore the warning and create the extra primary instance.
-      </label>
-    </div>
-    <div id="duplicate-instance-override" class="hidden form-check override-container">
-      <br>
-      <label class="green form-check-label">
-      <%= f.check_box(:duplicate_instance_override,{title: "Override the duplicate instance error message"}) %>
-        Ignore the error and create a duplicate instance.
-      </label>
-    </div>
+  <% if @take_focus %>
+    <script>
+      $(document).ready(function () {
+        focusOnField('instance-reference-typeahead');
+      })
+    </script>
+  <% end %>
 <% end %>
-
-<br>
-<br>
-<%= link_to("Refresh page",
-            '#',
-            id: "refresh-page-after-copy-link",
-            class: "btn btn-default hidden refresh-page-link",
-            title: "Refresh page")
-%>
-
-<% if @take_focus %>
-  <script>
-    $(document).ready(function () {
-      focusOnField('instance-reference-typeahead');
-    })
-  </script>
-<% end %>
-

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 25-Mar-2025
+  :jira_id: '31'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project draft-editor permissions: Only display instance copy tab for standalone and non-draft instances and display error message.
+- :date: 25-Mar-2025
   :jira_id:
   :description: |-
     Build: Remove scripted changing of active_record timezome from :localhost to :utc - just leave production AR TZ as :utc
@@ -7,7 +12,7 @@
   :description: |-
     Taxonomy: Honour <code>tree.is_read_only</code> by preventing tree operations when boolean is set true
 - :date: 24-Mar-2025
-  :jira_id: '52'
+  :jira_id: '31'
   :jira_project: FLOR
   :description: |-
     Foa Project: draft-editor permissions for copying an instance as draft secondary ref instance for a product (FOA)

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.23
+appversion=4.1.6.24

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -18,4 +18,52 @@ RSpec.describe Instance, type: :model do
       end
     end
   end
+
+  describe "#copy_with_product_reference_allowed?" do
+    let(:instance) { FactoryBot.create(:instance) }
+
+    context "when the instance is standalone and not a draft" do
+      before do
+        allow(instance).to receive(:standalone?).and_return(true)
+        allow(instance).to receive(:draft?).and_return(false)
+      end
+
+      it "returns true" do
+        expect(instance.copy_with_product_reference_allowed?).to be true
+      end
+    end
+
+    context "when the instance is not standalone" do
+      before do
+        allow(instance).to receive(:standalone?).and_return(false)
+        allow(instance).to receive(:draft?).and_return(false)
+      end
+
+      it "returns false" do
+        expect(instance.copy_with_product_reference_allowed?).to be false
+      end
+    end
+
+    context "when the instance is a draft" do
+      before do
+        allow(instance).to receive(:standalone?).and_return(true)
+        allow(instance).to receive(:draft?).and_return(true)
+      end
+
+      it "returns false" do
+        expect(instance.copy_with_product_reference_allowed?).to be false
+      end
+    end
+
+    context "when the instance is neither standalone nor a draft" do
+      before do
+        allow(instance).to receive(:standalone?).and_return(false)
+        allow(instance).to receive(:draft?).and_return(true)
+      end
+
+      it "returns false" do
+        expect(instance.copy_with_product_reference_allowed?).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
Copy tab (with default reference) for standalone & non-draft instances

<img width="1797" alt="image" src="https://github.com/user-attachments/assets/caf16780-31f4-498a-b80b-c6159b8987b8" />
<img width="1756" alt="image" src="https://github.com/user-attachments/assets/ea12a809-f8d8-4f0c-a1c8-523080ee7814" />


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
- Assign a draft-editor role to a user
- Select a standalone and non-draft instance. The copy tab will show up

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-31

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
