### PR TITLE
NSL-5376: Show unaffiliated users in batch stack listing

### DIFF
--- a/app/views/loader/batch/reviewers/tabs/_tab_details.html.erb
+++ b/app/views/loader/batch/reviewers/tabs/_tab_details.html.erb
@@ -18,7 +18,7 @@
                title:"Query the batch",class:'blue')} %>
 
 <%= render partial: 'detail_line',
-           locals: {info: @batch_reviewer.org.name, label: 'representing'} %>
+           locals: {info: @batch_reviewer.org.try('name'), label: 'representing'} %>
 <%= render partial: 'detail_line',
     locals: {label: 'query the stack',
              info: link_to("#{@batch_reviewer.batch_review.batch.name} Stack",

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 17-Apr-2025
+  :jira_id: '5376'
+  :description: |-
+    Show unaffiliated users in batch stack listing
+- :date: 17-Apr-2025
   :jira_id: '53'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.5
+appversion=4.1.7.6


### PR DESCRIPTION
## Description
Allow for batch reviewers not linked to an organisation.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


### New Dependencies
- [x] Also need to load an upgraded version of batch_stack_v into the database

## Tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
