### PR TITLE
NSL-5193:  Loader Name: Allow header records to have a remark_to_reviewer value and display it

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -1,8 +1,4 @@
 <% Rails.logger.debug("loader name record; record_type: #{search_result.record_type}") %>
-<% Rails.logger.debug("loader name record; record_type: #{search_result.record_type}") %>
-<% Rails.logger.debug("loader name record; record_type: #{search_result.record_type}") %>
-<% Rails.logger.debug("loader name record; record_type: #{search_result.record_type}") %>
-<% Rails.logger.debug("loader name record; record_type: #{search_result.record_type}") %>
 <%# There is complex logic here.
     The taxonomic note and distribution data from top-level records
     has to appear on separate lines _after_ any synonymy.
@@ -80,6 +76,15 @@
       <a class="review-show-details-link navigation-link takes-focus show-details" title='title' tabindex="<%= increment_tab_index(100) %>">
       <% if search_result.rank == 'family' %><%# is it a real record or not? %>
         <span class="review loader-name family"><%= "#{search_result.family}" %> </span>
+        <% unless search_result.remark_to_reviewers.blank? %>
+          <%# style text and link as well as we can %>
+          <span class="review loader-name remark-to-reviewers">
+            <%= search_result.remark_to_reviewers
+              .gsub(/<a/, "<a class='remark-to-reviewers'")
+              .sub(/(>)([^><]*$)/,'\1<span class="remark-to-reviewers">\2</span>')
+              .html_safe %>
+          </span>
+        <% end %>
       <% else %>
         <span class="review loader-name family"><%= "[#{search_result.family}]" %> </span>
       <% end %>

--- a/app/views/loader/names/tabs/forms/_form_for_heading.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_heading.html.erb
@@ -51,6 +51,11 @@
       <%= f.text_area :notes, class: 'form-control', title: "Enter notes", tabindex: increment_tab_index, autofocus: true %>
     </div>
 
+    <div class="form-group">
+      <label for="remark_to_reviewers">Remark to reviewers</label>
+      <%= f.text_area :remark_to_reviewers, class: 'form-control', title: "Enter remark to reviewers", tabindex: increment_tab_index %>
+    </div>
+
     <%= divider %>
 
     <div class="form-group align-right">

--- a/app/views/loader/names/tabs/heading_record_tabs/_tab_details.html.erb
+++ b/app/views/loader/names/tabs/heading_record_tabs/_tab_details.html.erb
@@ -18,6 +18,8 @@ Heading entry
 <%= render partial: 'detail_line', locals: {info: @loader_name.family, label: 'Family'} %>
 <%= render partial: 'detail_line', locals: {info: @loader_name.sort_key, label: 'Value for sorting'} %>
 <%= render partial: 'detail_line', locals: {info: @loader_name.rank, label: 'Rank'} %>
+<%= render partial: 'detail_line', locals: {info: @loader_name.notes, label: 'Notes'} %>
+<%= render partial: 'detail_line', locals: {info: @loader_name.remark_to_reviewers, label: 'Remark to Reviewers'} %>
 <br>
 
 <h5>Metadata</h5>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 29-Apr-2025
+  :jira_id: '5193'
+  :description: |-
+    Loader Name: Allow header records to have a <code>remark_to_reviewer</code> value and display it
 - :date: 17-Apr-2025
   :jira_id: '5376'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.6
+appversion=4.1.7.7


### PR DESCRIPTION


## Description
Use remark_to_reviewer as an alternative to in-batch-notes on header records.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Log in as a batch owner, add remark_to_reviewer values to family header records, view on Details tab, and then login as a reviewer and see the display of query results.


## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
