### PR TITLE
Multi-product support in tabs behind feature flag

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,24 +12,6 @@ module ApplicationHelper
     <div class='text-for-link'>#{text}</div>".html_safe
   end
 
-  def user_profile_tab_name
-    current_registered_user.available_product_from_roles&.name
-  end
-
-  def user_profile_tab_names
-    current_registered_user.available_products_from_roles.map(&:name)
-  end
-
-  def increment_tab_index(increment = 1)
-    @tab_index ||= 1
-    @tab_index += increment
-  end
-
-  def tab_index(offset = 0)
-    tabi = @tab_index || 1
-    tabi + offset
-  end
-
   def treated_label(label, treatment = :description)
     case treatment
     when :description
@@ -126,7 +108,7 @@ module ApplicationHelper
       "#{ShardConfig.shard_group_name}"
     else
       "#{ShardConfig.shard_group_name}"
-    end + ":" + (params["query_target"] || "Editor").gsub("_", " ").titleize
+    end + ":" + (params["query_target"] || "Editor").tr("_", " ").titleize
   end
 
   def development?
@@ -144,5 +126,3 @@ class String
     tr("_", " ").upcase
   end
 end
-
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,6 +16,10 @@ module ApplicationHelper
     current_registered_user.available_product_from_roles&.name
   end
 
+  def user_profile_tab_names
+    current_registered_user.available_products_from_roles.map(&:name)
+  end
+
   def increment_tab_index(increment = 1)
     @tab_index ||= 1
     @tab_index += increment

--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Help for Tabs display
+module TabsHelper
+  def user_profile_tab_name
+    current_registered_user.available_product_from_roles&.name
+  end
+
+  def user_profile_tab_names
+    current_registered_user.available_products_from_roles.map(&:name)
+  end
+
+  def increment_tab_index(increment = 1)
+    @tab_index ||= 1
+    @tab_index += increment
+  end
+
+  def tab_index(offset = 0)
+    tabi = @tab_index || 1
+    tabi + offset
+  end
+end

--- a/app/javascript/search_result_focus.js
+++ b/app/javascript/search_result_focus.js
@@ -122,7 +122,8 @@
       debug(err);
     }
     debug(`starting url: ${url}`);
-    url = url + '?format=js&tabIndex=' + tabIndex;
+    const paramJoin = url.includes('?') ? '&' : '?';
+    url = url + `${paramJoin}format=js&tabIndex=${tabIndex}`;
     if (row_type != null) {
       url = url + '&row-type=' + row_type;
     }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,11 +60,8 @@ class User < ActiveRecord::Base
     # which specific product this user is related to.
     # Currently, we're making an assumption that there will
     # be just one product associated with these roles.
-    # We are currently using this method for the profile items
-    roles_to_check = ['draft-editor','draft-profile-editor', 'profile-editor']
     product_roles
       .joins(:role)
-      .where(roles: { name: roles_to_check })
       .includes(:product)
       .first&.product
   end
@@ -73,10 +70,8 @@ class User < ActiveRecord::Base
     # Returns all products that this user has access to through their roles
     # This method supports multi-product scenarios by returning all available products
     # instead of just the first one
-    roles_to_check = ['draft-editor','draft-profile-editor', 'profile-editor']
     product_roles
       .joins(:role)
-      .where(roles: { name: roles_to_check })
       .includes(:product)
       .map(&:product)
       .compact

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,20 @@ class User < ActiveRecord::Base
       .first&.product
   end
 
+  def available_products_from_roles
+    # Returns all products that this user has access to through their roles
+    # This method supports multi-product scenarios by returning all available products
+    # instead of just the first one
+    roles_to_check = ['draft-editor','draft-profile-editor', 'profile-editor']
+    product_roles
+      .joins(:role)
+      .where(roles: { name: roles_to_check })
+      .includes(:product)
+      .map(&:product)
+      .compact
+      .uniq
+  end
+
   def set_audit_fields
     self.created_by = self.updated_by = @current_user&.username||'self as new user'
   end

--- a/app/views/names/show.html.erb
+++ b/app/views/names/show.html.erb
@@ -11,7 +11,12 @@
 
   <%= render partial: 'names/tabs/tabs' %>
 
+  <% if Rails.configuration.try('multi_product_tabs_enabled') && params[:product_name].present? %>
+  <% product = Product.find_by(name: params[:product_name].upcase) %>
+  <%= render partial: "names/tabs/#{@tab}", locals: { product: product } %>
+  <% else %>
   <%= render partial: "names/tabs/#{@tab}" %>
+  <% end %>
 
   <span class='server-response-time'><%= "(#{(Time.now - @start_time).round(2)}s)" if @start_time %></span>
 

--- a/app/views/names/tabs/_tab.html.erb
+++ b/app/views/names/tabs/_tab.html.erb
@@ -1,11 +1,15 @@
 <% this_tab_re = Regexp.new(this_tab) %>
-<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/)) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
+<% current_product_name = params[:product_name] || '' %>
+<% tab_product_name = local_assigns[:product_name] || '' %>
+<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/) && current_product_name == tab_product_name) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
 <% semi_active_tab = (@tab.match(/tab_comments|tab_name_tags|tab_refresh|tab_de_duplicate/) && this_tab.match(/tab_more/)) %>
 <% semi_active_tab = semi_active_tab || (@tab.match(/tab_more/) && this_tab.match(/tab_more/)) %>
 
 <% data = Hash.new %>
-<% data['edit-url'] = name_tab_path(@name,tab:"#{this_tab}") %>
-<% data['tab-url'] = name_tab_path(@name,tab:"#{this_tab}") %>
+<% tab_url_params = {tab: this_tab} %>
+<% tab_url_params[:product_name] = local_assigns[:product_name] if local_assigns[:product_name].present? %>
+<% data['edit-url'] = name_tab_path(@name, tab_url_params) %>
+<% data['tab-url'] = name_tab_path(@name, tab_url_params) %>
 <% data['prev-tab'] = prev_tab unless prev_tab.blank? %>
 <% data['tab-name'] = this_tab %>
 

--- a/app/views/names/tabs/_tab.html.erb
+++ b/app/views/names/tabs/_tab.html.erb
@@ -1,7 +1,7 @@
 <% this_tab_re = Regexp.new(this_tab) %>
-<% current_product_name = params[:product_name] || '' %>
+<% current_product_name = params[:product_name]&.split('?')&.first  || '' %>
 <% tab_product_name = local_assigns[:product_name] || '' %>
-<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/) && current_product_name == tab_product_name) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
+<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/) && (current_product_name == tab_product_name)) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
 <% semi_active_tab = (@tab.match(/tab_comments|tab_name_tags|tab_refresh|tab_de_duplicate/) && this_tab.match(/tab_more/)) %>
 <% semi_active_tab = semi_active_tab || (@tab.match(/tab_more/) && this_tab.match(/tab_more/)) %>
 
@@ -18,7 +18,7 @@
  <%= link_to link_text,
              '#',
              id: link_id,
-             class: 'tab edit-details-tab', 
+             class: 'tab edit-details-tab',
              title: link_title,
              tabindex: tab_index,
              take_focus: true,

--- a/app/views/names/tabs/_tab_instances_profile_v2.html.erb
+++ b/app/views/names/tabs/_tab_instances_profile_v2.html.erb
@@ -1,4 +1,4 @@
-<% product = @current_registered_user.available_product_from_roles %>
+<% product = local_assigns[:product] || @current_registered_user.available_product_from_roles %>
 
 <% if product.blank? || product.reference.blank? %>
   <div id="search-result-details-error-message-container" class="message-container">
@@ -17,7 +17,7 @@
     <div id="search-result-details-error-message-container-1" class="error-container"></div>
     <div id="search-result-details-error-message-container-2" class="error-container"></div>
     <div id="search-result-details-error-message-container-3" class="error-container"></div>
-    <h5>Add an instance for FOA</h5>
+    <h5>Add an instance for <%= product.name %></h5>
 
     <%= form_for(@instance, remote: true) do |f| %>
       The new instance will remain attached to:<br>

--- a/app/views/names/tabs/_tabs.html.erb
+++ b/app/views/names/tabs/_tabs.html.erb
@@ -1,89 +1,182 @@
-    <ul class="nav nav-tabs">
+<ul class="nav nav-tabs">
 
