### PR TITLE
NSL-5450: Loader Review: Do not display heading record full names e.g for Family heading records

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -35,8 +35,10 @@ end
 <% when search_result.record_type == 'in-batch-compiler-note' %>
 <% when @show_family && !search_result[:flushing] %> <%# final search_result is a flushing record %>
   <%= render partial: "#{wd}/loader_name_record/show_family_and_not_flushing", locals: {search_result: search_result} %>
-  <%= render partial: "#{wd}/loader_name_record/ordinary_record",
-             locals: {search_result: search_result, give_me_focus: give_me_focus} %>
+  <% unless search_result.record_type == 'heading' %>
+    <%= render partial: "#{wd}/loader_name_record/ordinary_record",
+               locals: {search_result: search_result, give_me_focus: give_me_focus} %>
+<% end %>
 <% when search_result.record_type == 'in-batch-note' %>
   <%= render partial: "#{wd}/loader_name_record/in_batch_note",
              locals: {search_result: search_result, give_me_focus: give_me_focus} %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 11-Jun-2025
+  :jira_id: '5450'
+  :description: |-
+    Loader Review: Do not display heading record full names e.g. for Family heading records
+- :date: 11-Jun-2025
   :jira_id: '5453'
   :description: |-
     Created By and Updated By: Editor now does not downcase usernames when displaying them in metadata

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.1
+appversion=4.1.9.2


### PR DESCRIPTION
## Description
Displaying loader name records to reviewers in a way that emulates the old Word documents is pretty tricky and this fixes a small bug in the recent rewrite of that code.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira.


## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
