### PR TITLE
Build: Remove scripted changing of active_record timezome from :localhost to :utc

### DIFF
--- a/build_prod/config-prod.ed
+++ b/build_prod/config-prod.ed
@@ -1,4 +1,0 @@
-/config.active_record.default_timezone = :local
-s/:local/:utc/
-p
-wq

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 25-Mar-2025
+  :jira_id:
+  :description: |-
+    Build: Remove scripted changing of active_record timezome from :localhost to :utc - just leave production AR TZ as :utc
 - :date: 24-Mar-2025
   :jira_id: '5164'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.22
+appversion=4.1.6.23

--- a/lib/tasks/build_prod.rake
+++ b/lib/tasks/build_prod.rake
@@ -1,12 +1,8 @@
 desc "build prod"
 task :build_prod do
   sh "RAILS_ENV=production bundle exec rake assets:precompile RAILS_RELATIVE_URL_ROOT='/nsl/editor'"
-  sh "echo 'Modify prod config with time utc'"
-  sh "ed config/environments/production.rb <build_prod/config-prod.ed"
   sh "echo 'Modify services build partial with build timestamp'"
   sh "ed app/views/services/_build.html.erb <build_prod/build-timestamp.ed"
-  # sh "echo rm node_modules"
-  # sh "rm -rf node_modules"
   sh "echo rm tests"
   sh "rm -rf test"
   sh "echo clear logs"


### PR DESCRIPTION
Just leave production AR TZ as :utc

The config-prod.ed script is failing on teamcity with no clear message why.

The script simply changes the prod active_record TZ from :local to :utc.

I added this script when migrating from CSIRO to AWS - and the script was probably needed then during the transition from one environment to the other.

We now don't need the script and will just leave the AR default TZ as :utc.

## Description
Build change

## Type of change
Build change

## How to Test
Build on TC

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
