### PR TITLE
Create new version of Profile::ProfileItem Service

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -147,6 +147,9 @@ class Ability
     can :manage, Profile::ProfileItem do |profile_item|
       profile_item.product_item_config.product_id == user.product_from_roles&.id
     end
+    can :create_version, Profile::ProfileItem do |profile_item|
+      !profile_item.is_draft?
+    end
     can :manage, Profile::ProfileItemReference
     can :manage, Profile::ProfileText
     can :manage, Profile::ProfileItemAnnotation

--- a/app/models/profile/profile_item_annotation.rb
+++ b/app/models/profile/profile_item_annotation.rb
@@ -27,6 +27,8 @@
 #
 module Profile
     class ProfileItemAnnotation < ApplicationRecord
+      include UserTrackable
+
       self.table_name = "profile_item_annotation"
       self.primary_key = "id"
 

--- a/app/services/profile_items/published/create_new_version_service.rb
+++ b/app/services/profile_items/published/create_new_version_service.rb
@@ -1,0 +1,101 @@
+class ProfileItems::Published::CreateNewVersionService < BaseService
+
+  validate :published_profile_item
+  validate :any_draft_profile_items
+
+  attr_reader :profile_item, :new_profile_item
+
+  def initialize(instance:, user:, profile_item:, params:)
+    super(params)
+    @instance = instance
+    @user = user
+    @profile_item = profile_item
+    @product_item_config = profile_item.product_item_config
+    @new_profile_item = nil
+  end
+
+  def execute
+    return unless valid?
+
+    ActiveRecord::Base.transaction do
+      copy_profile_item_as_draft
+      copy_profile_text
+      copy_profile_item_annotation
+      copy_profile_item_references
+      raise ActiveRecord::Rollback if errors.any?
+    end
+  end
+
+  private
+
+  attr_reader :instance, :params, :user, :product_item_config
+
+  def published_profile_item
+    return unless profile_item.is_draft
+    errors.add(:base, "Profile item must be published before creating a new version")
+  end
+
+  def any_draft_profile_items
+    return unless instance
+      .profile_items
+      .where(product_item_config_id: product_item_config.id, is_draft: true)
+      .exists?
+
+    errors.add(:base, "There is still a draft profile item for this product item config")
+  end
+
+  def copy_profile_item_as_draft
+    @new_profile_item = profile_item.dup
+    new_profile_item.is_draft = true
+    new_profile_item.published_date = nil
+    new_profile_item.current_user = user
+    new_profile_item.save
+
+    return errors.merge!(new_profile_item.errors) if new_profile_item.errors.any?
+
+    new_profile_item.reload
+  end
+
+  def copy_profile_text
+    new_profile_text = profile_item.profile_text.dup
+    new_profile_text.current_user = user
+    new_profile_text.save
+
+    return errors.merge!(new_profile_text.errors) if new_profile_text.errors.any?
+
+    @new_profile_item.profile_text = new_profile_text
+    @new_profile_item.save
+
+    return errors.merge!(@new_profile_item.errors) if @new_profile_item.errors.any?
+  end
+
+  def copy_profile_item_annotation
+    return unless profile_item.profile_item_annotation
+
+    new_profile_item_annotation = profile_item.profile_item_annotation.dup
+    new_profile_item_annotation.current_user = user
+    new_profile_item_annotation.profile_item_id = new_profile_item.id
+    new_profile_item_annotation.save
+
+    return errors.merge!(new_profile_item_annotation.errors) if new_profile_item_annotation.errors.any?
+  end
+
+  def copy_profile_item_references
+    return if profile_item.profile_item_references.blank?
+
+    profile_item.profile_item_references.each do |profile_item_reference|
+      new_profile_item_reference = Profile::ProfileItemReference.new(
+        profile_item_reference
+          .attributes
+          .except("profile_item_id", "created_by", "updated_by", "created_at", "updated_at")
+      )
+      new_profile_item_reference.profile_item_id = new_profile_item.id
+      new_profile_item_reference.current_user = user
+      new_profile_item_reference.annotation = "Modified from."
+      new_profile_item_reference.save
+
+      errors.merge!(new_profile_item_reference.errors) if new_profile_item_reference.errors.any?
+    end
+  end
+
+end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 18-June-2025
+  :jira_id: '77'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Backend service for creating new versioned profile items
 - :date: 12-June-2025
   :jira_id: '76'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.6
+appversion=4.1.9.7

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -330,6 +330,16 @@ RSpec.describe Ability, type: :model do
       expect(subject.can?(:manage, Profile::ProfileText)).to eq true
     end
 
+    it "can create_version Profile::ProfileItem if it is not draft" do
+      profile_item = create(:profile_item, is_draft: false)
+      expect(subject.can?(:create_version, profile_item)).to eq true
+    end
+
+    it "cannot create_version Profile::ProfileItem if it is a draft" do
+      profile_item = create(:profile_item, is_draft: true)
+      expect(subject.can?(:create_version, profile_item)).to eq false
+    end
+
     it 'can manage Profile::ProfileItemAnnotation' do
       expect(subject.can?(:manage, Profile::ProfileItemAnnotation)).to eq true
     end

