### PR TITLE
FLOR-76 Refactor and fix prompt's unstable behaviour

### DIFF
--- a/app/javascript/prompt_form_save.js
+++ b/app/javascript/prompt_form_save.js
@@ -1,6 +1,9 @@
 let pendingHref = null;
 let noUnloadCheck = false;
 
+// Track forms that have been approved by auto-submit handlers to prevent double prompting
+const autoSubmitApprovedForms = new WeakMap();
+
 const observer = new MutationObserver(mutations => {
   let nodeClass = "form";
   if (!window.enableSiteWidePromptUnsavedChanges) { nodeClass = "form.prompt-form-save"; }
@@ -32,15 +35,19 @@ function setInitialFormState(form) {
 }
 
 function hasFormChanged(form) {
-  if (getFormState(form) !== form.dataset.initialState) {
-    console.log("has form changed: ", getFormState(form))
-    console.log("has form initial: ", form.dataset.initialState)
+  const currentState = getFormState(form);
+  const initialState = form.dataset.initialState;
+  const hasChanged = currentState !== initialState;
+  
+  if (hasChanged && typeof debug === "function") {
+    debug("Form changed - Current: ", currentState);
+    debug("Form changed - Initial: ", initialState);
   }
-  return getFormState(form) !== form.dataset.initialState;
+  
+  return hasChanged;
 }
 
 function resetFormChanged(form) {
-  form.dataset.changed = "false";
   setInitialFormState(form);
 }
 
@@ -58,7 +65,12 @@ function showUnsavedChangesModal(onContinue, onBack, message) {
   const messageElem = document.getElementById('unsaved-changes-message');
   const defaultMsg = "You have unsaved changes. Continue?";
 
-  if (modal) modal.style.display = 'flex';
+  if (!modal) {
+    console.error('Unsaved changes modal not found');
+    return;
+  }
+
+  modal.style.display = 'flex';
   if (messageElem) messageElem.textContent = message || defaultMsg;
 
   if (continueBtn) {
@@ -83,8 +95,12 @@ function getPromptableForms() {
   } else {
     forms = Array.from(document.querySelectorAll("form.prompt-form-save"));
   }
-  return forms.filter(form => form.id !== "search-form" && !form.querySelector('.auto-submit-on-change'));
+  return forms.filter(form => form.id !== "search-form");
+}
 
+function hasUnsavedChangesInOtherForms(currentForm) {
+  const forms = getPromptableForms();
+  return forms.filter(form => form !== currentForm).some(form => hasFormChanged(form));
 }
 // --- Global Unsaved Changes Check ---
 window.hasUnsavedFormChanges = function() {
@@ -97,26 +113,50 @@ window.renderFormPrompt = function() {
   document.querySelectorAll('select.auto-submit-on-change').forEach(select => {
     select.dataset.prevValue = select.value;
 
-    select.addEventListener('change', function(event) {
+    // Remove existing handler if present
+    if (select._autoSubmitHandler) {
+      select.removeEventListener('change', select._autoSubmitHandler);
+    }
+
+    const handler = function(event) {
       const form = select.form;
-      if (window.enablePromptUnsavedChanges && window.hasUnsavedFormChanges && window.hasUnsavedFormChanges()) {
-        const doSubmit = () => form.requestSubmit();
+      if (window.enablePromptUnsavedChanges && hasUnsavedChangesInOtherForms(form)) {
+        const doSubmit = () => {
+          // Mark this form as approved by auto-submit to prevent double prompting
+          autoSubmitApprovedForms.set(form, true);
+          try {
+            form.requestSubmit ? form.requestSubmit() : form.submit();
+          } catch (error) {
+            console.error('Form submission failed:', error);
+            // Clear the approval flag if submission fails
+            autoSubmitApprovedForms.delete(form);
+          }
+        };
         const doCancel = () => { select.value = select.dataset.prevValue; };
         event.preventDefault();
         if (window.showUnsavedChangesModal) {
-          window.showUnsavedChangesModal(doSubmit, doCancel);
+          window.showUnsavedChangesModal(doSubmit, doCancel, "You have unsaved changes in other forms. Continue with this action?");
         }
         return false;
       }
       // No unsaved changes, submit as normal
-      form.requestSubmit ? form.requestSubmit() : form.submit();
-    });
+      try {
+        form.requestSubmit ? form.requestSubmit() : form.submit();
+      } catch (error) {
+        console.error('Form submission failed:', error);
+      }
+    };
+
+    select.addEventListener('change', handler);
+    select._autoSubmitHandler = handler;
 
     // Update prevValue on successful submit
-    if (select.form) {
-      select.form.addEventListener("submit", function() {
+    if (select.form && !select.form._autoSubmitFormHandler) {
+      const formHandler = function() {
         select.dataset.prevValue = select.value;
-      });
+      };
+      select.form.addEventListener("submit", formHandler);
+      select.form._autoSubmitFormHandler = formHandler;
     }
   });
 
@@ -132,13 +172,24 @@ window.renderFormPrompt = function() {
   forms.forEach(form => {
     setInitialFormState(form);
 
-    ["input", "change"].forEach(evt =>
-      form.addEventListener(evt, () => {
-        form.dataset.changed = hasFormChanged(form);
-      })
-    );
+    // Remove existing change handlers to prevent double binding
+    if (form._changeHandlers) {
+      form._changeHandlers.forEach(({ event, handler }) => {
+        form.removeEventListener(event, handler);
+      });
+    }
+    form._changeHandlers = [];
 
-    // Remove any previous handler to avoid double-binding
+    // Add change tracking
+    ["input", "change"].forEach(evt => {
+      const handler = () => {
+        // Don't use dataset.changed, just rely on hasFormChanged
+      };
+      form.addEventListener(evt, handler);
+      form._changeHandlers.push({ event: evt, handler });
+    });
+
+    // Remove any previous submit handler to avoid double-binding
     if (form._promptFormSaveHandler) {
       form.removeEventListener("submit", form._promptFormSaveHandler);
     }
@@ -161,9 +212,12 @@ window.renderFormPrompt = function() {
 
       const doSubmit = () => {
         skipNextSubmitMap.set(form, true);
-        form.requestSubmit ? form.requestSubmit(submitBtn) : form.submit();
-        if (modal) modal.style.display = 'none';
-        resetFormChanged(form)
+        try {
+          form.requestSubmit ? form.requestSubmit(submitBtn) : form.submit();
+        } catch (error) {
+          console.error('Form submission failed:', error);
+        }
+        resetFormChanged(form);
       };
       const onCancel = () => {
         if (submitBtn) submitBtn.disabled = false;
@@ -183,35 +237,41 @@ window.renderFormPrompt = function() {
   });
 
   // Tab navigation with unsaved changes prompt
-  const modal = document.getElementById('unsaved-changes-modal');
   document.querySelectorAll('a.tab').forEach(tab => {
-    tab.addEventListener('click', event => {
+    // Remove existing handler to prevent double binding
+    if (tab._tabClickHandler) {
+      tab.removeEventListener('click', tab._tabClickHandler);
+    }
+    
+    const handler = function(event) {
       if (window.hasUnsavedFormChanges && window.hasUnsavedFormChanges()) {
         event.preventDefault();
         pendingHref = tab.getAttribute('href');
-        if (modal) modal.style.display = 'flex';
+        
+        const proceedWithNavigation = () => {
+          if (pendingHref) {
+            window.location.href = pendingHref;
+            pendingHref = null;
+          }
+        };
+        
+        const cancelNavigation = () => {
+          pendingHref = null;
+        };
+        
+        if (window.showUnsavedChangesModal) {
+          window.showUnsavedChangesModal(proceedWithNavigation, cancelNavigation);
+        } else if (confirm("You have unsaved changes. Continue?")) {
+          proceedWithNavigation();
+        } else {
+          cancelNavigation();
+        }
       }
-    });
+    };
+    
+    tab.addEventListener('click', handler);
+    tab._tabClickHandler = handler;
   });
-
-  // Modal continue/back for tab navigation
-  const continueBtn = document.getElementById('unsaved-continue');
-  const backBtn = document.getElementById('unsaved-back');
-  if (continueBtn) {
-    continueBtn.onclick = () => {
-      if (modal) modal.style.display = 'none';
-      if (pendingHref) {
-        window.location.href = pendingHref;
-        pendingHref = null;
-      }
-    };
-  }
-  if (backBtn) {
-    backBtn.onclick = () => {
-      if (modal) modal.style.display = 'none';
-      pendingHref = null;
-    };
-  }
 };
 
 window.showUnsavedChangesModal = showUnsavedChangesModal;
@@ -221,6 +281,12 @@ $(window).on('beforeunload', function (e) {
     e.preventDefault();
     return false;
   }
+});
+
+// Clear approval flags on page unload to prevent memory leaks
+$(window).on('unload', function() {
+  // Note: WeakMap will be garbage collected anyway, but this is good practice
+  autoSubmitApprovedForms.clear?.();
 });
 
 $('body').on('click', 'a', function(event) {
@@ -238,15 +304,23 @@ $('body').on('click', 'a', function(event) {
         $.ajax({
           url: href,
           type: $(this).attr('data-method') || 'GET',
-          dataType: 'script'
+          dataType: 'script',
+          error: function(xhr, status, error) {
+            console.error('Remote link failed:', error);
+          }
         });
         resetAllFormsChanged();
       } else {
         window.location.href = href;
       }
     };
+    
+    const cancel = () => {
+      // User decided not to proceed
+    };
+    
     if (window.showUnsavedChangesModal) {
-      window.showUnsavedChangesModal(proceed);
+      window.showUnsavedChangesModal(proceed, cancel);
     } else if (confirm("You have unsaved changes. Continue?")) {
       proceed();
     }
@@ -258,24 +332,31 @@ document.body.addEventListener('submit', function(event) {
   const form = event.target;
   if (!(form instanceof HTMLFormElement)) return;
 
+  // Check if this form was already approved by auto-submit handler
+  if (autoSubmitApprovedForms.has(form)) {
+    // Clear the approval flag and allow submission to proceed
+    autoSubmitApprovedForms.delete(form);
+    return;
+  }
+
   // Only prompt if there are unsaved changes in *other* forms
-  if (window.enablePromptUnsavedChanges && window.hasUnsavedFormChanges && window.hasUnsavedFormChanges()) {
-    // Find all dirty forms except the one being submitted
-    const dirtyOtherForms = getPromptableForms().filter(f => f !== form && hasFormChanged(f));
-    if (dirtyOtherForms.length > 0) {
-      event.preventDefault();
-      const doSubmit = () => {
-        resetAllFormsChanged();
-        form.submit();
-      };
-      const doCancel = () => {};
-      if (window.showUnsavedChangesModal) {
-        window.showUnsavedChangesModal(doSubmit, doCancel);
-      } else if (confirm("You have unsaved changes in another form. Continue?")) {
-        doSubmit();
+  if (window.enablePromptUnsavedChanges && hasUnsavedChangesInOtherForms(form)) {
+    event.preventDefault();
+    const doSubmit = () => {
+      resetAllFormsChanged();
+      try {
+        form.requestSubmit ? form.requestSubmit() : form.submit();
+      } catch (error) {
+        console.error('Form submission failed:', error);
       }
-      return false;
+    };
+    const doCancel = () => {};
+    if (window.showUnsavedChangesModal) {
+      window.showUnsavedChangesModal(doSubmit, doCancel, "You have unsaved changes in other forms. Continue?");
+    } else if (confirm("You have unsaved changes in other forms. Continue?")) {
+      doSubmit();
     }
+    return false;
   }
   // Otherwise, allow normal logic (including per-form prompt)
 }, true);

--- a/app/javascript/search_result_focus.js
+++ b/app/javascript/search_result_focus.js
@@ -58,17 +58,16 @@
   });
 
   promptFormUnsavedChanges = function(event, proceedCallback) {
-    if (window.enablePromptUnsavedChanges && (window.hasUnsavedFormChanges ? window.hasUnsavedFormChanges() : window.formChanged)) {
+    if (window.enablePromptUnsavedChanges && window.hasUnsavedFormChanges && window.hasUnsavedFormChanges()) {
       event.preventDefault();
       if (window.showUnsavedChangesModal) {
         window.showUnsavedChangesModal(proceedCallback);
       } else if (confirm("You have unsaved changes. Continue?")) {
-        window.formChanged = false;
         if(proceedCallback) proceedCallback();
       }
       return false;
     }
-   proceedCallback();
+    if(proceedCallback) proceedCallback();
   };
 
   optionalFocusOnPageLoad = function() {

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 07-July-2025
+  :jira_id: '76'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Additional Fixes for the prompt for unsaved changes in the profile item editor
 - :date: 04-July-2025
   :jira_id: '76'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.16
+appversion=4.1.9.17


### PR DESCRIPTION
## Description
Fixup unstable/buggy prompt message for unsaved form

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Edit a foa form from the editor -> navigate away by visiting other tabs, links, submitting search form -> a popup should show


## Tests
- [ ] Unit tests
- [x] Manual testing

## Related Issues
FLOR-76

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
