### PR TITLE
Edit a linked profile item

### DIFF
--- a/app/controllers/profile_items/links_controller.rb
+++ b/app/controllers/profile_items/links_controller.rb
@@ -23,6 +23,20 @@ module ProfileItems
     end
 
     def update
+      @instance = Instance.find(params[:instance_id])
+      result = ProfileItems::Links::UpdateService.call(
+        instance: @instance,
+        profile_item: @source_profile_item
+        user: current_registered_user,
+        params: params
+      )
+
+      @profile_item = result.profile_item
+
+      if result.errors.any?
+        @message = "Error deleting profile item: #{result.errors.full_messages.to_sentence}"
+        render "update_field"
+      end
     end
 
     private

--- a/app/controllers/profile_items/links_controller.rb
+++ b/app/controllers/profile_items/links_controller.rb
@@ -23,19 +23,26 @@ module ProfileItems
     end
 
     def update
-      @instance = Instance.find(params[:instance_id])
       result = ProfileItems::Links::UpdateService.call(
-        instance: @instance,
-        profile_item: @source_profile_item
+        profile_item: @source_profile_item,
         user: current_registered_user,
         params: params
       )
 
-      @profile_item = result.profile_item
-
       if result.errors.any?
         @message = "Error deleting profile item: #{result.errors.full_messages.to_sentence}"
-        render "update_field"
+        render "update_failed"
+      else
+        @profile_item = result.profile_item
+        @profile_text = result.profile_text
+        @instance = @profile_item.instance
+        @product_configs_and_profile_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
+          .new(@current_user, @instance, {
+            instance_id: @instance.id,
+            product_item_config_id: @profile_item.product_item_config_id
+          }).run_query
+
+        render "profile_items/index"
       end
     end
 

--- a/app/models/profile/profile_text.rb
+++ b/app/models/profile/profile_text.rb
@@ -23,6 +23,8 @@
 #
 module Profile
   class ProfileText < ApplicationRecord
+    include UserTrackable
+
     strip_attributes
     self.table_name = "profile_text"
     self.primary_key = "id"

--- a/app/services/profile_items/links/create_service.rb
+++ b/app/services/profile_items/links/create_service.rb
@@ -11,7 +11,7 @@ class ProfileItems::Links::CreateService < BaseService
     @source_profile_item = source_profile_item
     @profile_item = Profile::ProfileItem.new(
       statement_type: Profile::ProfileItem::STATEMENT_TYPES[:link],
-      source_profile_item_id: source_profile_item.id,
+      source_profile_item_id: source_profile_item.fact? ? source_profile_item.id : source_profile_item.source_profile_item_id,
       is_draft: true,
       instance_id: instance.id,
       profile_text_id: source_profile_item.profile_text_id,

--- a/app/services/profile_items/links/update_service.rb
+++ b/app/services/profile_items/links/update_service.rb
@@ -1,0 +1,49 @@
+class ProfileItems::Links::UpdateService < BaseService
+
+  validate :draft_profile_item
+
+  attr_reader :profile_item, :profile_text
+
+  def initialize(user:, profile_item:, params:)
+    super(params)
+    @user = user
+    @profile_item = profile_item
+  end
+
+  def execute
+    return unless valid?
+
+    ActiveRecord::Base.transaction do
+      create_profile_text
+      update_profile_item
+      raise ActiveRecord::Rollback if errors.any?
+    end
+  end
+
+  private
+
+  attr_reader :user
+
+  def draft_profile_item
+    return if profile_item.is_draft
+    errors.add(:base, "Cannot update a published profile item")
+  end
+
+  def create_profile_text
+    @profile_text = Profile::ProfileText.new(value_md: profile_item.profile_text.value_md, value: profile_item.profile_text.value)
+    @profile_text.current_user = user
+    @profile_text.save
+    errors.merge!(@profile_text.errors) if @profile_text.errors.any?
+  end
+
+  def update_profile_item
+    profile_item.current_user = user
+    profile_item.assign_attributes(
+      source_profile_item_id: nil,
+      statement_type: Profile::ProfileItem::STATEMENT_TYPES[:fact],
+      profile_text_id: profile_text.id
+    )
+    profile_item.save
+    errors.merge!(profile_item.errors) if profile_item.errors.any?
+  end
+end

--- a/app/views/profile_items/_delete_widgets.html.erb
+++ b/app/views/profile_items/_delete_widgets.html.erb
@@ -3,7 +3,7 @@
   id: "profile-item-delete-link-#{profile_item.id}",
   class: "btn btn-warning unconfirmed-delete-link pull-right xhidden",
   style: "margin-top: 3px;margin-bottom:3px",
-  title: "Select to delete the profile item.  A confirmation dialog follows.",
+  title: "Select to delete the profile item. A confirmation dialog follows.",
   data: { show_this_id: "confirm-or-cancel-link-profile-item-container-#{profile_item.id}" })
 %>
 

