### PR TITLE
NSL-4889:  Reference New Instance: include names without an instance in the names typeahead

### DIFF
--- a/app/models/name/as_typeahead/on_full_name.rb
+++ b/app/models/name/as_typeahead/on_full_name.rb
@@ -43,7 +43,6 @@ class Name::AsTypeahead::OnFullName
         .where("lower(full_name) like lower(?)", prepared_search_term)
         .includes(:name_status)
         .joins(:name_rank)
-        .where("exists (select null from instance where instance.name_id = name.id)")
         .order("name_rank.sort_order, lower(full_name)")
         .limit(SEARCH_LIMIT)
         .collect do |n|

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 06-Jun-2025
+  :jira_id: '4889'
+  :description: |-
+    Reference New Instance: include names without an instance in the names typeahead (revert NSL-945)
 - :date: 04-Jun-2025
   :jira_id: '5448'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.8.20
+appversion=4.1.8.21

--- a/test/models/name/as_typeahead/on_full_name/should_include_names_without_instances_test.rb
+++ b/test/models/name/as_typeahead/on_full_name/should_include_names_without_instances_test.rb
@@ -19,13 +19,13 @@
 require "test_helper"
 
 # Single Name typeahead test.
-class NameTAOnFullNameSuggsShldNotInclNamesWOInstTest < ActiveSupport::TestCase
+class NameTAOnFullNameSuggsShldInclNamesWOInstTest < ActiveSupport::TestCase
   test "name on full name suggestions shd not incl names without instances" do
     suggestions = Name::AsTypeahead::OnFullName
                   .new(term: "a name without instances")
                   .suggestions
     assert(suggestions.is_a?(Array), "suggestions should be an array")
-    assert(suggestions.empty?,
-           'suggestions for "a name without instances" should be empty')
+    assert_not(suggestions.empty?,
+           'suggestions for "a name without instances" should not be empty')
   end
 end


### PR DESCRIPTION
## Description
Reverts NSL-945 that added this restriction to a typeahead query - we now simply remove that line of code.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Create name, grab a reference and add the new name to the reference within a New Instance - should now be possible.


## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
