### PR TITLE
NSL-5428: Loader Name: Suppress display of dummy family headers for synonyms/misapplications

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -43,7 +43,7 @@
      @previous_family = search_result.family 
      @show_family = true
      @add_white_space_around_family = false
-   elsif @previous_family != search_result.family
+   elsif @previous_family != search_result.family && %w(accepted excluded).include?(search_result.record_type)
      @previous_family = search_result.family 
      @show_family = true
      @add_white_space_before_family = @previous_previous_record_type != 'heading'

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 07-May-2025
+  :jira_id: '5428'
+  :description: |-
+    Loader Name: Suppress display of dummy family headers for synonyms/misapplications
+- :date: 07-May-2025
   :jira_id: '5406'
   :description: |-
     Loader Name: Switch order of full and simple names on loader name details tab for heading records too

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.19
+appversion=4.1.7.20


### PR DESCRIPTION
## Description
Small change to the way results are re-written to provide family headings.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Display loader names as a reviewer - with a synonym belonging to a different family than the accepted name.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