--- a/app/views/profile_items/_edit_widgets.html.erb
+++ b/app/views/profile_items/_edit_widgets.html.erb
@@ -1,0 +1,48 @@
+<% edit_link = link_to("Edit Profile Item",
+  '#',
+  id: "profile-item-edit-link-#{profile_item.id}",
+  class: "btn btn-primary unconfirmed-action-link pull-right xhidden",
+  style: "margin-top: 3px;margin-bottom:3px",
+  title: "Select to edit the profile item. A confirmation dialog follows.",
+  data: { show_this_id: "confirm-or-cancel-edit-link-profile-item-container-#{profile_item.id}" })
+%>
+
+<%
+# NOTES: Apparently, we need to add the turbo-related data attributes to ajax-driven links.
+# In this example, the delete button that makes an ajax request to the server should have the turbo attributes
+# if we want it to render the results via turbo stream. Just something we have to note of.
+confirm_edit_link = link_to("Confirm edit",
+                                profile_items_link_path(profile_item.id),
+                                class: "btn btn-warning",
+                                style: "margin-top: 3px;margin-bottom: 3px;",
+                                title: "Select to confirm the edit.",
+                                data: {
+                                  turbo_method: :put, # Makes sure the delete method is used
+                                  turbo_stream: true # Explicitly indicates that the request expects a Turbo Stream response
+                                })
+%>
+
+<% cancel_edit_link = link_to("Cancel edit",
+                                '#',
+                                id: "cancel-edit-link-#{profile_item.id}",
+                                class: "btn btn-default cancel-link",
+                                style: "margin-top: 3px;margin-bottom: 3px;",
+                                title: "Select to cancel the edit.",
+                                data: {enable_this_id: "profile-item-edit-link-#{profile_item.id}",
+                                       hide_this_id: "confirm-or-cancel-edit-link-profile-item-container-#{profile_item.id}"})
+%>
+
+<% confirm_or_cancel_element = %Q(<div id="confirm-or-cancel-edit-link-profile-item-container-#{profile_item.id}"
+                                  class="profile-item confirm-or-cancel-edit-link pull-right hidden">
+                                  #{confirm_edit_link}
+                                  #{cancel_edit_link}
+                                  <div class="red">The original source is being copied for editing</div>
+                                  <div id="edit-error-message" class="error-container"/>
+                                  </div>)
+%>
+<div style="padding-top: 30px;padding-bottom: 20px; overflow: hidden;">
+  <%= edit_link.html_safe %>
+  <%= confirm_or_cancel_element.html_safe %>
+  <div id="message-for-profile-item-<%= profile_item.id %>" class="message-container"></div>
+  <div id="error-for-profile-item-<%= profile_item.id %>" class="error-container"></div>
+</div>

--- a/app/views/profile_items/index.turbo_stream.erb
+++ b/app/views/profile_items/index.turbo_stream.erb
@@ -2,7 +2,7 @@
 <%= turbo_stream.replace "product-item-config-dropdown-container" do %>
   <%= render partial: "profile_items/product_item_config_dropdown", locals: {
       product_configs_and_profile_items: all_items,
-      selected_product_item_config_id: params[:product_item_config_id],
+      selected_product_item_config_id: params[:product_item_config_id] || @profile_item&.product_item_config_id,
       instance: @instance
     }
   %>
@@ -145,7 +145,14 @@
             </p>
           <% end %>
 
+          <div id="profile_item_actions_edit_<%= product_item_config.id %>">
+            <%= render partial: "profile_items/edit_widgets", locals: {profile_item: profile_item} %>
+          </div>
+
+          <hr/>
+
           <div id="profile_item_actions_<%= product_item_config.id %>">
+
             <% if profile_item.allow_delete?%>
               <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
             <% else %>

--- a/app/views/profile_items/links/create.html.erb
+++ b/app/views/profile_items/links/create.html.erb
@@ -33,4 +33,8 @@
       <%= @profile_item.profile_item_annotation.value %>
     </p>
   <% end %>
+
+  <div id="profile_item_actions_<%= product_item_config.id %>">
+    <%= render partial: "profile_items/edit_widgets", locals: {profile_item: @profile_item} %>
+  </div>
 <% end %>

--- a/app/views/profile_items/links/update_failed.turbo_stream.erb
+++ b/app/views/profile_items/links/update_failed.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "edit-error-message" do %>
+  <%= @message %>
+<% end %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 14-May-2025
+  :jira_id: '74'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Allow draft-profile-editor to edit a linked profile item
 - :date: 12-May-2025
   :jira_id: '5398'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.0
+appversion=4.1.8.1

