### PR TITLE
NSL-5439: Loader Review: Make in-batch compiler notes invisible to reviewers

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -67,6 +67,7 @@ class SearchController < ApplicationController
     params[:include_common_and_cultivar_session] = \
       session[:include_common_and_cultivar]
     apply_view_mode
+    params[:view_mode] = session[:view_mode]
     # Avoid "A copy of Search has been removed from the module tree but is still active" error
     # https://stackoverflow.com/questions/29636334/a-copy-of-xxx-has-been-removed-from-the-module-tree-but-is-still-active
     @search = ::Search::Base.new(params)

--- a/app/models/search/on_model/count_query.rb
+++ b/app/models/search/on_model/count_query.rb
@@ -21,6 +21,7 @@ class Search::OnModel::CountQuery
 
   def initialize(parsed_request)
     @parsed_request = parsed_request
+    @view_mode = parsed_request.params[:view_mode]
     prepare_query
     @info_for_display = "nothing yet from count query"
   end
@@ -29,7 +30,11 @@ class Search::OnModel::CountQuery
     Rails.logger.debug("Search::OnModel::CountQuery#prepare_query")
 
     @model_class = @parsed_request.target_model.constantize
-    prepared_query = @model_class.where("1=1")
+    if @parsed_request.target_table.match(/loader.name/) && @view_mode == 'review_view'
+      prepared_query = @model_class.where("record_type != 'in-batch-compiler-note'")
+    else
+      prepared_query = @model_class.where("1=1")
+    end
 
     where_clauses = Search::OnModel::WhereClauses.new(@parsed_request,
                                                       prepared_query)

--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -31,17 +31,14 @@ else
 end
 %>
 
-<%# final search_result is a flushing record %>
-<% if @show_family && !search_result[:flushing] %>
+<% case %>
+<% when search_result.record_type == 'in-batch-compiler-note' %>
+<% when @show_family && !search_result[:flushing] %> <%# final search_result is a flushing record %>
   <%= render partial: "#{wd}/loader_name_record/show_family_and_not_flushing", locals: {search_result: search_result} %>
-<% end %>
-
-<% if search_result.record_type == 'in-batch-note' %>
+<% when search_result.record_type == 'in-batch-note' %>
   <%= render partial: "#{wd}/loader_name_record/in_batch_note",
              locals: {search_result: search_result, give_me_focus: give_me_focus} %>
-<% end %>
-
-<% unless (@show_family && search_result.rank == 'family') || search_result.record_type == 'in-batch-note' %>
+<% else %>
   <%= render partial: "#{wd}/loader_name_record/ordinary_record",
              locals: {search_result: search_result, give_me_focus: give_me_focus} %>
 <% end %>

--- a/app/views/loader/names/tabs/in_batch_note_record_tabs/_tab_details.html.erb
+++ b/app/views/loader/names/tabs/in_batch_note_record_tabs/_tab_details.html.erb
@@ -1,5 +1,8 @@
 <ul class="nav nav-tabs">
   <%= @loader_name.record_type.gsub(/-/,' ').titlecase %>
+  <% if @loader_name.in_batch_compiler_note? %>
+    &mdash; will not appear in search results for reviewers
+  <% end %>
 </ul>
 
 <%#= render partial: 'detail_line', locals: {info: @loader_name.notes, label: 'Notes'} %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 29-May-2025
+  :jira_id: '5439'
+  :description: |-
+    Loader Review: Make in-batch compiler notes invisible to reviewers
 - :date: 28-May-2025
   :jira_id: '75'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.17
+appversion=4.1.8.18


### PR DESCRIPTION
## Description
Use session view_mode in loader_name query logic to filter out in-batch-compiler-notes from SQL query results if users is a reviewer.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Login as a reviewer and query a batch of loader_name records that has an in-batch-compiler-note - you should not see the record in any search results.

## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
