### PR TITLE
Draft editor permission for deleting draft instance

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -248,7 +248,7 @@ class InstancesController < ApplicationController
 
   # Different types of instances require different sets of tabs.
   def tabs_to_offer
-    offer = %w[tab_show_1 tab_edit tab_edit_notes]
+    offer = %w[tab_show_1 tab_edit tab_edit_profile_v2 tab_edit_notes]
 
     if @instance.standalone?
       offer << "tab_unpublished_citation"

--- a/app/helpers/instances_helper.rb
+++ b/app/helpers/instances_helper.rb
@@ -59,7 +59,7 @@ module InstancesHelper
   end
 
 
-  ALLOWED_TABS = %w[tab_show_1 tab_edit tab_edit_notes tab_comments].freeze
+  ALLOWED_TABS = %w[tab_show_1 tab_edit tab_edit_profile_v2 tab_edit_notes tab_comments].freeze
   ALLOWED_TABS_TO_OFFER = %w[tab_profile_details tab_edit_profile tab_profile_v2 tab_copy_to_new_profile_v2 tab_batch_loader] .freeze
   def tab_for_instance_type(tab, row_type)
     sanitized_allowed_tabs_to_offer_tab = tab.presence_in(ALLOWED_TABS_TO_OFFER) if @tabs_to_offer.include?(tab)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -107,13 +107,11 @@ class Ability
   end
 
   def draft_editor(user)
-    can [:update, :destroy], Instance do |instance|
-      instance.draft?
-    end
     can :create_with_product_reference, Instance
     can :copy_as_draft_secondary_reference, Instance
     can [
-      :edit,
+      :destroy,
+      :manage_draft_secondary_reference,
       :synonymy_as_draft_secondary_reference,
       :unpublished_citation_as_draft_secondary_reference
     ], Instance do |instance|
@@ -121,6 +119,7 @@ class Ability
     end
     can "instances", "create"
     can "instances", "tab_edit"
+    can "instances", "tab_edit_profile_v2"
     can "instances", "update"
     can "instances", "destroy"
     can "instances", "tab_copy_to_new_profile_v2"

--- a/app/models/profile/profile_item.rb
+++ b/app/models/profile/profile_item.rb
@@ -49,7 +49,7 @@ module Profile
 
     belongs_to :instance
     belongs_to :product_item_config, class_name: 'Profile::ProductItemConfig', foreign_key: 'product_item_config_id'
-    belongs_to :profile_text, class_name: 'Profile::ProfileText', foreign_key: 'profile_text_id', dependent: :destroy
+    belongs_to :profile_text, class_name: 'Profile::ProfileText', foreign_key: 'profile_text_id'
     belongs_to :profile_object_type,
               class_name: 'Profile::ProfileObjectType',
               primary_key: 'rdf_id',
@@ -76,12 +76,24 @@ module Profile
 
     default_scope { includes(:product_item_config).order("product_item_config.sort_order ASC") }
 
+    after_destroy :conditionally_destroy_profile_text
+
     def fresh?
       created_at > 1.hour.ago
     end
 
     def allow_delete?
       self.sourced_in_profile_items.blank?
+    end
+
+    def fact?
+      statement_type == "fact"
+    end
+
+    private
+
+    def conditionally_destroy_profile_text
+      profile_text.destroy if fact?
     end
   end
 end

--- a/app/views/instances/_delete_widgets.html.erb
+++ b/app/views/instances/_delete_widgets.html.erb
@@ -13,6 +13,16 @@
     </div>
   <% end %>
 
+  <% if @instance.profile_items.present? %>
+    <div class="text-warning">Note: Deleting this instance will also delete the following profile items:
+      <ul>
+        <% @instance.profile_items.each do |profile_item| %>
+          <li><%= profile_item.product_item_config.display_html %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <% confirm_delete_link = link_to("Confirm delete",
                                    instance_path(@instance.id),
                                    id: "confirm-delete-link",
@@ -40,6 +50,6 @@
   -%>
   <div class="actions"> <%= delete_link.html_safe %> </div>
   <div class="width-100-percent"> <%= confirm_or_cancel_element.html_safe %> </div>
- 
+
 <div id="instance-delete-info-message-container" class="message-container"></div>
 <div id="instance-delete-error-message-container" class="error-container message-container"></div>

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -18,18 +18,28 @@
     <% end %>
   <% end %>
 
-  <% if @tabs_to_offer.include?('tab_edit') %>
-    <% if can? :edit, @instance %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: false,
-                                        this_tab: 'tab_edit',
-                                        link_text: "Edit".html_safe,
-                                        link_id: 'instance-edit-tab',
-                                        link_title: 'Edit',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: '',
-                                        next_tab: '' } %>
-    <% end %>
+  <% if @tabs_to_offer.include?('tab_edit') && can?(:edit, @instance)%>
+    <%= render partial: 'instances/tabs/tab', locals: {first: false,
+                                      last: false,
+                                      this_tab: 'tab_edit',
+                                      link_text: "Edit".html_safe,
+                                      link_id: 'instance-edit-tab',
+                                      link_title: 'Edit',
+                                      tab_index: increment_tab_index,
+                                      prev_tab: '',
+                                      next_tab: '' } %>
+  <% end %>
+
+  <% if @tabs_to_offer.include?('tab_edit_profile_v2') && can?(:manage_draft_secondary_reference, @instance) %>
+    <%= render partial: 'instances/tabs/tab', locals: {first: false,
+                                      last: false,
+                                      this_tab: 'tab_edit_profile_v2',
+                                      link_text: "Edit".html_safe,
+                                      link_id: 'instance-edit-tab-profile-v2-tab',
+                                      link_title: 'Edit',
+                                      tab_index: increment_tab_index,
+                                      prev_tab: '',
+                                      next_tab: '' } %>
   <% end %>
 
   <% if @tabs_to_offer.include?('tab_edit_notes') %>

