### PR TITLE
Feature/flor 49 profile editor editing author

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -68,7 +68,7 @@ class Ability
     end
     can [:create, :read], Author
     can :update, Author do |author|
-      !author.referenced_in_any_instance? && author.no_other_authored_names?
+      !author.referenced_in_any_instance? && author.no_other_authored_names? && author.names.blank?
     end
     can :manage, Profile::ProfileItem do |profile_item|
       profile_item.is_draft?

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 05-May-2025
+  :jira_id: '49'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Don't allow draft profile editor to edit an author with authored names
+- :date: 05-May-2025
   :jira_id: '55'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.12
+appversion=4.1.7.13

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Ability, type: :model do
       author = FactoryBot.create(:author)
       allow(author).to receive(:referenced_in_any_instance?).and_return(false)
       allow(author).to receive(:no_other_authored_names?).and_return(true)
+      allow(author).to receive_message_chain(:names, :blank?).and_return(true)
       expect(subject.can?(:update, author)).to eq true
     end
 
@@ -51,14 +52,22 @@ RSpec.describe Ability, type: :model do
       author = FactoryBot.create(:author)
       allow(author).to receive(:referenced_in_any_instance?).and_return(false)
       allow(author).to receive(:no_other_authored_names?).and_return(false)
+      allow(author).to receive_message_chain(:names, :blank?).and_return(true)
       expect(subject.can?(:update, author)).to eq false
 
       allow(author).to receive(:referenced_in_any_instance?).and_return(true)
       allow(author).to receive(:no_other_authored_names?).and_return(true)
+      allow(author).to receive_message_chain(:names, :blank?).and_return(true)
       expect(subject.can?(:update, author)).to eq false
 
       allow(author).to receive(:referenced_in_any_instance?).and_return(true)
       allow(author).to receive(:no_other_authored_names?).and_return(false)
+      allow(author).to receive_message_chain(:names, :blank?).and_return(true)
+      expect(subject.can?(:update, author)).to eq false
+
+      allow(author).to receive(:referenced_in_any_instance?).and_return(true)
+      allow(author).to receive(:no_other_authored_names?).and_return(true)
+      allow(author).to receive_message_chain(:names, :blank?).and_return(false)
       expect(subject.can?(:update, author)).to eq false
     end
 


### PR DESCRIPTION
## Description
Don't allow draft profile editor users to edit an author with authored names

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-49

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
