### PR TITLE
NSL-5445: Users: save and query user logins in lower case…

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -70,7 +70,7 @@ class SessionsController < ApplicationController
   end
 
   def set_up_session
-    session[:username] = sign_in_params[:username]
+    session[:username] = sign_in_params[:username].downcase
     session[:groups] = @sign_in.groups
     session[:user_full_name] = @sign_in.user_full_name
     session[:user_cn] = @sign_in.user_cn

--- a/app/models/session_user.rb
+++ b/app/models/session_user.rb
@@ -76,7 +76,7 @@ class SessionUser < ActiveType::Object
   # find_or_create_by would be preferred method but
   # I couldn't get that to work
   def registered_user
-    registered_user = User.find_or_initialize_by(user_name: username) do |user|
+    registered_user = User.find_or_initialize_by(user_name: username.downcase) do |user|
       user.family_name = full_name.split(' ').last||'unknown'
       user.given_name = full_name.split(' ').first||'unknown'
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ActiveRecord::Base
   has_many :products, through: :product_roles
   has_many :roles, through: :product_roles
 
-  before_create :set_audit_fields
+  before_create :set_audit_fields, :force_lower_case_user_name
   before_update :set_updated_by
 
   def is?(requested_role_name)
@@ -71,6 +71,10 @@ class User < ActiveRecord::Base
 
   def set_audit_fields
     self.created_by = self.updated_by = @current_user&.username||'self as new user'
+  end
+
+  def force_lower_case_user_name
+    self.user_name = self.user_name.downcase
   end
 
   def set_updated_by

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 21-May-2025
+  :jira_id: '5445'
+  :description: |-
+    Users: save and query user logins in lower case regardless of how users enter them for login
+- :date: 21-May-2025
   :jira_id: ''
   :description: |-
     Loader Review: Revise <code>org-not-voted:</code> search directive SQL

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.11
+appversion=4.1.8.12

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5053,6 +5053,9 @@ CREATE TABLE public.users (
     updated_by character varying(50) DEFAULT USER NOT NULL
 );
 
+alter table public.users 
+add constraint users_user_name_lowercase_ck 
+check (user_name = lower(user_name));
 
 --
 -- Name: batch_stack_v; Type: VIEW; Schema: public; Owner: -

--- a/test/controllers/session/actions/new_session_known_user_upper_case_no_added_user_record_test.rb
+++ b/test/controllers/session/actions/new_session_known_user_upper_case_no_added_user_record_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Test User can sign in.
+class NewSessionKnownUserUpperCaseNoNewUserRecordTest < ActionController::TestCase
+  tests SearchController
+
+  def setup
+    @known_user = users(:user_one)
+  end
+
+  test "new session for known user upper case does not create user record" do
+    assert_no_difference("User.count") do
+      get(:search,
+          params: {},
+          session: { username: @known_user.user_name.upcase,
+                     user_full_name: "#{@known_user.given_name} #{@known_user.family_name}",
+                     groups: [:login] })
+      assert_response :success
+    end
+    assert assigns(:current_registered_user), "Current registered user should be assigned"
+    reg_user = assigns(:current_registered_user)
+    assert reg_user.user_name == @known_user.user_name, "Registered user not set correctly"
+  end
+end

--- a/test/controllers/session/actions/new_session_unknown_upper_case_user_creates_user_record_test.rb
+++ b/test/controllers/session/actions/new_session_unknown_upper_case_user_creates_user_record_test.rb
@@ -1,0 +1,45 @@
+#efrozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Test User can sign in.
+class NewSessionUnknownUserUpperCaseCreatesUserRecordTest < ActionController::TestCase
+  tests SearchController
+
+  def setup
+    @unknown_user_name = "FJones"
+    @unknown_user_full_name = "Fred Jones"
+  end
+
+  test "new session for unknown user upper case creates user record" do
+    assert_difference("User.count") do
+      get(:search,
+          params: {},
+          session: { username: @unknown_user_name,
+                     user_full_name: @unknown_user_full_name,
+                     groups: [:login] })
+      assert_response :success
+    end
+    assert assigns(:current_registered_user), "Current registered user should be assigned"
+    reg_user = assigns(:current_registered_user)
+    assert reg_user.user_name == @unknown_user_name.downcase, "Registered user not set correctly"
+    assert reg_user.created_by == 'self as new user', "Registered user created_by not set correctly"
+    assert reg_user.updated_by == 'self as new user', "Registered user updated_by not set correctly"
+  end
+end


### PR DESCRIPTION
… regardless of how users enter them for login

## Description
Force Users.user_name values to lower-case to ensure no duplicate entries.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Login with a user_name in mixed case.

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
<!-- Link to related issues (if any) -->

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
