### PR TITLE
NSL-5468: Batch Review: Keep commenting available until the end of the review period's closing day

### DIFF
--- a/app/models/loader/batch/review.rb
+++ b/app/models/loader/batch/review.rb
@@ -53,7 +53,7 @@ class Loader::Batch::Review < ActiveRecord::Base
   end
 
   def active_periods
-    review_periods.all.select {|a| a.active?}
+    review_periods.active
   end
 
   def update_if_changed(params, username)

--- a/app/models/loader/batch/review.rb
+++ b/app/models/loader/batch/review.rb
@@ -53,7 +53,7 @@ class Loader::Batch::Review < ActiveRecord::Base
   end
 
   def active_periods
-    review_periods.where("start_date <= Now()").where("end_date is null or end_date >= Now()")
+    review_periods.all.select {|a| a.active?}
   end
 
   def update_if_changed(params, username)

--- a/app/models/loader/batch/review/period.rb
+++ b/app/models/loader/batch/review/period.rb
@@ -50,6 +50,11 @@ class Loader::Batch::Review::Period < ActiveRecord::Base
 
   attr_accessor :give_me_focus, :message
 
+  scope :active, -> { 
+    where("start_date <= ?", Time.zone.today)
+    .where("end_date IS NULL OR end_date >= ?", Time.zone.today)
+  }
+
   def loader_name_comments(loader_name_id, scope = "unrestricted")
     if scope == "unrestricted"
       return comments.order(:created_at).collect.select do |x|

--- a/app/views/loader/batch/review/periods/tabs/_tab_details.html.erb
+++ b/app/views/loader/batch/review/periods/tabs/_tab_details.html.erb
@@ -19,6 +19,10 @@
                      info: @review_period&.end_date&.strftime("%d-%b-%Y")} %>
 
 <%= render partial: 'detail_line',
+           locals: { label: 'active?',
+                     info: @review_period.active?} %>
+
+<%= render partial: 'detail_line',
       locals: {label: 'names with comments',
                info: link_to(@review_period.names_with_comments.size,
                         search_path(

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 20-Jun-2025
+  :jira_id: '5468'
+  :description: |-
+    Batch Review: Keep commenting available until the end of the review period's closing day
+- :date: 20-Jun-2025
   :jira_id: '5462'
   :description: |-
     Batch Review: Remove ability for user to edit or delete their comments after review ends

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.9
+appversion=4.1.9.10


### PR DESCRIPTION
## Description
Use the review period's active? method to correctly decided whether the comment form should be offered.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Comment on a loader name record on the same day the batch review period closes.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog 
