### PR TITLE
Apply unsaved form prompt to all forms

### DIFF
--- a/.nsl-test-configs/editor-config.rb
+++ b/.nsl-test-configs/editor-config.rb
@@ -8,6 +8,7 @@ Rails.configuration.draft_instances = 'true'
 Rails.configuration.profile_edit_aware = true
 Rails.configuration.profile_v2_aware = true
 Rails.configuration.unsaved_form_prompt_enabled = true
+Rails.configuration.site_wide_form_prompt_enabled = true
 Rails.configuration.nsl_linker = "http://localhost:9090/"
 #Services
 Rails.configuration.services_clientside_root_url = "#{external_services_host}/"

--- a/app/javascript/search_result_focus.js
+++ b/app/javascript/search_result_focus.js
@@ -58,7 +58,7 @@
   });
 
   promptFormUnsavedChanges = function(event, proceedCallback) {
-    if (window.enablePromptUnsavedChanges == true && (window.hasUnsavedFormChanges ? window.hasUnsavedFormChanges() : window.formChanged)) {
+    if (window.enablePromptUnsavedChanges && (window.hasUnsavedFormChanges ? window.hasUnsavedFormChanges() : window.formChanged)) {
       event.preventDefault();
       if (window.showUnsavedChangesModal) {
         window.showUnsavedChangesModal(proceedCallback);

--- a/app/views/admin/_index.html.erb
+++ b/app/views/admin/_index.html.erb
@@ -197,6 +197,7 @@
     <tr><td class="width-40-percent min-width-10em">profile_v2_aware</td><td> <%= Rails.configuration.try(:profile_v2_aware) || false %> </td></tr>
     <tr><td class="width-40-percent min-width-10em">profile_v2_profile_v2_dropdown_ui</td><td> <%= Rails.configuration.try(:profile_v2_dropdown_ui) || false %> </td></tr>
     <tr><td class="width-40-percent min-width-10em">unsaved_form_prompt_enabled</td><td> <%= Rails.configuration.try(:unsaved_form_prompt_enabled) || false %> </td></tr>
+    <tr><td class="width-40-percent min-width-10em">site_wide_form_prompt_enabled</td><td> <%= Rails.configuration.try(:site_wide_form_prompt_enabled) || false %> </td></tr>
 
     </table>
     <br> <br>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,8 @@
 
     <script>
       window.relative_url_root = "<%= Rails.application.config.action_controller.relative_url_root %>";
-      window.enablePromptUnsavedChanges = <%= Rails.configuration.try('unsaved_form_prompt_enabled') %>;
+      window.enablePromptUnsavedChanges = <%= Rails.configuration.try('unsaved_form_prompt_enabled') || false %>;
+      window.enableSiteWidePromptUnsavedChanges = <%= Rails.configuration.try('site_wide_form_prompt_enabled') || false %>;
     </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.js"

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 12-June-2025
+  :jira_id: '76'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Add a feature flag for site-wide unsaved form changes prompt
 - :date: 12-Jun-2025
   :jira_id: '5457'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.5
+appversion=4.1.9.6


### PR DESCRIPTION
## Description
Introduce a functionality to request saving unsaved form data, applicable across all forms, including those not defined by a specific class. This is behind a feature flag.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Enable the flag, go to a form and make changes, navigate away from the page and a popup will show up prompting you to save your changes.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Related Issues
FLOR-76

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
