### PR TITLE
FLOR-53: Fix for copying profile item with tree_element_id

### DIFF
--- a/app/models/instance/as_copier.rb
+++ b/app/models/instance/as_copier.rb
@@ -127,6 +127,7 @@ class Instance::AsCopier < Instance
           new_profile_item.source_id = nil
           new_profile_item.source_id_string = nil
           new_profile_item.source_system = nil
+          new_profile_item.tree_element_id = nil
           new_profile_item.save!
         end
       end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 08-May-2025
+  :jira_id: '53'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Avoid profile_instance_constraint when copying profile item by setting the tree_element_id to nil
+- :date: 08-May-2025
   :jira_id: '5428'
   :description: |-
     Loader Name: Tweak the suppression of family headings to make sure real headings are shown

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.7.22
+appversion=4.1.7.23

--- a/spec/models/instance/as_copier_spec.rb
+++ b/spec/models/instance/as_copier_spec.rb
@@ -106,6 +106,7 @@ RSpec.describe Instance::AsCopier, type: :model do
             expect(copied_profile_item.statement_type).to eq "link"
             expect(copied_profile_item.source_id).to be_nil
             expect(copied_profile_item.source_id_string).to be_nil
+            expect(copied_profile_item.tree_element_id).to be_nil
             expect(copied_profile_item.source_system).to be_nil
           end
 


### PR DESCRIPTION
## Description
Set the `tree_element_id` of copied profile item to nil to avoid db error around `profile_instance_constraint`

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-53

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog
