### PR TITLE
Use f_unaccent to query for foreign chars in typeahead

### DIFF
--- a/app/models/instance/as_typeahead/for_product_item_config.rb
+++ b/app/models/instance/as_typeahead/for_product_item_config.rb
@@ -45,7 +45,8 @@ class Instance::AsTypeahead::ForProductItemConfig
       WHERE pic.id = ?
       AND i.draft = false
       AND pi.is_draft = false AND pi.statement_type = 'fact'
-      AND (lower(r.citation) like lower('%'||?||'%') or lower(name.full_name) like lower('%'||?||'%')) order by r.iso_publication_date"
+      AND (lower(r.citation) like lower('%'||?||'%') or lower(f_unaccent(name.full_name)) like lower('%'||?||'%')) order by r.iso_publication_date"
+
   end
 
   def display_value(i)

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.11
+appversion=4.1.7.12

--- a/spec/models/instance/as_typeahead/for_product_item_config_spec.rb
+++ b/spec/models/instance/as_typeahead/for_product_item_config_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe Instance::AsTypeahead::ForProductItemConfig, type: :model do
           expect(result.instances).not_to be_empty
         end
 
+        it 'returns instance matching the full name with foreign characters' do
+          name = instance.name
+          name.update(full_name: 'Céllerius')
+          result = described_class.new(product_item_config_id: profile_item.product_item_config_id, term: 'cellerius')
+          expect(result.instances).not_to be_empty
+        end
+
         it "returns a correct array format" do
           result = described_class.new(product_item_config_id: profile_item.product_item_config_id, term: term)
           expect(result.instances).to all(include(:value, :id, :profile_item_id))


### PR DESCRIPTION
## Description
Improved link profile item typeahead query to include foreign characters

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-55

## Pre-merge steps
- [x] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