-      <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                          last: false,
-                                          this_tab: 'tab_details',
-                                          link_text: 'Details',
-                                          link_id: 'name-details-tab',
-                                          link_title: 'See details of the name',
-                                          tab_index: increment_tab_index,
-                                          prev_tab: '',
-                                          next_tab: '' } %>
+  <% if Rails.configuration.try('multi_product_tabs_enabled') %>
+  <% @current_registered_user.available_products_from_roles.each do |product| %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_details',
+                                              link_text: "#{product.name} Details",
+                                              link_id: "name-details-#{product.name.downcase}-tab",
+                                              link_title: "See details of the name for #{product.name}",
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: '',
+                                              product_name: product.name } %>
 
-      <% if can? 'names', 'update' %>
+  <% if can? 'names', 'update' %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                                last: false,
+                                                this_tab: 'tab_edit',
+                                                link_text: "#{product.name} Edit".html_safe,
+                                                link_id: "name-edit-#{product.name.downcase}-tab",
+                                                link_title: "Edit details of the name for #{product.name}.",
+                                                tab_index: increment_tab_index,
+                                                prev_tab: '',
+                                                next_tab: '',
+                                                product_name: product.name} %>
+  <% end %>
 
-        <%= render partial: 'names/tabs/tab', locals: {first: false,
+  <% if can? :create_with_product_reference, Instance %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                                last: false,
+                                                this_tab: 'tab_instances_profile_v2',
+                                                link_text: "#{product.name} New instance".html_safe,
+                                                link_id: "name-instances-profile-v2-#{product.name.downcase}-tab",
+                                                link_title: "Create an instance for the name in #{product.name}.",
+                                                tab_index: increment_tab_index,
+                                                prev_tab: '',
+                                                next_tab: '',
+                                                product_name: product.name} %>
+  <% elsif can? :create, Instance %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                                last: false,
+                                                this_tab: 'tab_instances',
+                                                link_text: "#{product.name} New instance".html_safe,
+                                                link_id: "name-instances-#{product.name.downcase}-tab",
+                                                link_title: "Create an instance for the name in #{product.name}.",
+                                                tab_index: increment_tab_index,
+                                                prev_tab: '',
+                                                next_tab: '',
+                                                product_name: product.name} %>
+  <% end %>
+  <% end %>
+  <% else %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
                                             last: false,
-                                            this_tab: 'tab_edit',
-                                            link_text: "Edit".html_safe,
-                                            link_id: 'name-edit-tab',
-                                            link_title: 'Edit details of the name.',
+                                            this_tab: 'tab_details',
+                                            link_text: 'Details',
+                                            link_id: 'name-details-tab',
+                                            link_title: 'See details of the name',
                                             tab_index: increment_tab_index,
                                             prev_tab: '',
-                                            next_tab: ''} %>
-      <% end %>
+                                            next_tab: '' } %>
 
-      <% if can? :create_with_product_reference, Instance %>
-        <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                            last: false,
-                                            this_tab: 'tab_instances_profile_v2',
-                                            link_text: "New instance".html_safe,
-                                            link_id: 'name-instances-profile-v2-tab',
-                                            link_title: 'Create an instance for the name.',
-                                            tab_index: increment_tab_index,
-                                            prev_tab: '',
-                                            next_tab: ''} %>
-      <% elsif can? :create, Instance %>
-        <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                            last: false,
-                                            this_tab: 'tab_instances',
-                                            link_text: "New instance".html_safe,
-                                            link_id: 'name-instances-tab',
-                                            link_title: 'Create an instance for the name.',
-                                            tab_index: increment_tab_index,
-                                            prev_tab: '',
-                                            next_tab: ''} %>
-      <% end %>
+  <% if can? 'names', 'update' %>
 
-      <% if can? :create, Instance %>
-        <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                            last: false,
-                                            this_tab: 'tab_copy',
-                                            link_text: "Copy".html_safe,
-                                            link_id: 'name-copy-tab',
-                                            link_title: 'Copy the name.',
-                                            tab_index: increment_tab_index,
-                                            prev_tab: '',
-                                            next_tab: ''} %>
-      <% end %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_edit',
+                                              link_text: "Edit".html_safe,
+                                              link_id: 'name-edit-tab',
+                                              link_title: 'Edit details of the name.',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
+  <% end %>
 
