### PR TITLE
NSL-5368: Author: Check field lengths before saving to database

### DIFF
--- a/app/models/concerns/author_validations.rb
+++ b/app/models/concerns/author_validations.rb
@@ -8,6 +8,8 @@ module AuthorValidations
               presence: { if: -> { abbrev.blank? },
                           unless: -> { duplicate_of_id.present? },
                           message: "can't be blank if abbrev is blank." }
+    validates :name, length: { maximum: 1000,
+                                 too_long: "%{count} characters is the maximum allowed" }
     validates :abbrev,
               presence: { if: -> { name.blank? },
                           unless: -> { duplicate_of_id.present? },
@@ -35,11 +37,17 @@ module AuthorValidations
               uniqueness: { unless: -> { abbrev.blank? },
                             case_sensitive: false,
                             message: "has already been used" }
+    validates :abbrev, length: { maximum: 100,
+                                 too_long: "%{count} characters is the maximum allowed" }
     validates_exclusion_of :duplicate_of_id,
                            in: ->(author) { [author.id] },
                            allow_blank: true,
                            message: "and master cannot be the same record"
     validate :master_has_abbrev_if_needed, on: :update
+    validates :full_name, length: { maximum: 255,
+                                 too_long: "%{count} characters is the maximum allowed" }
+    validates :notes, length: { maximum: 1000,
+                                too_long: "%{count} characters is the maximum allowed" }
   end
 
   def master_has_abbrev_if_needed

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 28-Mar-2025
+  :jira_id: '5368'
+  :description: |-
+    Author: Check field lengths before saving to database
 - :date: 27-Mar-2025
   :jira_id: '33'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.27
+appversion=4.1.6.28

--- a/test/models/author/validations/length/abbrev_too_long_test.rb
+++ b/test/models/author/validations/length/abbrev_too_long_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2025 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single author model test.
+class AuthorAbbrevTooLongTest < ActiveSupport::TestCase
+
+  def setup
+    @max = 100
+  end
+
+  test "author abbrev too long test" do
+    author = authors(:joe)
+    assert author.valid?, "Author should be valid to start"
+    author.abbrev = "X" * @max 
+    assert author.valid?, "Author should be valid with abbrev #{@max} chars long"
+    assert author.save!, "Author should save"
+    author.abbrev = "X" * (@max + 1)
+    assert_not author.valid?, "Author should not be valid with abbrev #{@max + 1} chars long"
+  end
+end

--- a/test/models/author/validations/length/full_name_too_long_test.rb
+++ b/test/models/author/validations/length/full_name_too_long_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2025 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single author model test.
+class AuthorFullNameTooLongTest < ActiveSupport::TestCase
+
+  def setup
+    @max = 255
+  end
+
+  test "author full name too long test" do
+    author = authors(:joe)
+    assert author.valid?, "Author should be valid to start"
+    author.full_name = "X" * @max 
+    assert author.valid?, "Author should be valid with full name #{@max} chars long"
+    assert author.save!, "Author should save"
+    author.full_name = "X" * (@max + 1)
+    assert_not author.valid?, "Author should not be valid with full name #{@max + 1} chars long"
+  end
+end

--- a/test/models/author/validations/length/name_too_long_test.rb
+++ b/test/models/author/validations/length/name_too_long_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2025 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single author model test.
+class AuthorNameTooLongTest < ActiveSupport::TestCase
+
+  def setup
+    @max = 1000
+  end
+
+  test "author name too long test" do
+    author = authors(:joe)
+    assert author.valid?, "Author should be valid to start"
+    author.name = "X" * @max 
+    assert author.valid?, "Author should be valid with name #{@max} chars long"
+    assert author.save!, "Author should save"
+    author.name = "X" * (@max + 1)
+    assert_not author.valid?, "Author should not be valid with name #{@max + 1} chars long"
+  end
+end

--- a/test/models/author/validations/length/notes_too_long_test.rb
+++ b/test/models/author/validations/length/notes_too_long_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2025 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single author model test.
+class AuthorNotesTooLongTest < ActiveSupport::TestCase
+
+  def setup
+    @max = 1000
+  end
+
+  test "author notes too long test" do
+    author = authors(:joe)
+    assert author.valid?, "Author should be valid to start"
+    author.notes = "X" * @max 
+    assert author.valid?, "Author should be valid with notes #{@max} chars long"
+    assert author.save!, "Author should save"
+    author.notes = "X" * (@max + 1)
+    assert_not author.valid?, "Author should not be valid with notes #{@max + 1} chars long"
+  end
+end


### PR DESCRIPTION
## Description
Add length validations to Author model via a concern.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Enter over-length data in name, abbrev, full_name, and notes.

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
