### PR TITLE
NSL-5462: Batch Review: Remove ability for user to edit or delete their comments after review ends

### DIFF
--- a/app/controllers/loader/name/review/comments_controller.rb
+++ b/app/controllers/loader/name/review/comments_controller.rb
@@ -48,8 +48,9 @@ class Loader::Name::Review::CommentsController < ApplicationController
   end
 
   def update
-    logger.debug("update")
     @review_comment = Loader::Name::Review::Comment.find(review_comment_params[:id])
+    raise 'Update not permitted because Review is not active' unless @review_comment.batch_review_period.active?
+    raise 'You cannot update a comment that is not your own' unless @current_user.username == @review_comment.reviewer.user.user_name
     @message = @review_comment.update_if_changed(review_comment_params,
                                                  current_user.username)
     render "update"
@@ -76,6 +77,8 @@ class Loader::Name::Review::CommentsController < ApplicationController
   end
 
   def destroy
+    raise 'Delete is not permitted because Review is not active' unless @review_comment.batch_review_period.active?
+    raise 'You cannot delete a comment that is not your own' unless @current_user.username == @review_comment.reviewer.user.user_name
     @review_comment.destroy
   rescue StandardError => e
     logger.error("Loader::Name::Review::Comment#destroy rescuing #{e}")

--- a/app/models/loader/name/review/comment.rb
+++ b/app/models/loader/name/review/comment.rb
@@ -39,6 +39,16 @@ class Loader::Name::Review::Comment < ActiveRecord::Base
 
   attr_accessor :give_me_focus, :message
 
+  before_update :check_review_active
+  before_destroy :check_review_active
+
+  def check_review_active
+    unless batch_review_period.active?
+      Rails.logger.error("Check review active will now abort action because review is not active")
+      throw :abort
+    end
+  end
+
   def fresh?
     created_at > 1.hour.ago
   end
@@ -75,7 +85,7 @@ class Loader::Name::Review::Comment < ActiveRecord::Base
   end
 
   def can_be_deleted?
-    true # for now
+    false # for now
   end
 
   def self.context_for(focus)

--- a/app/views/loader/names/review/tabs/common/_one_comment.html.erb
+++ b/app/views/loader/names/review/tabs/common/_one_comment.html.erb
@@ -9,8 +9,13 @@
   <%= render partial: 'detail_line',
              locals: {label: 'Comment by',
                       info: 
-                      "#{comment.reviewer.user.full_name} (#{comment.reviewer.org.try('abbrev')} #{comment.reviewer.role.name}) #{link_to('(edit)',
-                      edit_name_review_comment_path(comment.id), remote: true, class: 'blue', title: 'Edit your comment') if @current_user.username == comment.reviewer.user.user_name} "} %>
+                      "#{comment.reviewer.user.full_name} (#{comment.reviewer.org.try('abbrev')} #{comment.reviewer.role.name})l
+                       #{link_to('(edit)', edit_name_review_comment_path(comment.id),
+                                           remote: true,
+                                           class: 'blue',
+                                           title: 'Edit your comment') if comment.batch_review_period.active? && 
+                                                                          @current_user.username == comment.reviewer.user.user_name} "}
+                    %>
 
   </div>
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 20-Jun-2025
+  :jira_id: '5462'
+  :description: |-
+    Batch Review: Remove ability for user to edit or delete their comments after review ends
 - :date: 18-June-2025
   :jira_id: '73'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.8
+appversion=4.1.9.9


### PR DESCRIPTION
## Description
Don't offer user a link to edit/delete their comments when review is not active (i.e. after the review has closed), also check in controller and model to prevent update/delete when review isn't active.

## Type of change
- [x] Add missing feature (non-breaking change which adds functionality) - fix an oversight be adding these checks

## How to Test
Set up review, add comments as reviewer, end review, check user cannot edit/delete existing comments.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