-      <% if can? 'names', 'delete' %>
+  <% if can? :create_with_product_reference, Instance %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_instances_profile_v2',
+                                              link_text: "New instance".html_safe,
+                                              link_id: 'name-instances-profile-v2-tab',
+                                              link_title: 'Create an instance for the name.',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
+  <% elsif can? :create, Instance %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_instances',
+                                              link_text: "New instance".html_safe,
+                                              link_id: 'name-instances-tab',
+                                              link_title: 'Create an instance for the name.',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
+  <% end %>
+  <% end %>
 
-        <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                            last: false,
-                                            this_tab: 'tab_delete',
-                                            link_text: "Delete".html_safe,
-                                            link_id: 'name-delete-tab',
-                                            link_title: 'Delete name.',
-                                            tab_index: increment_tab_index,
-                                            prev_tab: '',
-                                            next_tab: ''} %>
+  <% if ENV['ENABLE_MULTI_PRODUCT_TABS'] == 'true' %>
+  <% @current_registered_user.available_products_from_roles.each do |product| %>
+  <% if can? :create, Instance %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                                last: false,
+                                                this_tab: 'tab_copy',
+                                                link_text: "#{product.name} Copy".html_safe,
+                                                link_id: "name-copy-#{product.name.downcase}-tab",
+                                                link_title: "Copy the name for #{product.name}.",
+                                                tab_index: increment_tab_index,
+                                                prev_tab: '',
+                                                next_tab: '',
+                                                product_name: product.name} %>
+  <% end %>
 
-      <% end %>
+  <% if can? 'names', 'delete' %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                                last: false,
+                                                this_tab: 'tab_delete',
+                                                link_text: "#{product.name} Delete".html_safe,
+                                                link_id: "name-delete-#{product.name.downcase}-tab",
+                                                link_title: "Delete name for #{product.name}.",
+                                                tab_index: increment_tab_index,
+                                                prev_tab: '',
+                                                next_tab: '',
+                                                product_name: product.name} %>
+  <% end %>
+  <% end %>
 
-      <% if can? 'names', 'update' %>
+  <% if can? 'names', 'update' %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_more',
+                                              link_text: "More".html_safe,
+                                              link_id: 'name-more-tab',
+                                              link_title: 'Show more tabs',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
+  <% end %>
+  <% else %>
+  <% if can? :create, Instance %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_copy',
+                                              link_text: "Copy".html_safe,
+                                              link_id: 'name-copy-tab',
+                                              link_title: 'Copy the name.',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
+  <% end %>
 
-        <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                            last: false,
-                                            this_tab: 'tab_more',
-                                            link_text: "More".html_safe,
-                                            link_id: 'name-more-tab',
-                                            link_title: 'Show more tabs',
-                                            tab_index: increment_tab_index,
-                                            prev_tab: '',
-                                            next_tab: ''} %>
+  <% if can? 'names', 'delete' %>
 
-      <% end %>
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_delete',
+                                              link_text: "Delete".html_safe,
+                                              link_id: 'name-delete-tab',
+                                              link_title: 'Delete name.',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
 
-    </ul>
+  <% end %>
 
+  <% if can? 'names', 'update' %>
+
+  <%= render partial: 'names/tabs/tab', locals: {first: false,
+                                              last: false,
+                                              this_tab: 'tab_more',
+                                              link_text: "More".html_safe,
+                                              link_id: 'name-more-tab',
+                                              link_title: 'Show more tabs',
+                                              tab_index: increment_tab_index,
+                                              prev_tab: '',
+                                              next_tab: ''} %>
+
+  <% end %>
+  <% end %>
+
+</ul>

--- a/app/views/names/tabs/_tabs.html.erb
+++ b/app/views/names/tabs/_tabs.html.erb
@@ -1,182 +1,245 @@
 <ul class="nav nav-tabs">
