### PR TITLE
NSL-5386: Author abbreviation: Allow for up to 150 characters

### DIFF
--- a/app/models/concerns/author_validations.rb
+++ b/app/models/concerns/author_validations.rb
@@ -37,17 +37,17 @@ module AuthorValidations
               uniqueness: { unless: -> { abbrev.blank? },
                             case_sensitive: false,
                             message: "has already been used" }
-    validates :abbrev, length: { maximum: 100,
-                                 too_long: "%{count} characters is the maximum allowed" }
+    validates :abbrev, length: { maximum: 150,
+                                 too_long: "- %{count} characters is the maximum allowed" }
     validates_exclusion_of :duplicate_of_id,
                            in: ->(author) { [author.id] },
                            allow_blank: true,
                            message: "and master cannot be the same record"
     validate :master_has_abbrev_if_needed, on: :update
     validates :full_name, length: { maximum: 255,
-                                 too_long: "%{count} characters is the maximum allowed" }
+                                 too_long: "- %{count} characters is the maximum allowed" }
     validates :notes, length: { maximum: 1000,
-                                too_long: "%{count} characters is the maximum allowed" }
+                                too_long: "- %{count} characters is the maximum allowed" }
   end
 
   def master_has_abbrev_if_needed

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 15-Apr-2025
+  :jira_id: '5386'
+  :description: |-
+    Author abbreviation: Allow for up to 150 characters
+- :date: 15-Apr-2025
   :jira_id: '54'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.2
+appversion=4.1.7.3

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1169,7 +1169,7 @@ SET default_table_access_method = heap;
 CREATE TABLE public.author (
     id bigint DEFAULT nextval('public.nsl_global_seq'::regclass) NOT NULL,
     lock_version bigint DEFAULT 0 NOT NULL,
-    abbrev character varying(100),
+    abbrev text,
     created_at timestamp with time zone NOT NULL,
     created_by character varying(255) NOT NULL,
     date_range character varying(50),
@@ -11047,6 +11047,10 @@ ALTER TABLE ONLY public.product_role
 ALTER TABLE ONLY public.user_product_role
     ADD CONSTRAINT upr_users_fk FOREIGN KEY (user_id) REFERENCES public.users(id);
 
+
+ALTER TABLE only public.author
+ADD CONSTRAINT abbrev_length_check
+CHECK (char_length(abbrev) <= 150);
 
 --
 -- PostgreSQL database dump complete

--- a/test/models/author/validations/length/abbrev_too_long_test.rb
+++ b/test/models/author/validations/length/abbrev_too_long_test.rb
@@ -22,7 +22,7 @@ require "test_helper"
 class AuthorAbbrevTooLongTest < ActiveSupport::TestCase
 
   def setup
-    @max = 100
+    @max = 150
   end
 
   test "author abbrev too long test" do


### PR DESCRIPTION
## Description
Set length validation to allow for 150 chars to match the DDL change.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Enter values into author abbreviation field.

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
