### PR TITLE
FLOR-53: Fixup copying of profile items of an instance

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -239,7 +239,8 @@ class InstancesController < ApplicationController
                                      :duplicate_instance_override,
                                      :draft,
                                      :parent_id,
-                                     :instance_id)
+                                     :instance_id,
+                                     :copy_profile_items)
   end
 
   def instance_name_params
@@ -362,6 +363,7 @@ class InstancesController < ApplicationController
 
   def find_instance_for_copy
     @current_instance_for_copy = Instance::AsCopier.find(params[:id])
+    @current_instance_for_copy.copy_profile_items = instance_params[:copy_profile_items] == "1"
     @current_instance_for_copy.multiple_primary_override = instance_params[:multiple_primary_override] == "1"
     @current_instance_for_copy.duplicate_instance_override = instance_params[:duplicate_instance_override] == "1"
   end

--- a/app/models/search/on_instance/base.rb
+++ b/app/models/search/on_instance/base.rb
@@ -86,7 +86,7 @@ class Search::OnInstance::Base
 
   def include_profile_items(instances)
     results = []
-    instances.each do |instance|
+    instances.includes(:profile_items).each do |instance|
       results << instance
       results << instance.profile_items.where(profile_object_rdf_id: "text")
       results.flatten!

--- a/app/views/instances/tabs/_tab_show_1.html.erb
+++ b/app/views/instances/tabs/_tab_show_1.html.erb
@@ -63,7 +63,7 @@
 <% if Rails.configuration.try('profile_v2_aware') && @instance.profile_items.present? %>
   <h5><%= user_profile_tab_name %> Profile</h5>
   <dl class="dl-horizontal">
-    <% @instance.profile_items.each do |profile_item| %>
+    <% @instance.profile_items.includes(:product_item_config, :profile_text).each do |profile_item| %>
       <dt><%= profile_item.product_item_config.try(:display_html) %></dt>
       <dd>
         <%= link_to(

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 07-May-2025
+  :jira_id: '53'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Fixup issue not able to profile items of an instance
+- :date: 07-May-2025
   :jira_id: '5395'
   :description: |-
     Loader Name: Show real family headers in vote query results

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.17
+appversion=4.1.7.18


### PR DESCRIPTION
## Description
Addressed issue with instance copying; ensure profile items are copied as well. And address some n+1 queries reported by bullet.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Select an instance with profile items to copy ->  tick the copy profile items checkbox -> copy

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-53

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
