### PR TITLE
NSL-5088: Loader Search Targets: change order of target options to reflect use

### DIFF
--- a/app/views/search/search_targets/_standard_targets.html.erb
+++ b/app/views/search/search_targets/_standard_targets.html.erb
@@ -16,12 +16,12 @@
               >Names plus instances</a>
           </li>
           <% if Rails.configuration.try(:batch_loader_aware) %>
-            <li><a id="search-target-item-loader-batch-stack" 
+            <li><a id="search-target-item-loader-name" 
                    href="#" 
-                   title="Search loader batches and retrieve batches, reviews, review periods, reviewers in a stack" 
-                   data-help="loader-batch-stack-search-help" 
-                   data-examples="loader-batch-stack-search-examples"
-                >Batch stacks</a>
+                   title="Search loader names" 
+                   data-help="loader-name-search-help" 
+                   data-examples="loader-name-search-examples"
+                >Loader names</a>
             </li>
           <% end %>
 
@@ -84,19 +84,12 @@
           <li role="separator" class="divider"></li>
 
           <% if Rails.configuration.try(:batch_loader_aware) %>
-            <li><a id="search-target-item-loader-batch" 
+            <li><a id="search-target-item-loader-batch-stack" 
                    href="#" 
-                   title="Search loader batches" 
-                   data-help="loader-batch-search-help" 
-                   data-examples="loader-batch-search-examples"
-                >Loader batches</a>
-            </li>
-            <li><a id="search-target-item-loader-name" 
-                   href="#" 
-                   title="Search loader names" 
-                   data-help="loader-name-search-help" 
-                   data-examples="loader-name-search-examples"
-                >Loader names</a>
+                   title="Search loader batches and retrieve batches, reviews, review periods, reviewers in a stack" 
+                   data-help="loader-batch-stack-search-help" 
+                   data-examples="loader-batch-stack-search-examples"
+                >Batch stacks</a>
             </li>
 
             <li><a id="search-target-item-batch-review" 
@@ -123,6 +116,15 @@
                    data-advanced="bulk-processing-logs-search-advanced" 
                 >Bulk processing logs</a>
             </li>
+
+            <li><a id="search-target-item-loader-batch" 
+                   href="#" 
+                   title="Search loader batches" 
+                   data-help="loader-batch-search-help" 
+                   data-examples="loader-batch-search-examples"
+                >Loader batches</a>
+            </li>
+
             <li role="separator" class="divider"></li>
           <% end %>
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 26-Mar-2025
+  :jira_id: '5088'
+  :description: |-
+    Loader Search Targets: change order of target options to relect use
 - :date: 25-Mar-2025
   :jira_id: '31'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.24
+appversion=4.1.6.25


### PR DESCRIPTION


## Description
Minor change to order of Search Targets

## Type of change
- [x] Small non-breaking change

## How to Test
Drop down search target list


## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
