### PR TITLE
FLOR-69: Don't offer instance delete button if there are profile items

### DIFF
--- a/app/views/instances/widgets/_no_delete_reasons.html.erb
+++ b/app/views/instances/widgets/_no_delete_reasons.html.erb
@@ -35,7 +35,11 @@
     <%= link_to("See instance and children".html_safe,
                 search_path(query_string: "id: #{@instance.id},#{@instance.children.collect {|i| i.id}.join(',')}", query_target: 'instances'),
                 title: "Query the instances.") %>
-    <br> 
+    <br>
+  <% end %>
+  <% if @instance.profile_items.present? %>
+    <span title="See the <%= current_registered_user.available_product_from_roles&.name %> Profile tab."><%= "#{current_registered_user.available_product_from_roles&.name} Profile items: #{@instance.profile_items.size} (see the 'Profile' tab)" %></span>
+    <br>
   <% end %>
 
   <%# Code should be cleaned up once loader tables are in all databases %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,8 +1,13 @@
+- :date: 10-Apr-2025
+  :jira_id: '69'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project draft-editor permissions: Don't offer the delete button when the instance has profile items
 - :date: 09-Apr-2025
   :jira_id: '72'
   :jira_project: FLOR
   :description: |-
-    Foa Project permissions: add a <code>Product_Role</code> table and re-arrange the associations between <code>Users</code>, <code>Roles</code>, and <code>User_Product_Role</code> 
+    Foa Project permissions: add a <code>Product_Role</code> table and re-arrange the associations between <code>Users</code>, <code>Roles</code>, and <code>User_Product_Role</code>
 - :date: 09-Apr-2025
   :jira_id: '69'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.6.34
+appversion=4.1.6.35

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Author, type: :model do
   describe '#referenced_in_any_instance?' do
     let(:author) { FactoryBot.create(:author) }
-    let(:reference) { FactoryBot.create(:reference, author: author) }
+    let!(:language) { FactoryBot.create(:language, iso6391code: "en", iso6393code: "eng") }
+    let!(:reference) { FactoryBot.create(:reference, language: language, author: author) }
 
     context 'when the author has references associated with instances' do
       before do

--- a/spec/models/instance/as_copier_spec.rb
+++ b/spec/models/instance/as_copier_spec.rb
@@ -14,16 +14,17 @@ RSpec.describe Instance::AsCopier, type: :model do
       let(:params) { {} }
       let(:username) { "username" }
 
-      let(:reference) { FactoryBot.create(:reference) }
+      let!(:language) { FactoryBot.create(:language, iso6391code: "en", iso6393code: "eng") }
+      let!(:reference) { FactoryBot.create(:reference, language: language) }
       let(:name_category) { FactoryBot.create(:name_category, name: "other") }
       let(:name_type) { FactoryBot.create(:name_type, cultivar: false, name_category: name_category) }
       let(:name) { FactoryBot.create(:name, name_type: name_type) }
-      
+
       let(:instance_type) { FactoryBot.create(:instance_type, primary_instance: false)}
       let(:instance) { FactoryBot.create(:instance, reference: reference, instance_type_id: instance_type.id) }
-      
+
       let(:instance_citation) { FactoryBot.create(:instance, :synonym_instance, name: name, reference: reference) }
-      
+
       context "with invalid parameters" do
         it "raises an error for blank reference_id" do
           expect{subject.copy_with_product_reference(params, username)}.to raise_error(RuntimeError, "Need a reference")

--- a/test/factories/language.rb
+++ b/test/factories/language.rb
@@ -17,8 +17,20 @@
 FactoryBot.define do
   factory :language do
     lock_version { 1 }
-    sequence(:iso6391code) {|n| n.to_s.rjust(2, '0') }
-    sequence(:iso6393code) {|n| n.to_s.rjust(3, '0') }
+    sequence(:iso6391code) do |n|
+      # Generate a 2-letter code based on the sequence number
+      letters = ('A'..'Z').to_a
+      first, second = letters[n / 26], letters[n % 26]
+      "#{first}#{second}"
+    end
+    sequence(:iso6393code) do |n|
+      # Generate a 3-letter code based on the sequence number
+      letters = ('A'..'Z').to_a
+      a = letters[(n / (26 * 26)) % 26]
+      b = letters[(n / 26) % 26]
+      c = letters[n % 26]
+      "#{a}#{b}#{c}"
+    end
     sequence(:name) {|n| "Language Name #{n}" }
   end
 end


### PR DESCRIPTION
## Description
Draft editor: Only offer the delete instance button if there are no profile items attached to the instance.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-69

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
