### PR TITLE
NSL-5406: Loader Name: Switch order of full and simple names on loader name details tab for heading records too

### DIFF
--- a/app/views/loader/names/tabs/heading_record_tabs/_tab_details.html.erb
+++ b/app/views/loader/names/tabs/heading_record_tabs/_tab_details.html.erb
@@ -13,8 +13,8 @@ Heading entry
                      class: 'blue underline'), 
                      label: "query family #{members} members"} %>
 <% end %>
-<%= render partial: 'detail_line', locals: {info: @loader_name.simple_name, label: 'Simple Name'} %>
 <%= render partial: 'detail_line', locals: {info: @loader_name.full_name, label: 'Full Name'} %>
+<%= render partial: 'detail_line', locals: {info: @loader_name.simple_name, label: 'Simple Name'} %>
 <%= render partial: 'detail_line', locals: {info: @loader_name.family, label: 'Family'} %>
 <%= render partial: 'detail_line', locals: {info: @loader_name.sort_key, label: 'Value for sorting'} %>
 <%= render partial: 'detail_line', locals: {info: @loader_name.rank, label: 'Rank'} %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 07-May-2025
+  :jira_id: '5406'
+  :description: |-
+    Loader Name: Switch order of full and simple names on loader name details tab for heading records too
+- :date: 07-May-2025
   :jira_id: '53'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.18
+appversion=4.1.7.19


### PR DESCRIPTION
## Description
Small change on Details tab for heading records

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Go to details tab for loader name heading records

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