+  <% if Rails.configuration.try('multi_product_tabs_enabled') %>
+    <% @current_registered_user.available_products_from_roles.each do |product| %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_details',
+          link_text: "#{product.name} Details",
+          link_id: "name-details-#{product.name.downcase}-tab",
+          link_title: "See details of the name for #{product.name}",
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: '',
+          product_name: product.name
+        })
+      %>
+
+      <% if can? 'names', 'update' %>
+        <%= render(
+          partial: 'names/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_edit',
+            link_text: "#{product.name} Edit".html_safe,
+            link_id: "name-edit-#{product.name.downcase}-tab",
+            link_title: "Edit details of the name for #{product.name}.",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name
+          })
+        %>
+      <% end %>
+
+      <% if can? :create_with_product_reference, Instance %>
+        <%= render(
+          partial: 'names/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_instances_profile_v2',
+            link_text: "#{product.name} New instance".html_safe,
+            link_id: "name-instances-profile-v2-#{product.name.downcase}-tab",
+            link_title: "Create an instance for the name in #{product.name}.",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name
+          })
+        %>
+      <% elsif can? :create, Instance %>
+        <%= render(
+          partial: 'names/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_instances',
+            link_text: "#{product.name} New instance".html_safe,
+            link_id: "name-instances-#{product.name.downcase}-tab",
+            link_title: "Create an instance for the name in #{product.name}.",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name
+          })
+        %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= render(
+      partial: 'names/tabs/tab',
+      locals: {
+        first: false,
+        last: false,
+        this_tab: 'tab_details',
+        link_text: 'Details',
+        link_id: 'name-details-tab',
+        link_title: 'See details of the name',
+        tab_index: increment_tab_index,
+        prev_tab: '',
+        next_tab: ''
+      })
+    %>
+
+    <% if can? 'names', 'update' %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_edit',
+          link_text: "Edit".html_safe,
+          link_id: 'name-edit-tab',
+          link_title: 'Edit details of the name.',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
+
+    <% if can? :create_with_product_reference, Instance %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_instances_profile_v2',
+          link_text: "New instance".html_safe,
+          link_id: 'name-instances-profile-v2-tab',
+          link_title: 'Create an instance for the name.',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% elsif can? :create, Instance %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_instances',
+          link_text: "New instance".html_safe,
+          link_id: 'name-instances-tab',
+          link_title: 'Create an instance for the name.',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
+  <% end %>
 
   <% if Rails.configuration.try('multi_product_tabs_enabled') %>
-  <% @current_registered_user.available_products_from_roles.each do |product| %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_details',
-                                              link_text: "#{product.name} Details",
-                                              link_id: "name-details-#{product.name.downcase}-tab",
-                                              link_title: "See details of the name for #{product.name}",
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: '',
-                                              product_name: product.name } %>
+    <% @current_registered_user.available_products_from_roles.each do |product| %>
+      <% if can? :create, Instance %>
+        <%= render(
+          partial: 'names/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_copy',
+            link_text: "#{product.name} Copy".html_safe,
+            link_id: "name-copy-#{product.name.downcase}-tab",
+            link_title: "Copy the name for #{product.name}.",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name
+          })
+        %>
+      <% end %>
 
-  <% if can? 'names', 'update' %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                                last: false,
-                                                this_tab: 'tab_edit',
-                                                link_text: "#{product.name} Edit".html_safe,
-                                                link_id: "name-edit-#{product.name.downcase}-tab",
-                                                link_title: "Edit details of the name for #{product.name}.",
-                                                tab_index: increment_tab_index,
-                                                prev_tab: '',
-                                                next_tab: '',
-                                                product_name: product.name} %>
-  <% end %>
+      <% if can? 'names', 'delete' %>
+        <%= render(
+          partial: 'names/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_delete',
+            link_text: "#{product.name} Delete".html_safe,
+            link_id: "name-delete-#{product.name.downcase}-tab",
+            link_title: "Delete name for #{product.name}.",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name
+          })
+        %>
+      <% end %>
+    <% end %>
 
-  <% if can? :create_with_product_reference, Instance %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                                last: false,
-                                                this_tab: 'tab_instances_profile_v2',
-                                                link_text: "#{product.name} New instance".html_safe,
-                                                link_id: "name-instances-profile-v2-#{product.name.downcase}-tab",
-                                                link_title: "Create an instance for the name in #{product.name}.",
-                                                tab_index: increment_tab_index,
-                                                prev_tab: '',
-                                                next_tab: '',
-                                                product_name: product.name} %>
-  <% elsif can? :create, Instance %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                                last: false,
-                                                this_tab: 'tab_instances',
-                                                link_text: "#{product.name} New instance".html_safe,
-                                                link_id: "name-instances-#{product.name.downcase}-tab",
-                                                link_title: "Create an instance for the name in #{product.name}.",
-                                                tab_index: increment_tab_index,
-                                                prev_tab: '',
-                                                next_tab: '',
-                                                product_name: product.name} %>
-  <% end %>
-  <% end %>
+    <% if can? 'names', 'update' %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_more',
+          link_text: "More".html_safe,
+          link_id: 'name-more-tab',
+          link_title: 'Show more tabs',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
   <% else %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                            last: false,
