### PR TITLE
Fix product reference lookup in _tab_copy_to_new_profile_v2.html.erb

### DIFF
--- a/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
@@ -3,7 +3,7 @@
     You do not have a product reference. Please contact your administrator.
   </div>
 <% else %>
-  <% product_reference = Profile::Product.find_by(name: @current_registered_user.available_product_from_roles&.name).reference %>
+  <% product_reference = Product.find_by(name: @current_registered_user.available_product_from_roles&.name).reference %>
   <div id="search-result-details-info-message-container" class="message-container"></div>
   <div id="search-result-details-error-message-container" class="message-container"></div>
   <% increment_tab_index(0) %>


### PR DESCRIPTION
## Description
Fixup the profile v2 copy tab not working which is due to the Profile::Product call which is no longer valid since we unified the Product model.

## Type of change
Please delete options that are not relevant.
- [ x ] Bug fix (non-breaking change which fixes an issue)

## How to Test
As profile editor, find an instance to copy and click on the copy tab

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
