### PR TITLE
FLOR-55 Update typeahead sql query

### DIFF
--- a/app/models/instance/as_typeahead/for_product_item_config.rb
+++ b/app/models/instance/as_typeahead/for_product_item_config.rb
@@ -23,12 +23,14 @@ class Instance::AsTypeahead::ForProductItemConfig
     @instances = []
     return if product_item_config_id.blank?
 
-    @instances = Instance.find_by_sql(
-      [sql_string,
+    @instances = Instance.find_by_sql([
+      sql_string,
       product_item_config_id.to_i,
-       ActiveRecord::Base::sanitize_sql(term)]).collect do |i|
-         { value: display_value(i), id: i.id, profile_item_id: i.pid}
-       end
+      ActiveRecord::Base::sanitize_sql(term),
+      ActiveRecord::Base::sanitize_sql(term)]
+    ).collect do |i|
+      { value: display_value(i), id: i.id, profile_item_id: i.pid}
+    end
   end
 
   private
@@ -43,7 +45,7 @@ class Instance::AsTypeahead::ForProductItemConfig
       WHERE pic.id = ?
       AND i.draft = false
       AND pi.is_draft = false AND pi.statement_type = 'fact'
-      AND lower(r.citation) like lower('%'||?||'%') order by r.iso_publication_date"
+      AND (lower(r.citation) like lower('%'||?||'%') or lower(name.full_name) like lower('%'||?||'%')) order by r.iso_publication_date"
   end
 
   def display_value(i)

--- a/app/views/profile_items/index.turbo_stream.erb
+++ b/app/views/profile_items/index.turbo_stream.erb
@@ -14,14 +14,16 @@
       <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
       <% profile_text = profile_item.profile_text || Profile::ProfileText.new %>
 
-      <% unless profile_text.persisted? %>
-        <%= render partial: "profile_items/link_profile_item",
-          locals: {
-            product_item_config: product_item_config,
-            instance_id: @instance.id
-          }
-        %>
-      <% end %>
+      <div id="link-profile-item-container">
+        <% unless profile_text.persisted? %>
+          <%= render partial: "profile_items/link_profile_item",
+            locals: {
+              product_item_config: product_item_config,
+              instance_id: @instance.id
+            }
+          %>
+        <% end %>
+      </div>
 
       <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
         <% if profile_item.fact? %>

--- a/app/views/profile_texts/create.turbo_stream.erb
+++ b/app/views/profile_texts/create.turbo_stream.erb
@@ -17,6 +17,9 @@
   </div>
 <% end %>
 
+<%= turbo_stream.replace "link-profile-item-container" do %>
+<% end %>
+
 <%= turbo_stream.replace "profile_text_form_#{@profile_item.product_item_config.id}" do %>
   <div id="profile_text_form_<%= @profile_item.product_item_config.id %>" style="overflow: hidden; margin-bottom: 10px;overflow:hidden;" >
     <%= render partial: "profile_texts/form",

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 05-May-2025
+  :jira_id: '55'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Support for link profile item's typeahead to search for name's full name and UI fix for draft item.
 - :date: 02-May-2025
   :jira_id: '5193'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.10
+appversion=4.1.7.11

--- a/spec/models/instance/as_typeahead/for_product_item_config_spec.rb
+++ b/spec/models/instance/as_typeahead/for_product_item_config_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe Instance::AsTypeahead::ForProductItemConfig, type: :model do
           expect(result.instances).not_to be_empty
         end
 
+        it 'returns instances matching the full name' do
+          result = described_class.new(product_item_config_id: profile_item.product_item_config_id, term: instance.name.full_name)
+          expect(result.instances).not_to be_empty
+        end
+
         it "returns a correct array format" do
           result = described_class.new(product_item_config_id: profile_item.product_item_config_id, term: term)
           expect(result.instances).to all(include(:value, :id, :profile_item_id))


### PR DESCRIPTION
## Description
- Updated the link profile item's typeahead to be able to query by a name's full name.
- Fixed up the UI particularly on the link profile item checkbox to hide after creating a draft item.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-55

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