--- a/app/views/instances/tabs/_tab_edit_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_edit_profile_v2.html.erb
@@ -1,0 +1,22 @@
+<% if can? :manage_draft_secondary_reference, @instance %>
+  <% increment_tab_index(0) %>
+
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container-0" class="error-container"></div>
+  <div id="search-result-details-error-message-container-1" class="error-container"></div>
+  <div id="search-result-details-error-message-container-2" class="error-container"></div>
+  <div id="search-result-details-error-message-container-3" class="error-container"></div>
+
+  <%= render partial: "instances/tabs/show_standalone"%>
+
+  <%= divider %>
+  <% if @instance.allow_delete? %>
+    <%= render 'instances/delete_widgets' %>
+  <% else %>
+    <%= render 'instances/widgets/no_delete_reasons' %>
+  <% end %>
+
+<% else %>
+  <%= render partial: "instances/tabs/tab_empty" %>
+<% end %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 09-Apr-2025
+  :jira_id: '69'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project draft-editor permissions: Permissions for draft-editor to delete a draft instance via edit tab
 - :date: 03-Apr-2025
   :jira_id: '48'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.32
+appversion=4.1.6.33

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -207,14 +207,6 @@ RSpec.describe Ability, type: :model do
     context "when the instance is a draft" do
       let(:instance) { FactoryBot.create(:instance, draft: true) }
 
-      it "allows updating the instance" do
-        expect(subject.can?(:update, instance)).to eq true
-      end
-
-      it "allows destroying the instance" do
-        expect(subject.can?(:destroy, instance)).to eq true
-      end
-
       context "when instance product reference is the same as the user's product" do
         before do
           product = FactoryBot.create(:product)
@@ -222,16 +214,20 @@ RSpec.describe Ability, type: :model do
           allow(session_user).to receive(:product_from_roles).and_return(product)
         end
 
-        it "allows synonymy as draft secondary reference" do
-          expect(subject.can?(:synonymy_as_draft_secondary_reference, instance)).to eq true
+        it "allows destroying the instance" do
+          expect(subject.can?(:destroy, instance)).to eq true
         end
 
-        it "allows editing the instance" do
-          expect(subject.can?(:edit, instance)).to eq true
+        it "allows synonymy as draft secondary reference" do
+          expect(subject.can?(:synonymy_as_draft_secondary_reference, instance)).to eq true
         end
       end
 
       context "when instance product reference is not the same as the user's product" do
+        it "does not allows destroying the instance" do
+          expect(subject.can?(:destroy, instance)).to eq false
+        end
+
         it "does not allow synonymy as draft secondary reference" do
           allow(instance).to receive(:reference).and_return(FactoryBot.create(:reference))
           allow(session_user).to receive(:product_from_roles).and_return(FactoryBot.create(:product))

--- a/spec/models/instance_spec.rb
+++ b/spec/models/instance_spec.rb
@@ -1,6 +1,57 @@
 require 'rails_helper'
 
 RSpec.describe Instance, type: :model do
+  describe "#delete_as_user" do
+    let(:instance_type) { FactoryBot.create(:instance_type, secondary_instance: false)}
+    let(:instance) { FactoryBot.create(:instance, instance_type: instance_type) }
+    let(:username) { "test_user" }
+
+    context "when deletion is successful" do
+      before do
+        allow(Instance::AsServices).to receive(:delete).with(instance.id).and_return(true)
+        allow(instance).to receive(:cleanup_records)
+      end
+
+      it "updates the updated_by field with the username" do
+        expect(instance).to receive(:update_attribute).with(:updated_by, username)
+        instance.delete_as_user(username)
+      end
+
+      it "calls cleanup_records" do
+        expect(instance).to receive(:cleanup_records)
+        instance.delete_as_user(username)
+      end
+    end
+
+    context "when deletion fails" do
+      before do
+        allow(Instance::AsServices).to receive(:delete).with(instance.id).and_return(false)
+        allow(instance).to receive(:cleanup_records)
+      end
+
+      it "does not call cleanup_records" do
+        expect(instance).not_to receive(:cleanup_records)
+        instance.delete_as_user(username)
+      end
+    end
+
+    context "when an exception occurs" do
+      before do
+        allow(Instance::AsServices).to receive(:delete).with(instance.id).and_raise(StandardError, "Deletion failed")
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it "logs the exception" do
+        expect(Rails.logger).to receive(:error).with(/delete_as_user exception: Deletion failed/)
+        expect { instance.delete_as_user(username) }.to raise_error(StandardError, "Deletion failed")
+      end
+
+      it "raises the exception" do
+        expect { instance.delete_as_user(username) }.to raise_error(StandardError, "Deletion failed")
+      end
+    end
+  end
+
   describe "#secondary_reference?" do
     let(:instance) { FactoryBot.create(:instance, instance_type: instance_type) }
 

