### PR TITLE
Draft editor permission for unpub tab

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -251,7 +251,8 @@ class InstancesController < ApplicationController
     offer = %w[tab_show_1 tab_edit tab_edit_notes]
 
     if @instance.standalone?
-      offer << @current_user.profile_v2_context.unpublished_citation_tab(@instance)
+      offer << "tab_unpublished_citation"
+      offer << "tab_unpublished_citation_for_profile_v2" if @instance.draft? && @instance.secondary_reference?
       offer << "tab_synonymy"
       offer << "tab_synonymy_for_profile_v2" if @instance.draft? && @instance.secondary_reference?
       offer << "tab_classification"

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -112,7 +112,7 @@ class Ability
       instance.draft?
     end
     can :copy_as_draft_secondary_reference, Instance
-    can :synonymy_as_draft_secondary_reference, Instance do |instance|
+    can [:synonymy_as_draft_secondary_reference, :unpublished_citation_as_draft_secondary_reference], Instance do |instance|
       instance.draft? && user.product_from_roles.present? && instance.reference.products.pluck(:name).any?(user.product_from_roles.name)
     end
     can "instances", "tab_copy_to_new_profile_v2"
@@ -120,6 +120,9 @@ class Ability
     can "instances", "tab_synonymy_for_profile_v2"
     can "instances", "typeahead_for_synonymy"
     can "instances", "create_cites_and_cited_by"
+    can "instances", "create_cited_by"
+    can "instances", "tab_unpublished_citation_for_profile_v2"
+    can "names/typeaheads/for_unpub_cit", "index"
   end
 
   def profile_editor

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -89,7 +89,7 @@
   <% end %>
 
   <% if @tabs_to_offer.include?('tab_unpublished_citation_for_profile_v2') %>
-    <% if can? 'instances', 'tab_unpublished_citation_for_profile_v2' %>
+    <% if can? :copy_as_draft_secondary_reference, @instance %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                           last: false,
                                           this_tab: 'tab_unpublished_citation_for_profile_v2',

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -89,7 +89,7 @@
   <% end %>
 
   <% if @tabs_to_offer.include?('tab_unpublished_citation_for_profile_v2') %>
-    <% if can? :copy_as_draft_secondary_reference, @instance %>
+    <% if can? :unpublished_citation_as_draft_secondary_reference, @instance %>
       <%= render partial: 'instances/tabs/tab', locals: {first: false,
                                           last: false,
                                           this_tab: 'tab_unpublished_citation_for_profile_v2',

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -3,6 +3,11 @@
   :description: |-
     Author: Check field lengths before saving to database
 - :date: 27-Mar-2025
+  :jira_id: '34'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project draft-editor permissions: Show unpub tab for draft and secondary reference instance
+- :date: 27-Mar-2025
   :jira_id: '33'
   :jira_project: FLOR
   :description: |-

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,12 +1,12 @@
 - :date: 28-Mar-2025
-  :jira_id: '5368'
-  :description: |-
-    Author: Check field lengths before saving to database
-- :date: 27-Mar-2025
   :jira_id: '34'
   :jira_project: FLOR
   :description: |-
     Foa Project draft-editor permissions: Show unpub tab for draft and secondary reference instance
+- :date: 28-Mar-2025
+  :jira_id: '5368'
+  :description: |-
+    Author: Check field lengths before saving to database
 - :date: 27-Mar-2025
   :jira_id: '33'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.28
+appversion=4.1.6.29

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -187,6 +187,18 @@ RSpec.describe Ability, type: :model do
       expect(subject.can?("instances", "copy_for_profile_v2")).to eq true
     end
 
+    it 'can access instances create_cited_by' do
+      expect(subject.can?("instances", "create_cited_by")).to eq true
+    end
+
+    it 'can access instances tab_unpublished_citation_for_profile_v2' do
+      expect(subject.can?("instances", "tab_unpublished_citation_for_profile_v2")).to eq true
+    end
+
+    it 'can access names/typeaheads/for_unpub_cit index' do
+      expect(subject.can?("names/typeaheads/for_unpub_cit", "index")).to eq true
+    end
+
     it "allows copying as draft secondary reference" do
       instance = FactoryBot.create(:instance, draft: false)
       expect(subject.can?(:copy_as_draft_secondary_reference, instance)).to eq true


### PR DESCRIPTION
## Description
Adding permissions for draft-editor to access unpub tab for draft instances

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-34

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