-                                            this_tab: 'tab_details',
-                                            link_text: 'Details',
-                                            link_id: 'name-details-tab',
-                                            link_title: 'See details of the name',
-                                            tab_index: increment_tab_index,
-                                            prev_tab: '',
-                                            next_tab: '' } %>
+    <% if can? :create, Instance %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_copy',
+          link_text: "Copy".html_safe,
+          link_id: 'name-copy-tab',
+          link_title: 'Copy the name.',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
 
-  <% if can? 'names', 'update' %>
+    <% if can? 'names', 'delete' %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_delete',
+          link_text: "Delete".html_safe,
+          link_id: 'name-delete-tab',
+          link_title: 'Delete name.',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
 
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_edit',
-                                              link_text: "Edit".html_safe,
-                                              link_id: 'name-edit-tab',
-                                              link_title: 'Edit details of the name.',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
+    <% if can? 'names', 'update' %>
+      <%= render(
+        partial: 'names/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_more',
+          link_text: "More".html_safe,
+          link_id: 'name-more-tab',
+          link_title: 'Show more tabs',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
   <% end %>
-
-  <% if can? :create_with_product_reference, Instance %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_instances_profile_v2',
-                                              link_text: "New instance".html_safe,
-                                              link_id: 'name-instances-profile-v2-tab',
-                                              link_title: 'Create an instance for the name.',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
-  <% elsif can? :create, Instance %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_instances',
-                                              link_text: "New instance".html_safe,
-                                              link_id: 'name-instances-tab',
-                                              link_title: 'Create an instance for the name.',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
-  <% end %>
-  <% end %>
-
-  <% if ENV['ENABLE_MULTI_PRODUCT_TABS'] == 'true' %>
-  <% @current_registered_user.available_products_from_roles.each do |product| %>
-  <% if can? :create, Instance %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                                last: false,
-                                                this_tab: 'tab_copy',
-                                                link_text: "#{product.name} Copy".html_safe,
-                                                link_id: "name-copy-#{product.name.downcase}-tab",
-                                                link_title: "Copy the name for #{product.name}.",
-                                                tab_index: increment_tab_index,
-                                                prev_tab: '',
-                                                next_tab: '',
-                                                product_name: product.name} %>
-  <% end %>
-
-  <% if can? 'names', 'delete' %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                                last: false,
-                                                this_tab: 'tab_delete',
-                                                link_text: "#{product.name} Delete".html_safe,
-                                                link_id: "name-delete-#{product.name.downcase}-tab",
-                                                link_title: "Delete name for #{product.name}.",
-                                                tab_index: increment_tab_index,
-                                                prev_tab: '',
-                                                next_tab: '',
-                                                product_name: product.name} %>
-  <% end %>
-  <% end %>
-
-  <% if can? 'names', 'update' %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_more',
-                                              link_text: "More".html_safe,
-                                              link_id: 'name-more-tab',
-                                              link_title: 'Show more tabs',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
-  <% end %>
-  <% else %>
-  <% if can? :create, Instance %>
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_copy',
-                                              link_text: "Copy".html_safe,
-                                              link_id: 'name-copy-tab',
-                                              link_title: 'Copy the name.',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
-  <% end %>
-
-  <% if can? 'names', 'delete' %>
-
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_delete',
-                                              link_text: "Delete".html_safe,
-                                              link_id: 'name-delete-tab',
-                                              link_title: 'Delete name.',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
-
-  <% end %>
-
-  <% if can? 'names', 'update' %>
-
-  <%= render partial: 'names/tabs/tab', locals: {first: false,
-                                              last: false,
-                                              this_tab: 'tab_more',
-                                              link_text: "More".html_safe,
-                                              link_id: 'name-more-tab',
-                                              link_title: 'Show more tabs',
-                                              tab_index: increment_tab_index,
-                                              prev_tab: '',
-                                              next_tab: ''} %>
-
-  <% end %>
-  <% end %>
-
 </ul>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 21-July-2025
+  :jira_id: '82'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Implement multi-product tabs
 - :date: 15-Jul-2025
   :jira_id: '5505'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.19
