### PR TITLE
NSL-5439: Loader Review: hide in-batch-compiler from reviewers - fix problem in re-factored display algorithm

### DIFF
--- a/app/views/application/search_results/review/_loader_name_record.html.erb
+++ b/app/views/application/search_results/review/_loader_name_record.html.erb
@@ -31,17 +31,18 @@ else
 end
 %>
 
-<% case %>
-<% when search_result.record_type == 'in-batch-compiler-note' %>
-<% when @show_family && !search_result[:flushing] %> <%# final search_result is a flushing record %>
+<%# real or virtual family headings are processed here %>
+<% if @show_family && !search_result[:flushing] %> <%# final search_result is a flushing record %>
   <%= render partial: "#{wd}/loader_name_record/show_family_and_not_flushing", locals: {search_result: search_result} %>
-  <% unless search_result.record_type == 'heading' %>
-    <%= render partial: "#{wd}/loader_name_record/ordinary_record",
-               locals: {search_result: search_result, give_me_focus: give_me_focus} %>
 <% end %>
-<% when search_result.record_type == 'in-batch-note' %>
+
+<% case search_result.record_type %>
+<% when 'in-batch-compiler-note' %>
+<% when 'in-batch-note' %>
   <%= render partial: "#{wd}/loader_name_record/in_batch_note",
              locals: {search_result: search_result, give_me_focus: give_me_focus} %>
+<% when 'heading' %>
+  <%# handled above via show_family code %>
 <% else %>
   <%= render partial: "#{wd}/loader_name_record/ordinary_record",
              locals: {search_result: search_result, give_me_focus: give_me_focus} %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,7 +1,12 @@
 - :date: 12-Jun-2025
   :jira_id: '5439'
   :description: |-
-    Loader Review: hide in-batch-compiler from reviewers - correct problem in re-factored display algorithm 
+    Loader Review: hide in-batch-compiler notes from reviewers - fix problem found testing re-factored display algorithm
+- :date: 11-June-2025
+  :jira_id: '76'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Prompt message for there are unsaved changes in the profile item editor
 - :date: 11-Jun-2025
   :jira_id: '5450'
   :description: |-

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 12-Jun-2025
+  :jira_id: '5439'
+  :description: |-
+    Loader Review: hide in-batch-compiler from reviewers - correct problem in re-factored display algorithm 
 - :date: 11-Jun-2025
   :jira_id: '5450'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.3
+appversion=4.1.9.4

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.2
+appversion=4.1.9.3


### PR DESCRIPTION
## Description
In-batch-notes weren't being displayed, which was a regression.  I've tweaked and improved the display algorithm to fix this.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) in code so far only in test

## How to Test
Display batch records as a reviewer.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