--- a/spec/views/instances/tabs/tab_edit_profile_v2_spec.rb
+++ b/spec/views/instances/tabs/tab_edit_profile_v2_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe "instances/tabs/_tab_edit_profile_v2.html.erb", type: :view do
+  let(:language) { FactoryBot.create(:language, iso6391code: "en", iso6393code: "eng") }
+  let(:reference) { FactoryBot.create(:reference, language: language) }
+  let(:instance_type) { FactoryBot.create(:instance_type, secondary_instance: false)}
+  let(:instance) { FactoryBot.create(:instance, reference: reference) }
+
+  before do
+    assign(:instance, instance)
+    allow(view).to receive(:increment_tab_index).and_return(0)
+    allow(view).to receive(:divider).and_return("<hr>".html_safe)
+  end
+
+  context "when the user can manage draft secondary references" do
+    before do
+      allow(view).to receive(:can?).with(:manage_draft_secondary_reference, instance).and_return(true)
+      allow(ShardConfig).to receive(:classification_tree_key).and_return("some_value")
+      allow(ShardConfig).to receive(:name_space).and_return("some_value")
+      allow_any_instance_of(Name).to receive(:accepted_concept?).and_return(false)
+      allow_any_instance_of(Name).to receive(:excluded_concept?).and_return(false)
+      allow(Tree).to receive_message_chain(:accepted, :first, :current_tree_version).and_return(double("TreeVersion", id: 1, name_in_version: "Test"))
+    end
+
+    context "when the instance allows deletion" do
+      before do
+        allow(instance).to receive(:allow_delete?).and_return(true)
+      end
+
+      it "renders the delete widgets" do
+        render
+        expect(rendered).to render_template(partial: "instances/tabs/_show_standalone")
+        expect(rendered).to render_template("instances/_delete_widgets")
+        expect(rendered).not_to render_template("instances/widgets/_no_delete_reasons")
+      end
+    end
+
+    context "when the instance does not allow deletion" do
+      before do
+        allow(instance).to receive(:allow_delete?).and_return(false)
+      end
+
+      it "renders the no delete reasons widget" do
+        render
+        expect(rendered).to render_template(partial: "instances/tabs/_show_standalone")
+        expect(rendered).to render_template("instances/widgets/_no_delete_reasons")
+        expect(rendered).not_to render_template("delete_widgets")
+      end
+    end
+  end
+
+  context "when the user cannot manage draft secondary references" do
+    before do
+      allow(view).to receive(:can?).with(:manage_draft_secondary_reference, instance).and_return(false)
+    end
+
+    it "does not render the edit tab" do
+      render
+      expect(rendered).not_to have_selector("a#instance-edit-tab-profile-v2-tab", text: "Edit")
+    end
+  end
+end

--- a/spec/views/names/tabs/tab_instances_profile_v2_partial_spec.rb
+++ b/spec/views/names/tabs/tab_instances_profile_v2_partial_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "names/tabs/_tab_instances_profile_v2.html.erb", type: :view do
   let(:name) { FactoryBot.create(:name) }
   let(:instance) { FactoryBot.create(:instance, name: name) }
   let(:product) { FactoryBot.create(:product, name: "FOA") }
-  let(:reference) { FactoryBot.create(:reference) }
+  let!(:language) { FactoryBot.create(:language, iso6391code: "en", iso6393code: "eng") }
+  let!(:reference) { FactoryBot.create(:reference, language: language) }
   let!(:instance_type) { FactoryBot.create(:instance_type, name: "secondary reference") }
 
   before do

--- a/test/controllers/profile_items_controller_test.rb
+++ b/test/controllers/profile_items_controller_test.rb
@@ -32,7 +32,7 @@ class ProfileItemsControllerTest < ActionController::TestCase
     end
     assert_response :success
     assert_equal "Deleted profile item.", assigns(:message)
-  end
+end
 
   test "should set instance variables" do
     delete :destroy, params: { id: @profile_item.id }, session: @session, xhr: true

--- a/test/factories/language.rb
+++ b/test/factories/language.rb
@@ -17,8 +17,8 @@
 FactoryBot.define do
   factory :language do
     lock_version { 1 }
-    sequence(:iso6391code) {|n| "#{n}" }
-    sequence(:iso6393code) {|n| "#{n}" }
+    sequence(:iso6391code) {|n| n.to_s.rjust(2, '0') }
+    sequence(:iso6393code) {|n| n.to_s.rjust(3, '0') }
     sequence(:name) {|n| "Language Name #{n}" }
   end
 end


### PR DESCRIPTION
## Description
Draft editor permission for deleting a draft instance

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-69

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