+appversion=4.1.9.20

--- a/spec/helpers/instances_helper_spec.rb
+++ b/spec/helpers/instances_helper_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe InstancesHelper, type: :helper do
   describe "#tab_for_instance_record" do
     context "for invalid arguments" do
       it "raises an error" do
-        expect{helper.tab_for_instance_record}.to raise_error(ArgumentError)
+        expect { helper.tab_for_instance_record }.to raise_error(ArgumentError)
       end
     end
 
     context "passing a known tab" do
       it "returns the tab" do
         %w[tab_synonymy
-        tab_synonymy_for_profile_v2
-        tab_unpublished_citation
-        tab_unpublished_citation_for_profile_v2
-        tab_classification
-        tab_copy_to_new_reference].each do |tab|
+           tab_synonymy_for_profile_v2
+           tab_unpublished_citation
+           tab_unpublished_citation_for_profile_v2
+           tab_classification
+           tab_copy_to_new_reference].each do |tab|
           expect(helper.tab_for_instance_record(tab)).to eq tab
         end
       end
@@ -35,29 +35,29 @@ RSpec.describe InstancesHelper, type: :helper do
 
     context "for invalid arguments" do
       it "raises an error" do
-        expect{helper.tab_for_iapo_concept_record}.to raise_error(ArgumentError)
+        expect { helper.tab_for_iapo_concept_record }.to raise_error(ArgumentError)
       end
     end
 
     context "passing a known tab" do
       let(:tabs_to_offer) do
         %w[tab_synonymy
-          tab_synonymy_for_profile_v2
-          tab_unpublished_citation
-          tab_unpublished_citation_for_profile_v2
-          tab_classification
-          tab_copy_to_new_reference
-          tab_batch_loader_2]
+           tab_synonymy_for_profile_v2
+           tab_unpublished_citation
+           tab_unpublished_citation_for_profile_v2
+           tab_classification
+           tab_copy_to_new_reference
+           tab_batch_loader_2]
       end
 
       it "returns the tab" do
         %w[tab_synonymy
-          tab_synonymy_for_profile_v2
-          tab_unpublished_citation
-          tab_unpublished_citation_for_profile_v2
-          tab_classification
-          tab_copy_to_new_reference
-          tab_batch_loader_2].each do |tab|
+           tab_synonymy_for_profile_v2
+           tab_unpublished_citation
+           tab_unpublished_citation_for_profile_v2
+           tab_classification
+           tab_copy_to_new_reference
+           tab_batch_loader_2].each do |tab|
           expect(helper.tab_for_iapo_concept_record(tab)).to eq tab
         end
       end
@@ -74,16 +74,16 @@ RSpec.describe InstancesHelper, type: :helper do
   describe "#tab_for_citing_instance_in_name_search" do
     context "for invalid arguments" do
       it "raises an error" do
-        expect{helper.tab_for_citing_instance_in_name_search}.to raise_error(ArgumentError)
+        expect { helper.tab_for_citing_instance_in_name_search }.to raise_error(ArgumentError)
       end
     end
 
     context "passing a known tab" do
       it "returns the tab" do
         %w[tab_synonymy
-          tab_synonymy_for_profile_v2
-          tab_create_unpublished_citation
-          tab_unpublished_citation_for_profile_v2].each do |tab|
+           tab_synonymy_for_profile_v2
+           tab_create_unpublished_citation
+           tab_unpublished_citation_for_profile_v2].each do |tab|
           expect(helper.tab_for_citing_instance_in_name_search(tab)).to eq tab
         end
       end

