### PR TITLE
NSL-5433: Loader: Make in-batch note appear below distribution entry of previous record

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -18,7 +18,7 @@
    <% end %>
 <% else %>
    <% @previous_record_type = search_result.record_type %>
-   <% if search_result.record_type == 'accepted' or search_result.record_type == 'excluded' then %>
+   <% if %w(accepted included in-batch-note).include?(search_result.record_type) then %>
      <%= render partial: 'application/search_results/review/loader_name_stored_comment', locals: {search_result: search_result, give_me_focus: give_me_focus} %>
      <%= render partial: 'application/search_results/review/loader_name_stored_distribution', locals: {search_result: search_result, give_me_focus: give_me_focus} %>
      <% @stored_distribution = search_result.distribution %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,7 +1,7 @@
 - :date: 16-May-2025
   :jira_id: '5433'
   :description: |-
-    Loader: Make in-batch note appear below distribution
+    Loader: Make in-batch note appear below distribution entry of previous accepted record
 - :date: 16-May-2025
   :jira_id: '5432'
   :description: |-

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 16-May-2025
+  :jira_id: '5433'
+  :description: |-
+    Loader: Make in-batch note appear below distribution
+- :date: 16-May-2025
   :jira_id: '5432'
   :description: |-
     Loader: Remove stray "&gt;" in review output for some note and text fields

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.3
+appversion=4.1.8.4


### PR DESCRIPTION
## Description
Reviewer output of loader name records is a complex algorithm.

In that  output, we noticed that in-batch-notes were appearing before the previous record’s distribution entry.

That isn’t expected or desirable and this jira fixes that.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Output batch data for reviewers as discussed with Anna.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