--- a/spec/services/profile_items/published/create_new_version_service_spec.rb
+++ b/spec/services/profile_items/published/create_new_version_service_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe ProfileItems::Published::CreateNewVersionService, type: :service do
+  let(:instance) { create(:instance) }
+  let(:user) { create(:user) }
+  let(:product_item_config) { create(:product_item_config) }
+  let(:profile_item) { create(:profile_item, instance: instance, product_item_config: product_item_config, is_draft: false) }
+  let!(:profile_text) { create(:profile_text, profile_item: profile_item) }
+  let!(:profile_item_annotation) { create(:profile_item_annotation, profile_item: profile_item) }
+  let!(:profile_item_reference) { create(:profile_item_reference, profile_item: profile_item) }
+
+  subject do
+    described_class.new(
+      instance: instance,
+      user: user,
+      profile_item: profile_item,
+      params: {}
+    )
+  end
+
+  describe "#execute" do
+    context "when profile item is published and no draft exists" do
+      it "creates a new draft version with copied associations" do
+        expect { subject.execute }.to change { Profile::ProfileItem.where(is_draft: true).count }.by(1)
+
+        new_draft = Profile::ProfileItem.where(is_draft: true).last
+        expect(new_draft.profile_text).to be_present
+        expect(new_draft.profile_item_annotation).to be_present
+        expect(new_draft.profile_item_references.count).to eq(1)
+        expect(new_draft.profile_text.value_md).to eq(profile_text.value_md)
+        expect(new_draft.profile_item_annotation.value).to eq(profile_item_annotation.value)
+        expect(new_draft.profile_item_references.first.reference_id).to eq(profile_item_reference.reference_id)
+      end
+
+      context "when there are errors copying the profile item" do
+        before do
+          errors = ActiveModel::Errors.new(profile_item)
+          errors.add(:base, "An error")
+          allow_any_instance_of(Profile::ProfileItem).to receive(:save).and_return(errors)
+          allow_any_instance_of(Profile::ProfileItem).to receive(:errors).and_return(errors)
+        end
+
+        it "rolls back the transaction and returns errors" do
+          expect { subject.execute }.to change { Profile::ProfileItem.count }.by(0)
+          expect(subject.errors.full_messages).to include("An error")
+        end
+      end
+
+      context "when there are errors copying the profile text" do
+        before do
+          errors = ActiveModel::Errors.new(profile_item)
+          errors.add(:base, "An error")
+          allow_any_instance_of(Profile::ProfileText).to receive(:save).and_return(errors)
+          allow_any_instance_of(Profile::ProfileText).to receive(:errors).and_return(errors)
+        end
+
+        it "rolls back the transaction and returns errors" do
+          expect { subject.execute }.to change { Profile::ProfileText.count }.by(0)
+          expect(subject.errors.full_messages).to include("An error")
+        end
+      end
+
+      context "when there are errors copying the profile item annotation" do
+        before do
+          errors = ActiveModel::Errors.new(profile_item_annotation)
+          errors.add(:base, "An error")
+          allow_any_instance_of(Profile::ProfileItemAnnotation).to receive(:save).and_return(errors)
+          allow_any_instance_of(Profile::ProfileItemAnnotation).to receive(:errors).and_return(errors)
+        end
+
+        it "rolls back the transaction and returns errors" do
+          expect { subject.execute }.to change { Profile::ProfileItemAnnotation.count }.by(0)
+          expect(subject.errors.full_messages).to include("An error")
+        end
+      end
+
+      context "when there are errors copying the profile item references" do
+        before do
+          errors = ActiveModel::Errors.new(profile_item_reference)
+          errors.add(:base, "An error")
+          allow_any_instance_of(Profile::ProfileItemReference).to receive(:save).and_return(errors)
+          allow_any_instance_of(Profile::ProfileItemReference).to receive(:errors).and_return(errors)
+        end
+
+        it "rolls back the transaction and returns errors" do
+          expect { subject.execute }.to change { Profile::ProfileItemReference.count }.by(0)
+          expect(subject.errors.full_messages).to include("An error")
+        end
+      end
+    end
+
+    context "when profile item is a draft" do
+      let(:profile_item) { create(:profile_item, instance: instance, product_item_config: product_item_config, is_draft: true) }
+
+      it "does not create a new version and adds an error" do
+        subject.execute
+        expect(subject.errors.full_messages).to include("Profile item must be published before creating a new version")
+      end
+    end
+
+    context "when a draft already exists for the product item config" do
+      before do
+        create(:profile_item, instance: instance, product_item_config: product_item_config, is_draft: true)
+      end
+
+      it "does not create a new version and adds an error" do
+        subject.execute
+        expect(subject.errors.full_messages).to include("There is still a draft profile item for this product item config")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Adding a service responsible for creating a versioned copy of a profile item (copying the profile item and its associated annotations, profile text, and profile item references)

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Backend change, can only be tested from the specs atm or via console

## Tests
- [x] Unit tests
- [ ] Manual testing

## Related Issues
FLOR-77

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
