### PR TITLE
Draft editor permission for editing relationship instance

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -117,6 +117,11 @@ class Ability
     ], Instance do |instance|
       instance.draft? && instance.reference.products.pluck(:name).any?(user.product_from_roles&.name.to_s)
     end
+    can :edit, Instance do |instance|
+      instance.relationship? &&
+      instance.this_is_cited_by.draft? &&
+      instance.this_is_cited_by.reference.products.pluck(:name).any?(user.product_from_roles&.name.to_s)
+    end
     can "instances", "create"
     can "instances", "tab_edit"
     can "instances", "tab_edit_profile_v2"

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 15-Apr-2025
+  :jira_id: '70'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project draft-editor permissions: Allow editing of a relationship instance
 - :date: 14-Apr-2025
   :jira_id: '54'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.0
+appversion=4.1.7.1


### PR DESCRIPTION
## Description
Adding permissions for draft-editor to edit a relationship instance where the cited by is draft and is associated to a product that the user belongs to.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
As draft editor, access the relationship instance, you should see an edit tab and be able to update the instance fields.

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-70

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
