### PR TITLE
Stop calling focus() on null object

### DIFF
--- a/app/javascript/details/focus_on_field.js
+++ b/app/javascript/details/focus_on_field.js
@@ -4,9 +4,7 @@
 
   focusOnField = function(field_id) {
     let field = document.getElementById(field_id);
-      //if (field) {
-        field.focus()
-      //};
+      field?.focus()
   };
   window.focusOnField = focusOnField;
 

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.30
+appversion=4.1.6.31


### PR DESCRIPTION
## Description
Stop calling focus() on null objects.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Click around on detail tabs watching for errors in JS Console.


## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [ ] Updated changelog - not needed
