### PR TITLE
Add ability for draft-editor to copy profile items for an instance

### DIFF
--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -105,6 +105,8 @@ class Instance < ActiveRecord::Base
 
   has_many :tree_join_v
 
+  attr_accessor :copy_profile_items
+
   def self.to_csv
     attributes = %w[id]
     headings = ["Instance ID", "Name ID", "Full Name", "Reference ID",

--- a/app/models/instance/as_copier.rb
+++ b/app/models/instance/as_copier.rb
@@ -117,6 +117,19 @@ class Instance::AsCopier < Instance
         new_citer.created_by = new_citer.updated_by = as_username
         new_citer.save!
       end
+      if copy_profile_items
+        self.profile_items.each do |profile_item|
+          new_profile_item = profile_item.dup
+          new_profile_item.instance_id = new.id
+          new_profile_item.source_profile_item_id = profile_item.id if profile_item.fact?
+          new_profile_item.is_draft = true
+          new_profile_item.statement_type = "link"
+          new_profile_item.source_id = nil
+          new_profile_item.source_id_string = nil
+          new_profile_item.source_system = nil
+          new_profile_item.save!
+        end
+      end
     end
     new
   end

--- a/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
@@ -46,7 +46,17 @@
     <% if Rails.configuration.try("draft_instances")  %>
       <%= f.hidden_field :draft, value: true %>
     <% end %>
-
+    <% if @instance.profile_items.present? %>
+      <label class="form-check-label">
+        <%= f.check_box(:copy_profile_items,{title: "Copy profile items"}) %>
+        Copy profile items:
+      </label>
+      <ul>
+        <% @instance.profile_items.includes(:product_item_config).each do |profile_item| %>
+          <li><%= profile_item.product_item_config.display_html %></li>
+        <% end %>
+      </ul>
+    <% end %>
     <br>
   <div class="width-100-percent">
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 17-Apr-2025
+  :jira_id: '53'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project draft-editor permissions: Offer to copy profile items of a standalone isntance
+- :date: 17-Apr-2025
   :jira_id: '5397'
   :description: |-
     Admin configuration page: display schema search path

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.4
+appversion=4.1.7.5


### PR DESCRIPTION


## Description
Add ability for draft-editor to copy profile items for an instance by offering them an option to copy profile items

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
As draft-editor user, select a draft standalone instance  to copy, if there's a profile item attached to it, there should be an option to copy the profile items as well.

## Tests
- [x] Unit tests
- [ ] Manual testing

## Related Issues
FLOR-53

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
