### PR TITLE
Copy profile item reference of the sourced profile item

### DIFF
--- a/app/models/profile/profile_item.rb
+++ b/app/models/profile/profile_item.rb
@@ -52,6 +52,7 @@ module Profile
     belongs_to :instance
     belongs_to :product_item_config, class_name: 'Profile::ProductItemConfig', foreign_key: 'product_item_config_id'
     belongs_to :profile_text, class_name: 'Profile::ProfileText', foreign_key: 'profile_text_id'
+    belongs_to :source_profile_item, class_name: 'Profile::ProfileItem', foreign_key: 'source_profile_item_id', optional: true
     belongs_to :profile_object_type,
               class_name: 'Profile::ProfileObjectType',
               primary_key: 'rdf_id',

--- a/app/models/profile/profile_item_reference.rb
+++ b/app/models/profile/profile_item_reference.rb
@@ -22,6 +22,8 @@
 #
 module Profile
     class ProfileItemReference < ApplicationRecord
+      include UserTrackable
+
       self.table_name = "profile_item_reference"
       self.primary_key = [:profile_item_id, :reference_id]
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 16-May-2025
+  :jira_id: '74'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Copy the profile item references of sourced profile item when converting a link item to fact
+- :date: 16-May-2025
   :jira_id: '5431'
   :description: |-
     Loader: Users no longer enter a comment type to make a review comment

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.5
+appversion=4.1.8.6

--- a/spec/models/profile/profile_item_spec.rb
+++ b/spec/models/profile/profile_item_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Profile::ProfileItem, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:instance) }
+    it { is_expected.to belong_to(:source_profile_item).class_name('Profile::ProfileItem').optional }
     it { is_expected.to belong_to(:product_item_config).class_name('Profile::ProductItemConfig').with_foreign_key('product_item_config_id') }
     it { is_expected.to belong_to(:profile_text).class_name('Profile::ProfileText').with_foreign_key('profile_text_id') }
     it { is_expected.to belong_to(:profile_object_type).class_name('Profile::ProfileObjectType').with_primary_key('rdf_id').with_foreign_key('profile_object_rdf_id').optional }


### PR DESCRIPTION
## Description
When converting a linked profile item to a `fact`, also copy the profile item references of the source if there are any.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
<!-- Provide instructions for testing this PR -->

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-74

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