--- a/spec/services/profile_items/links/update_service_spec.rb
+++ b/spec/services/profile_items/links/update_service_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe ProfileItems::Links::UpdateService, type: :service do
+  let!(:instance) { create(:instance, name:) }
+
+  let(:profile_text) { create(:profile_text) }
+  let!(:product_item_config) { create(:product_item_config) }
+  let!(:source_profile_item) do
+    build(:profile_item,
+      instance_id: instance.id,
+      product_item_config:,
+      profile_text:,
+      statement_type: 'fact',
+      is_draft: false
+    )
+  end
+
+  let!(:profile_item) do
+    create(:profile_item,
+      product_item_config:,
+      instance_id: instance.id,
+      profile_text_id: profile_text.id,
+      source_profile_item_id: source_profile_item.id,
+      statement_type: 'link'
+    )
+  end
+
+  let!(:name) { create(:name) }
+  let!(:user) { create(:user) }
+  let(:params) { {} }
+
+  let(:service) { described_class.new(instance: instance, user: user, profile_item: profile_item, params: params) }
+
+  describe '#execute' do
+    context 'when the profile item is a draft' do
+      it 'updates the profile item and creates a profile text' do
+        expect { service.execute }.to change { Profile::ProfileText.count }.by(1)
+
+        new_profile_text = Profile::ProfileText.last
+        expect(profile_item.reload.profile_text_id).to eq(new_profile_text.id)
+        expect(new_profile_text.value_md).to eq(profile_text.value_md)
+        expect(new_profile_text.value).to eq(profile_text.value)
+        expect(new_profile_text.created_by).to eq(user.user_name)
+        expect(new_profile_text.updated_by).to eq(user.user_name)
+
+        expect(profile_item.statement_type).to eq(Profile::ProfileItem::STATEMENT_TYPES[:fact])
+        expect(profile_item.source_profile_item_id).to be_nil
+        expect(profile_item.updated_by).to eq(user.user_name)
+      end
+    end
+
+    context 'when the profile item is not a draft' do
+      before { profile_item.update(is_draft: false) }
+
+      it 'does not update the profile item and adds an error' do
+        expect { service.execute }.not_to change { Profile::ProfileText.count }
+        expect(service.errors[:base]).to include("Cannot update a published profile item")
+      end
+    end
+
+    context 'when invalid' do
+      before { allow(service).to receive(:valid?).and_return(false) }
+
+      it 'does not perform any updates' do
+        expect { service.execute }.not_to change { Profile::ProfileText.count }
+        expect(profile_item.reload.profile_text_id).to eq(profile_text.id)
+      end
+    end
+
+    context "when there are error saving the profile text" do
+      before do
+        errors = ActiveModel::Errors.new(profile_text)
+        errors.add(:base, "An error")
+        allow_any_instance_of(Profile::ProfileText).to receive(:save).and_return(errors)
+        allow_any_instance_of(Profile::ProfileText).to receive(:errors).and_return(errors)
+      end
+
+      it "does not update the profile item" do
+        service.execute
+        expect(service.errors[:base]).to include("An error")
+        expect(profile_item.reload.profile_text_id).to eq(profile_text.id)
+      end
+    end
+
+    context "when there are errors saving the profile item" do
+      let!(:source_profile_item) do
+        create(:profile_item,
+          instance_id: instance.id,
+          product_item_config:,
+          profile_text:,
+          statement_type: 'fact',
+          is_draft: false
+        )
+      end
+
+      before do
+        errors = ActiveModel::Errors.new(profile_item)
+        errors.add(:base, "An error")
+        allow_any_instance_of(Profile::ProfileItem).to receive(:save).and_return(errors)
+        allow_any_instance_of(Profile::ProfileItem).to receive(:errors).and_return(errors)
+      end
+
+      it "does not update the profile item" do
+        expect { service.execute }.to change { Profile::ProfileText.count }.by(0)
+        expect(profile_item.reload.profile_text_id).to eq(profile_text.id)
+        expect(profile_item.source_profile_item_id).not_to eq(nil)
+        expect(service.errors[:base]).to include("An error")
+      end
+    end
+  end
+
+  describe '#draft_profile_item' do
+    context 'when the profile item is a draft' do
+      it 'does not add any errors' do
+        service.send(:draft_profile_item)
+        expect(service.errors).to be_empty
+      end
+    end
+
+    context 'when the profile item is not a draft' do
+      before { profile_item.update(is_draft: false) }
+
+      it 'adds an error to the service' do
+        service.send(:draft_profile_item)
+        expect(service.errors[:base]).to include("Cannot update a published profile item")
+      end
+    end
+  end
+end

--- a/spec/services/profile_items/links/update_service_spec.rb
+++ b/spec/services/profile_items/links/update_service_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProfileItems::Links::UpdateService, type: :service do
   let!(:user) { create(:user) }
   let(:params) { {} }
 
-  let(:service) { described_class.new(instance: instance, user: user, profile_item: profile_item, params: params) }
+  let(:service) { described_class.new(user: user, profile_item: profile_item, params: params) }
 
   describe '#execute' do
     context 'when the profile item is a draft' do


### PR DESCRIPTION
## Description
Adding support for draft profile editors to edit a linked profile item

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
For a draft instance, select a linked profile item -> click on edit

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-74

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