--- a/spec/helpers/tabs_helper_spec.rb
+++ b/spec/helpers/tabs_helper_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe TabsHelper, type: :helper do
+  let(:product1) { double(name: "FOO") }
+  let(:product2) { double(name: "BAR") }
+
+  before do
+    user =  double(
+      available_product_from_roles: product1,
+      available_products_from_roles: [product1, product2]
+    )
+    helper.define_singleton_method(:current_registered_user) { user }
+    helper.instance_variable_set(:@tab_index, nil)
+  end
+
+  describe "#user_profile_tab_name" do
+    it "returns the name of the user's available product" do
+      expect(helper.user_profile_tab_name).to eq(product1.name)
+    end
+  end
+
+  describe "#user_profile_tab_names" do
+    it "returns the names of all user's available products" do
+      expect(helper.user_profile_tab_names).to eq(%w[FOO BAR])
+    end
+  end
+
+  describe "#increment_tab_index" do
+    it "increments @tab_index by 1 by default" do
+      expect(helper.increment_tab_index).to eq(2)
+      expect(helper.increment_tab_index).to eq(3)
+    end
+
+    it "increments @tab_index by a given value" do
+      expect(helper.increment_tab_index(3)).to eq(4)
+    end
+  end
+
+  describe "#tab_index" do
+    it "returns @tab_index plus offset" do
+      helper.increment_tab_index
+      expect(helper.tab_index).to eq(2)
+      expect(helper.tab_index(2)).to eq(4)
+    end
+
+    it "defaults @tab_index to 1 if not set" do
+      helper.instance_variable_set(:@tab_index, nil)
+      expect(helper.tab_index).to eq(1)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,14 +62,16 @@ RSpec.describe User, type: :model do
     let!(:user_product_role2) { create(:user_product_role, user: user, product: product2, role: role2) }
     let!(:user_product_role3) { create(:user_product_role, user: user, product: product3, role: role3) }
 
-    it "returns all unique products for allowed roles" do
-      expect(user.available_products_from_roles).to match_array([product1, product2])
+    it "returns all unique products for all roles" do
+      expect(user.available_products_from_roles).to match_array([product1, product2, product3])
     end
 
-    it "does not include products for roles not in the allowed list" do
-      allowed_products = user.available_products_from_roles
-      expect(allowed_products).not_to include(nil)
-      expect(allowed_products).not_to include(product3) if user.product_roles.where(role: role3).exists?
+    it "returns unique products only" do
+      test_role = create(:role, name: "test-editor")
+      create(:user_product_role, user: user, product: product1, role: test_role)
+
+      expect(user.available_products_from_roles.count(product1)).to eq(1)
     end
+
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,4 +29,47 @@ RSpec.describe User, type: :model do
       end
     end
   end
+
+  describe "#available_product_from_roles" do
+    let!(:role1) { create(:role, name: "draft-editor") }
+    let!(:role2) { create(:role, name: "profile-editor") }
+
+    let!(:product1) { create(:product, name: "FOO") }
+    let!(:product2) { create(:product, name: "BAR") }
+
+    let!(:user) {create(:user, user_name: "testuser", given_name: "Test", family_name: "User", created_by: "Tester", updated_by: "Tester") }
+
+    let!(:user_product_role1) { create(:user_product_role, user: user, product: product1, role: role1) }
+    let!(:user_product_role2) { create(:user_product_role, user: user, product: product2, role: role2) }
+
+    it "returns the first product for allowed roles" do
+      expect(user.available_product_from_roles).to eq(product1)
+    end
+  end
+
+  describe "#available_products_from_roles" do
+    let!(:role1) { create(:role, name: "draft-editor") }
+    let!(:role2) { create(:role, name: "profile-editor") }
+    let!(:role3) { create(:role, name: "other-editor") }
+
+    let!(:product1) { create(:product, name: "FOO") }
+    let!(:product2) { create(:product, name: "BAR") }
+    let!(:product3) { create(:product, name: "CAN") }
+
+    let!(:user) {create(:user, user_name: "testuser", given_name: "Test", family_name: "User", created_by: "Tester", updated_by: "Tester") }
+
+    let!(:user_product_role1) { create(:user_product_role, user: user, product: product1, role: role1) }
+    let!(:user_product_role2) { create(:user_product_role, user: user, product: product2, role: role2) }
+    let!(:user_product_role3) { create(:user_product_role, user: user, product: product3, role: role3) }
+
+    it "returns all unique products for allowed roles" do
+      expect(user.available_products_from_roles).to match_array([product1, product2])
+    end
+
+    it "does not include products for roles not in the allowed list" do
+      allowed_products = user.available_products_from_roles
+      expect(allowed_products).not_to include(nil)
+      expect(allowed_products).not_to include(product3) if user.product_roles.where(role: role3).exists?
+    end
+  end
 end


### PR DESCRIPTION
## Description

Adding support for multi-product tabs based on the available user's product role. Behind a feature flag `multi_product_tabs_enabled`

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Login with 2 or more user product role (with diff product) -> search for a name -> tabs will be available for each product

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-82

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
