### PR TITLE
Refactor Reference model associations

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -105,7 +105,7 @@ class Reference < ActiveRecord::Base
 
   attr_accessor :display_as, :message
 
-  has_many :products, dependent: :nullify, foreign_key: "reference_id"
+  has_many :products, foreign_key: "reference_id"
 
   before_validation :set_defaults
   before_create :set_defaults

--- a/app/views/references/tabs/_tab_edit_3.html.erb
+++ b/app/views/references/tabs/_tab_edit_3.html.erb
@@ -15,6 +15,10 @@
       You cannot delete this reference because it has one or more instances.
     <% end %>
 
+    <% if @reference.products.any? %>
+      You cannot delete this reference because it has one or more products.
+    <% end %>
+
     <% unless @reference.children? || @reference.instances? %>
 
       <% delete_link = link_to("Delete the reference...",

--- a/app/views/references/tabs/_tab_show_1.html.erb
+++ b/app/views/references/tabs/_tab_show_1.html.erb
@@ -1,7 +1,7 @@
 <% increment_tab_index %>
 
-<%= @reference.ref_type.name %> by 
-<%= link_to("#{@reference.author.name} (#{@reference.ref_author_role.name}) #{search_icon_on_tab}".html_safe, search_path(query_string: "id:#{@reference.author_id}",query_target: 'author'),title: 'Search for the author(s)/editor(s)...',class: 'author') %> 
+<%= @reference.ref_type.name %> by
+<%= link_to("#{@reference.author.name} (#{@reference.ref_author_role.name}) #{search_icon_on_tab}".html_safe, search_path(query_string: "id:#{@reference.author_id}",query_target: 'author'),title: 'Search for the author(s)/editor(s)...',class: 'author') %>
 <br>
 <span title="Title"><%= @reference.title %></span>
 <br>
@@ -24,15 +24,15 @@
 <% if @reference.children && @reference.children.size != 0 %>
   <br>
   <% label_string = pluralize(@reference.children.size,'child') %>
-  <%= link_to("#{label_string} #{search_icon_on_tab}".html_safe, 
+  <%= link_to("#{label_string} #{search_icon_on_tab}".html_safe,
               search_path(query_target: "reference", query_string: "parent-id:#{@reference.id}"),
-              title: "Search for the #{label_string}", 
+              title: "Search for the #{label_string}",
               tabindex: increment_tab_index) %>
 <% end %>
 
 <% if @reference.duplicate_of.present? %>
   <br>
-  Duplicate of 
+  Duplicate of
   <%= link_to("#{@reference.duplicate_of.citation} #{search_icon_on_tab}".html_safe,
               search_path(query_target: "reference", query_string: "id:#{@reference.duplicate_of_id}"),
               title: 'Search for the duplicate reference.') %>
@@ -42,7 +42,7 @@
 <% if duplicates.size > 0 %>
   <br>
   <%= link_to(pluralize(duplicates.size,"Duplicate"),
-                          search_path(query_target: "reference", 
+                          search_path(query_target: "reference",
                                       query_string: "master-id:#{@reference.id}"),
                           title: "Retrieve this reference with its #{pluralize(duplicates.size,'duplicate')}") %>
 <% end %>
@@ -52,8 +52,8 @@
   <br>
   <% if instances_size == 1 %>
     <%= link_to("1 Instance #{search_icon_on_tab}".html_safe,
-                          search_path(query_target: "references", query_string: "id: #{@reference.id} show-instances:"), 
-                          tabindex: increment_tab_index, 
+                          search_path(query_target: "references", query_string: "id: #{@reference.id} show-instances:"),
+                          tabindex: increment_tab_index,
                           title: 'Search for the instance.') %>
   <% else %>
     <%= "#{instances_size} Instances" %>
@@ -62,7 +62,7 @@
                 search_path(query_string:
                             "id: #{@reference.id} show-instances:",
                             query_target: 'references'),
-                tabindex: increment_tab_index, 
+                tabindex: increment_tab_index,
                 title: 'Search for the instances, sorted by name.',
                 class: 'instance')
     %>
@@ -70,7 +70,7 @@
     <%= link_to("&mdash; sorted by page #{search_icon_on_tab}".html_safe,
                 search_path(query_string: "id:#{@reference.id.to_s} show-instances-by-page:",
                             query_target: "references"),
-                tabindex: increment_tab_index, 
+                tabindex: increment_tab_index,
                 title: 'Search for the instances, sorted by page.',
                 class: 'instance')
     %>
@@ -80,12 +80,18 @@
 <% novelties = @reference.novelties %>
 <% if novelties.size > 0 %>
   <%= link_to("#{pluralize(novelties.size,"Novelty")} #{search_icon_on_tab}".html_safe,
-                        search_path(query_target: "References with novelties", query_string: "id:#{@reference.id}"), 
-                        tabindex: increment_tab_index, 
+                        search_path(query_target: "References with novelties", query_string: "id:#{@reference.id}"),
+                        tabindex: increment_tab_index,
                         title: 'Taxon novelties in this reference.',
                         class: 'instance') %>
 <% end %>
 
+<% if @reference.products.present? %>
+  <h5>Products:</h5>
+  <% @reference.products.each do |product| %>
+    <p><%= "#{product.name} - ##{product.id}"%></p>
+  <% end %>
+<% end %>
 
 <% unless @reference.doi.blank? %>
   <br/>

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Reference, type: :model do
+  describe "associations" do
+    it { is_expected.to have_many(:products).with_foreign_key('reference_id') }
+  end
+end


### PR DESCRIPTION
## Description
Remove the nullify option from the has_many association of reference to a product and display the product associated to a reference int he details tab.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
- Go to a reference with associated product, select on the details tab (the product name and id will be displayed)
- Go to the 3rd edit tab (the number of products associated to the reference will be displayed and information that they wont be able to delete the reference)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Related Issues
NSL-5472

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
