### PR TITLE
Set NSL-5441 in release notes as the Jira for the revision of org-not-voted: made on 21 May

### DIFF
--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -11,7 +11,7 @@
   :description: |-
     Users: save and query user logins in lower case regardless of how users enter them for login
 - :date: 21-May-2025
-  :jira_id: ''
+  :jira_id: '5441'
   :description: |-
     Loader Review: Revise <code>org-not-voted:</code> search directive SQL
 - :date: 21-May-2025


### PR DESCRIPTION
## Description
Added a Jira number to change log/release notes.

## Type of change
- [x] Trivial change to doco

## How to Test
Display release notes for 2025.


## Tests
- [ ] Unit tests
- [x] Manual testing

No need to bump version.
## Pre-merge steps
- [ ] Bumped version
- [x] Updated changelog - as part of the change, didn't note this as a separate entry in changelog
