### PR TITLE
FLOR-53: Setup copied profile item's published_date to nil

### DIFF
--- a/app/models/instance/as_copier.rb
+++ b/app/models/instance/as_copier.rb
@@ -120,6 +120,7 @@ class Instance::AsCopier < Instance
       if copy_profile_items
         self.profile_items.each do |profile_item|
           new_profile_item = profile_item.dup
+          new_profile_item.published_date = nil
           new_profile_item.instance_id = new.id
           new_profile_item.source_profile_item_id = profile_item.id if profile_item.fact?
           new_profile_item.is_draft = true
@@ -128,6 +129,7 @@ class Instance::AsCopier < Instance
           new_profile_item.source_id_string = nil
           new_profile_item.source_system = nil
           new_profile_item.tree_element_id = nil
+          new_profile_item.created_by = new_profile_item.updated_by = as_username
           new_profile_item.save!
         end
       end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 21-May-2025
+  :jira_id: '53'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Set copied profile item's published_date to nil, and set the created_by and updated_by field appropriately
+- :date: 21-May-2025
   :jira_id: ''
   :description: |-
     Loader Review: Fix problem in has-review-comment-by: search directive

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.8
+appversion=4.1.8.9

--- a/spec/models/instance/as_copier_spec.rb
+++ b/spec/models/instance/as_copier_spec.rb
@@ -105,9 +105,12 @@ RSpec.describe Instance::AsCopier, type: :model do
             expect(copied_profile_item.is_draft).to be true
             expect(copied_profile_item.statement_type).to eq "link"
             expect(copied_profile_item.source_id).to be_nil
+            expect(copied_profile_item.published_date).to be_nil
             expect(copied_profile_item.source_id_string).to be_nil
             expect(copied_profile_item.tree_element_id).to be_nil
             expect(copied_profile_item.source_system).to be_nil
+            expect(copied_profile_item.created_by).to eq username
+            expect(copied_profile_item.updated_by).to eq username
           end
 
           context "when profile item is not a fact" do


### PR DESCRIPTION
## Description
Setup copied profile item's `published_date` to nil and set the `created_by` and `updated_by` to user currently doing the action

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
select an instance with profile item -> click on copy tab 

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-53

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
