### PR TITLE
Multi-tabs for instances page and refactor codes

### DIFF
--- a/.nsl-test-configs/editor-config.rb
+++ b/.nsl-test-configs/editor-config.rb
@@ -1,19 +1,22 @@
-#Host
+# frozen_string_literal: true
+
+# Host
 external_services_host = "http://localhost:9093/nsl/services"
-internal_services_host = 'http://localhost:9090/nsl/services'
-#Environment
+internal_services_host = "http://localhost:9090/nsl/services"
+# Environment
 Rails.configuration.action_controller.relative_url_root = "/nsl/editor"
-Rails.configuration.environment = 'test'
-Rails.configuration.draft_instances = 'true'
+Rails.configuration.environment = "test"
+Rails.configuration.draft_instances = "true"
 Rails.configuration.profile_edit_aware = true
 Rails.configuration.profile_v2_aware = true
 Rails.configuration.unsaved_form_prompt_enabled = true
 Rails.configuration.site_wide_form_prompt_enabled = true
+Rails.configuration.multi_product_tabs_enabled = false
 Rails.configuration.nsl_linker = "http://localhost:9090/"
-#Services
+# Services
 Rails.configuration.services_clientside_root_url = "#{external_services_host}/"
 Rails.configuration.services = "#{internal_services_host}/"
 Rails.configuration.name_services = "#{internal_services_host}/rest/name/apni/"
 Rails.configuration.reference_services = "#{internal_services_host}/rest/reference/apni/"
 # - API key for the services
-Rails.configuration.api_key = 'test-api-key'
+Rails.configuration.api_key = "test-api-key"

--- a/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
+++ b/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
@@ -33,7 +33,7 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
   attr_reader :user, :params
 
   def find_product_by_name
-    return user.products.find_by(name: params[:product_name]) if params&.dig(:product_name).present?
+    return user.products.find_by(name: params[:product_name]) if params.dig(:product_name).present?
 
     supported_product = user.products.where(name: SUPPORTED_PRODUCTS).first&.name
     Product.find_by(name: supported_product) if supported_product

--- a/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
+++ b/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
@@ -54,8 +54,8 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
   end
 
   def fetch_product_item_configs
-    base_query
-      .then { |query| filter_by_config_id(query) }
+    query = base_query
+    filter_by_config_id(query)
   end
 
   def base_query

--- a/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
+++ b/app/models/profile/profile_item/defined_query/product_and_product_item_configs.rb
@@ -1,29 +1,29 @@
+# frozen_string_literal: true
+
 class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
   attr_reader :product,
-              :instance,
-              :product_configs_and_profile_items
+    :instance,
+    :product_configs_and_profile_items
 
   SUPPORTED_PRODUCTS = ["FOA"].freeze
 
   def initialize(session_user, instance, params = {})
+    @params = params
     @session_user = session_user
     @user = session_user.user
     @product = find_product_by_name
     @product_configs_and_profile_items = []
     @instance = instance
-    @params = params
   end
 
   def debug(s)
     tag = "Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs"
-    Rails.logger.debug("#{tag}: #{s}")
+    Rails.logger.debug { "#{tag}: #{s}" }
   end
 
   def run_query
     debug("run_query")
-    if profile_v2_aware?
-      @product_configs_and_profile_items = find_or_initialize_profile_items
-    end
+    @product_configs_and_profile_items = find_or_initialize_profile_items if profile_v2_aware?
 
     [product_configs_and_profile_items, product]
   end
@@ -33,17 +33,18 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
   attr_reader :user, :params
 
   def find_product_by_name
-    product_name = user.products.where(name: SUPPORTED_PRODUCTS).first&.name
+    return user.products.find_by(name: params[:product_name]) if params&.dig(:product_name).present?
 
-    Product.find_by(name: product_name)
+    supported_product = user.products.where(name: SUPPORTED_PRODUCTS).first&.name
+    Product.find_by(name: supported_product) if supported_product
   end
 
   def profile_v2_aware?
-    Rails.configuration.try('profile_v2_aware')
+    Rails.configuration.try("profile_v2_aware")
   end
 
   def find_or_initialize_profile_items
-    return [] unless @product && @instance
+    return [] if @product.nil? || @instance.nil?
 
     product_item_configs = fetch_product_item_configs
 
@@ -53,43 +54,54 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
   end
 
   def fetch_product_item_configs
-    product_item_configs =
-      Profile::ProductItemConfig
-        .where(product_id: @product.id)
-        .joins("left join profile_item_type AS pit ON pit.id = product_item_config.profile_item_type_id")
-        .joins("inner join profile_object_type As pot ON pot.id = pit.profile_object_type_id")
-        .where("pot.rdf_id = ?", @params[:rdf_id] || "text")
-        .where.not(display_html: nil)
+    base_query
+      .then { |query| filter_by_config_id(query) }
+  end
 
-    product_item_configs = product_item_configs.where(id: @params[:product_item_config_id]) if @params[:product_item_config_id]
-    product_item_configs
+  def base_query
+    Profile::ProductItemConfig
+      .where(product_id: @product.id)
+      .joins(profile_item_type: :profile_object_type)
+      .where(profile_object_type: { rdf_id: @params[:rdf_id] || "text" })
+      .where.not(display_html: nil)
+  end
+
+  def filter_by_config_id(query)
+    return query unless @params[:product_item_config_id]
+
+    query.where(id: @params[:product_item_config_id])
   end
 
   def fetch_existing_profile_items(product_item_configs)
-    existing_profile_items =
-      Profile::ProfileItem
-        .where(
-          product_item_config_id: product_item_configs.pluck(:id),
-          instance_id: @instance.id
-        )
-        .includes([
-          :sourced_in_profile_items,
-          :profile_item_annotation,
-          :profile_item_references,
-          :profile_text
-        ])
-        .order(created_at: :desc)
+    items = Profile::ProfileItem
+      .where(
+        product_item_config_id: product_item_configs.select(:id),
+        instance_id: @instance.id,
+      )
+      .includes(
+        :sourced_in_profile_items,
+        :profile_item_annotation,
+        :profile_item_references,
+        :profile_text,
+      )
+      .order(created_at: :desc)
 
-   return existing_profile_items if params[:all]
+    return items if params[:all]
 
-    existing_profile_items.group_by(&:product_item_config_id).transform_values { |items| items.first }
+    group_items_by_config(items)
+  end
+
+  def group_items_by_config(items)
+    items
+      .group_by(&:product_item_config_id)
+      .transform_values(&:first)
   end
 
   def map_product_item_configs_to_profile_items(product_item_configs, existing_profile_items)
     product_item_configs.map do |product_item_config|
       profile_item = find_or_initialize_profile_item(
         product_item_config,
-        existing_profile_items[product_item_config.id]
+        existing_profile_items[product_item_config.id],
       )
 
       { product_item_config: product_item_config, profile_item: profile_item }
@@ -101,7 +113,7 @@ class Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
 
     Profile::ProfileItem.new(
       product_item_config: product_item_config,
-      instance_id: @instance.id
+      instance_id: @instance.id,
     )
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,8 @@ class User < ActiveRecord::Base
   self.primary_key = "id"
   self.sequence_name = "nsl_global_seq"
 
-  has_many :batch_reviewers, class_name: "Loader::Batch::Reviewer"
-  has_many :user_product_roles, class_name: "User::ProductRole"
+  has_many :batch_reviewers, class_name: "Loader::Batch::Reviewer", foreign_key: :user_id
+  has_many :user_product_roles, class_name: "User::ProductRole", foreign_key: :user_id
   has_many :product_roles, through: :user_product_roles
   has_many :products, through: :product_roles
   has_many :roles, through: :product_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,9 +71,9 @@ class User < ActiveRecord::Base
     # This method supports multi-product scenarios by returning all available products
     # instead of just the first one
     product_roles
-      .joins(:role)
+      .joins(:role, :product)
       .includes(:product)
-      .order("product.name ASC")
+      .order(Product.arel_table[:name].asc)
       .filter_map(&:product)
       .uniq
   end

--- a/app/views/instances/tabs/_all_multi_product_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_multi_product_tab_headings.html.erb
@@ -75,7 +75,7 @@
               first: false,
               last: false,
               this_tab: 'tab_edit_notes',
-              link_text: "#{product.name}  Notes".html_safe,
+              link_text: "#{product.name} Notes".html_safe,
               link_id: "instance-edit-notes-#{product.name}-tab",
               link_title: "#{product.name} Notes",
               tab_index: increment_tab_index,

--- a/app/views/instances/tabs/_all_multi_product_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_multi_product_tab_headings.html.erb
@@ -1,0 +1,380 @@
+<% increment_tab_index %>
+
+<ul class="nav nav-tabs">
+
+  <% this_tab = 'tab_show_1' %>
+  <% first_tab_of_each_type = Hash.new(true) %>
+
+  <% @current_registered_user.available_products_from_roles.each_with_index do |product, index| %>
+    <% if @tabs_to_offer.include?('tab_show_1') %>
+      <% if can? 'instances', 'tab_show_1' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_show_1',
+            link_text: "#{product.name} Details".html_safe,
+            link_id: "instance-show-#{product.name.downcase}-tab",
+            link_title: "#{product.name} Details",
+            tab_index: @tab_index,
+            prev_tab: ".search-result.show-details",
+            next_tab: '',
+            product_name: product.name,
+            is_first_tab_of_type: first_tab_of_each_type['tab_show_1']
+          })
+        %>
+        <% first_tab_of_each_type['tab_show_1'] = false %>
+      <% end %>
+    <% end %>
+    <% if @tabs_to_offer.include?('tab_edit') && can?(:edit, @instance)%>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_edit',
+            link_text: "#{product.name} Edit".html_safe,
+            link_id: "instance-edit-#{product.name.downcase}-tab",
+            link_title: "#{product.name} Edit",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name,
+            is_first_tab_of_type: first_tab_of_each_type['tab_edit']
+          })
+        %>
+        <% first_tab_of_each_type['tab_edit'] = false %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_edit_profile_v2') && can?(:manage_draft_secondary_reference, @instance) %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_edit_profile_v2',
+            link_text: "#{product.name} Edit".html_safe,
+            link_id: "instance-edit-tab-profile-v2-#{product.name}-tab",
+            link_title: "#{product.name} Edit",
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: '',
+            product_name: product.name,
+            is_first_tab_of_type: first_tab_of_each_type['tab_edit_profile_v2']
+          })
+        %>
+        <% first_tab_of_each_type['tab_edit_profile_v2'] = false %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_edit_notes') %>
+        <% if can? 'instance_notes', 'edit' %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_edit_notes',
+              link_text: "#{product.name}  Notes".html_safe,
+              link_id: "instance-edit-notes-#{product.name}-tab",
+              link_title: "#{product.name} Notes",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_edit_notes']
+            })
+          %>
+          <% first_tab_of_each_type['tab_edit_notes'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_synonymy') %>
+        <% if can? :create, Instance %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_synonymy',
+              link_text: "#{product.name} Syn".html_safe,
+              link_id: "instance-cite-this-instance-#{product.name}-tab",
+              link_title: "#{product.name} Synonym",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_synonymy']
+            })
+          %>
+          <% first_tab_of_each_type['tab_synonymy'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_synonymy_for_profile_v2') %>
+        <% if can? :synonymy_as_draft_secondary_reference, @instance %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_synonymy_for_profile_v2',
+              link_text: "#{product.name} Syn".html_safe,
+              link_id: "instance-cite-this-instance-for-profile-v2-#{product.name}-tab",
+              link_title: "#{product.name} Synonym",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_synonymy_for_profile_v2']
+            })
+          %>
+          <% first_tab_of_each_type['tab_synonymy_for_profile_v2'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_unpublished_citation') %>
+        <% if can? :create, @instance %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_unpublished_citation',
+              link_text: "#{product.name} Unpub".html_safe,
+              link_id: "unpublished-citation-#{product.name}-tab",
+              link_title: "#{product.name} Unpublished citation",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_unpublished_citation']
+            })
+          %>
+          <% first_tab_of_each_type['tab_unpublished_citation'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_unpublished_citation_for_profile_v2') %>
+        <% if can? :unpublished_citation_as_draft_secondary_reference, @instance %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_unpublished_citation_for_profile_v2',
+              link_text: "#{product.name} Unpub".html_safe,
+              link_id: "unpublished-citation-for-profile-v2-#{product.name}-tab",
+              link_title: "#{product.name} Unpublished citation",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_unpublished_citation_for_profile_v2']
+            })
+          %>
+          <% first_tab_of_each_type['tab_unpublished_citation_for_profile_v2'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_classification') %>
+        <% if can? 'classification', 'place' %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_classification',
+              link_text: "#{product.name} Tree".html_safe,
+              link_id: "instance-classification-#{product.name}-tab",
+              link_title: "#{product.name} Tree placement",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_classification']
+            })
+          %>
+          <% first_tab_of_each_type['tab_classification'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_comments') %>
+        <% if can? 'comments', 'create' %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: true,
+              this_tab: 'tab_comments',
+              link_text: "#{product.name} Adnot".html_safe,
+              link_id: "instance-comments-#{product.name}-tab",
+              link_title: "#{product.name} Adnot",
+              tab_index: increment_tab_index,
+              prev_tab: '',
+              next_tab: '',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_comments']
+            })
+          %>
+          <% first_tab_of_each_type['tab_comments'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_copy_to_new_reference') %>
+        <% if can? 'instances', 'copy_standalone' %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_copy_to_new_reference',
+              link_text: "#{product.name} Copy".html_safe,
+              link_id: "instance-copy-to-new-reference-#{product.name}-tab",
+              link_title: "#{product.name} Copy the instance",
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-comments-tab',
+              next_tab: '.search-result.show-details',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_copy_to_new_reference']
+            })
+          %>
+          <% first_tab_of_each_type['tab_copy_to_new_reference'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_copy_to_new_profile_v2') %>
+        <% if (can? :copy_as_draft_secondary_reference, Instance) && @current_registered_user.available_product_from_roles.present? %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_copy_to_new_profile_v2',
+              link_text: "#{product.name} Copy".html_safe,
+              link_id: "instance-copy-to-new-profile-v2-#{product.name}-tab",
+              link_title: "#{product.name} Copy the instance",
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-comments-tab',
+              next_tab: '.search-result.show-details',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_copy_to_new_profile_v2']
+            })
+          %>
+          <% first_tab_of_each_type['tab_copy_to_new_profile_v2'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_profile_details') %>
+        <% if can? 'classification', 'place' %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: false,
+              this_tab: 'tab_profile_details',
+              link_text: "#{product.name} Profile".html_safe,
+              link_id: "instance-profile-#{product.name}-tab",
+              link_title: "#{product.name} Profile details",
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-copy-to-new-reference-tab',
+              next_tab: 'instance-edit-profile-tab',
+              product_name: product.name,
+              is_first_tab_of_type: first_tab_of_each_type['tab_profile_details']
+            })
+          %>
+          <% first_tab_of_each_type['tab_profile_details'] = false %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_edit_profile') %>
+        <% if Rails.configuration.try('profile_edit_aware') %>
+          <% if can? 'classification', 'place' %>
+            <%= render(
+              partial: 'instances/tabs/tab',
+              locals: {
+                first: false,
+                last: true,
+                this_tab: 'tab_edit_profile',
+                link_text: "#{product.name} Edit Profile".html_safe,
+                link_id: "instance-edit-profile-#{product.name}-tab",
+                link_title: "#{product.name} Edit Profile",
+                tab_index: increment_tab_index,
+                prev_tab: 'instance-profile-tab',
+                next_tab: 'instance-batch-loader-tab',
+                product_name: product.name,
+                is_first_tab_of_type: first_tab_of_each_type['tab_edit_profile']
+              })
+            %>
+            <% first_tab_of_each_type['tab_edit_profile'] = false %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_batch_loader') %>
+        <% if can?('loader/batches', 'process') %>
+            <%= render(
+              partial: 'instances/tabs/tab',
+              locals: {
+                first: false,
+                last: true,
+                this_tab: 'tab_batch_loader',
+                link_text: "#{product.name} Loader 1".html_safe,
+                link_id: "instance-batch-loader-#{product.name}-tab",
+                link_title: "#{product.name} Batch Loader operations",
+                tab_index: increment_tab_index,
+                prev_tab: "instance-edit-profile-#{product.name}-tab",
+                next_tab: 'instance-batch-loader-tab-2',
+                product_name: product.name,
+                is_first_tab_of_type: first_tab_of_each_type['tab_batch_loader']
+              })
+            %>
+            <% first_tab_of_each_type['tab_batch_loader'] = false %>
+
+        <% if can?('loader/instances-loader-2', 'use') %>
+            <%= render(
+              partial: 'instances/tabs/tab',
+              locals: {
+                first: false,
+                last: true,
+                this_tab: 'tab_batch_loader_2',
+                link_text: "#{product.name} Loader 2".html_safe,
+                link_id: "instance-batch-loader-#{product.name}-tab-2",
+                link_title: "#{product.name} More batch Loader operations",
+                tab_index: increment_tab_index,
+                prev_tab: 'instance-batch-tab-loader',
+                next_tab: 'instance-show-tab',
+                product_name: product.name,
+                is_first_tab_of_type: first_tab_of_each_type['tab_batch_loader_2']
+              })
+            %>
+            <% first_tab_of_each_type['tab_batch_loader_2'] = false %>
+            <% end %>
+          <% end %>
+      <% end %>
+
+      <% if @tabs_to_offer.include?('tab_profile_v2') %>
+        <% if can?(:manage_profile, @instance) %>
+          <% if Rails.configuration.try('profile_v2_aware') %>
+            <%= render(
+              partial: 'instances/tabs/tab',
+              locals: {
+                first: false,
+                last: true,
+                this_tab: 'tab_profile_v2',
+                link_id: "instance-profile-v2-#{product.name}-tab",
+                link_text: "#{product.name} Profile".html_safe,
+                link_title: "#{product.name} Profile",
+                tab_index: increment_tab_index,
+                prev_tab: "instance-edit-profile-v2-#{product.name.downcase}-tab",
+                next_tab: '.search-result.show-details',
+                product_name: product.name,
+                is_first_tab_of_type: first_tab_of_each_type['tab_profile_v2']
+              })
+            %>
+            <% first_tab_of_each_type['tab_profile_v2'] = false %>
+          <% end %>
+        <% end %>
+      <% end %>
+  <% end %>
+</ul>

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -4,240 +4,327 @@
 
   <% this_tab = 'tab_show_1' %>
 
-  <% if @tabs_to_offer.include?('tab_show_1') %>
-    <% if can? 'instances', 'tab_show_1' %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: true,
-                                        last: false,
-                                        this_tab: 'tab_show_1',
-                                        link_text: "Details".html_safe,
-                                        link_id: 'instance-show-tab',
-                                        link_title: 'Details',
-                                        tab_index: @tab_index,
-                                        prev_tab: '.search-result.show-details',
-                                        next_tab: '' } %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_edit') && can?(:edit, @instance)%>
-    <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                      last: false,
-                                      this_tab: 'tab_edit',
-                                      link_text: "Edit".html_safe,
-                                      link_id: 'instance-edit-tab',
-                                      link_title: 'Edit',
-                                      tab_index: increment_tab_index,
-                                      prev_tab: '',
-                                      next_tab: '' } %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_edit_profile_v2') && can?(:manage_draft_secondary_reference, @instance) %>
-    <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                      last: false,
-                                      this_tab: 'tab_edit_profile_v2',
-                                      link_text: "Edit".html_safe,
-                                      link_id: 'instance-edit-tab-profile-v2-tab',
-                                      link_title: 'Edit',
-                                      tab_index: increment_tab_index,
-                                      prev_tab: '',
-                                      next_tab: '' } %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_edit_notes') %>
-    <% if can? 'instance_notes', 'edit' %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: false,
-                                        this_tab: 'tab_edit_notes',
-                                        link_text: "Notes".html_safe,
-                                        link_id: 'instance-edit-notes-tab',
-                                        link_title: 'Notes',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: '',
-                                        next_tab: '' } %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_synonymy') %>
-    <% if can? :create, Instance %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                          last: false,
-                                          this_tab: 'tab_synonymy',
-                                          link_text: "Syn".html_safe,
-                                          link_id: 'instance-cite-this-instance-tab',
-                                          link_title: 'Synonym',
-                                          tab_index: increment_tab_index,
-                                          prev_tab: '',
-                                          next_tab: ''} %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_synonymy_for_profile_v2') %>
-    <% if can? :synonymy_as_draft_secondary_reference, @instance %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                          last: false,
-                                          this_tab: 'tab_synonymy_for_profile_v2',
-                                          link_text: "Syn".html_safe,
-                                          link_id: 'instance-cite-this-instance-for-profile-v2-tab',
-                                          link_title: 'Synonym',
-                                          tab_index: increment_tab_index,
-                                          prev_tab: '',
-                                          next_tab: ''} %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_unpublished_citation') %>
-    <% if can? :create, @instance %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                          last: false,
-                                          this_tab: 'tab_unpublished_citation',
-                                          link_text: "Unpub".html_safe,
-                                          link_id: 'unpublished-citation-tab',
-                                          link_title: 'Unpublished citation',
-                                          tab_index: increment_tab_index,
-                                          prev_tab: '',
-                                          next_tab: ''} %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_unpublished_citation_for_profile_v2') %>
-    <% if can? :unpublished_citation_as_draft_secondary_reference, @instance %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                          last: false,
-                                          this_tab: 'tab_unpublished_citation_for_profile_v2',
-                                          link_text: "Unpub".html_safe,
-                                          link_id: 'unpublished-citation-for-profile-v2-tab',
-                                          link_title: 'Unpublished citation',
-                                          tab_index: increment_tab_index,
-                                          prev_tab: '',
-                                          next_tab: ''} %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_classification') %>
-      <% if can? 'classification', 'place' %>
-          <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                                             last: false,
-                                                             this_tab: 'tab_classification',
-                                                             link_text: "Tree".html_safe,
-                                                             link_id: 'instance-classification-tab',
-                                                             link_title: 'Tree placement',
-                                                             tab_index: increment_tab_index,
-                                                             prev_tab: '',
-                                                             next_tab: ''} %>
-      <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_comments') %>
-    <% if can? 'comments', 'create' %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: true,
-                                        this_tab: 'tab_comments',
-                                        link_text: "Adnot".html_safe,
-                                        link_id: 'instance-comments-tab',
-                                        link_title: 'Adnot',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: '',
-                                        next_tab: '' } %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_copy_to_new_reference') %>
-    <% if can? 'instances', 'copy_standalone' %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: false,
-                                        this_tab: 'tab_copy_to_new_reference',
-                                        link_text: "Copy".html_safe,
-                                        link_id: 'instance-copy-to-new-reference-tab',
-                                        link_title: 'Copy the instance',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-comments-tab',
-                                        next_tab: '.search-result.show-details' } %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_copy_to_new_profile_v2') %>
-    <% if (can? :copy_as_draft_secondary_reference, Instance) && @current_registered_user.available_product_from_roles.present? %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: false,
-                                        this_tab: 'tab_copy_to_new_profile_v2',
-                                        link_text: "Copy".html_safe,
-                                        link_id: 'instance-copy-to-new-profile-v2-tab',
-                                        link_title: 'Copy the instance',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-comments-tab',
-                                        next_tab: '.search-result.show-details' } %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_profile_details') %>
-    <% if can? 'classification', 'place' %>
-      <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: false,
-                                        this_tab: 'tab_profile_details',
-                                        link_text: "Profile".html_safe,
-                                        link_id: 'instance-profile-tab',
-                                        link_title: 'Profile details',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-copy-to-new-reference-tab',
-                                        next_tab: 'instance-edit-profile-tab' } %>
-    <% end %>
-  <% end %>
-
-  <% if @tabs_to_offer.include?('tab_edit_profile') %>
-    <% if Rails.configuration.try('profile_edit_aware') %>
-      <% if can? 'classification', 'place' %>
-        <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: true,
-                                        this_tab: 'tab_edit_profile',
-                                        link_text: "Edit Profile".html_safe,
-                                        link_id: 'instance-edit-profile-tab',
-                                        link_title: 'Edit Profile',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-profile-tab',
-                                        next_tab: 'instance-batch-loader-tab' } %>
+  <% if Rails.configuration.try('multi_product_tabs_enabled') %>
+    <%= render partial: "instances/tabs/all_multi_product_tab_headings" %>
+  <% else %>
+    <% if @tabs_to_offer.include?('tab_show_1') %>
+      <% if can? 'instances', 'tab_show_1' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: true,
+            last: false,
+            this_tab: 'tab_show_1',
+            link_text: "Details".html_safe,
+            link_id: 'instance-show-tab',
+            link_title: 'Details',
+            tab_index: @tab_index,
+            prev_tab: '.search-result.show-details',
+            next_tab: ''
+          })
+        %>
       <% end %>
     <% end %>
-  <% end %>
 
-  <% if @tabs_to_offer.include?('tab_batch_loader') %>
-     <% if can?('loader/batches', 'process') %>
-        <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: true,
-                                        this_tab: 'tab_batch_loader',
-                                        link_text: "Loader 1".html_safe,
-                                        link_id: 'instance-batch-loader-tab',
-                                        link_title: 'Batch Loader operations',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-edit-profile-tab',
-                                        next_tab: 'instance-batch-loader-tab-2' } %>
+    <% if @tabs_to_offer.include?('tab_edit') && can?(:edit, @instance)%>
+      <%= render(
+        partial: 'instances/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_edit',
+          link_text: "Edit".html_safe,
+          link_id: 'instance-edit-tab',
+          link_title: 'Edit',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
 
-     <% if can?('loader/instances-loader-2', 'use') %>
-        <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: true,
-                                        this_tab: 'tab_batch_loader_2',
-                                        link_text: "Loader 2".html_safe,
-                                        link_id: 'instance-batch-loader-tab-2',
-                                        link_title: 'More batch Loader operations',
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-batch-tab-loader',
-                                        next_tab: 'instance-show-tab' } %>
+    <% if @tabs_to_offer.include?('tab_edit_profile_v2') && can?(:manage_draft_secondary_reference, @instance) %>
+      <%= render(
+        partial: 'instances/tabs/tab',
+        locals: {
+          first: false,
+          last: false,
+          this_tab: 'tab_edit_profile_v2',
+          link_text: "Edit".html_safe,
+          link_id: 'instance-edit-tab-profile-v2-tab',
+          link_title: 'Edit',
+          tab_index: increment_tab_index,
+          prev_tab: '',
+          next_tab: ''
+        })
+      %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_edit_notes') %>
+      <% if can? 'instance_notes', 'edit' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_edit_notes',
+            link_text: "Notes".html_safe,
+            link_id: 'instance-edit-notes-tab',
+            link_title: 'Notes',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_synonymy') %>
+      <% if can? :create, Instance %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_synonymy',
+            link_text: "Syn".html_safe,
+            link_id: 'instance-cite-this-instance-tab',
+            link_title: 'Synonym',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_synonymy_for_profile_v2') %>
+      <% if can? :synonymy_as_draft_secondary_reference, @instance %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_synonymy_for_profile_v2',
+            link_text: "Syn".html_safe,
+            link_id: 'instance-cite-this-instance-for-profile-v2-tab',
+            link_title: 'Synonym',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_unpublished_citation') %>
+      <% if can? :create, @instance %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_unpublished_citation',
+            link_text: "Unpub".html_safe,
+            link_id: 'unpublished-citation-tab',
+            link_title: 'Unpublished citation',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_unpublished_citation_for_profile_v2') %>
+      <% if can? :unpublished_citation_as_draft_secondary_reference, @instance %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_unpublished_citation_for_profile_v2',
+            link_text: "Unpub".html_safe,
+            link_id: 'unpublished-citation-for-profile-v2-tab',
+            link_title: 'Unpublished citation',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_classification') %>
+      <% if can? 'classification', 'place' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_classification',
+            link_text: "Tree".html_safe,
+            link_id: 'instance-classification-tab',
+            link_title: 'Tree placement',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_comments') %>
+      <% if can? 'comments', 'create' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: true,
+            this_tab: 'tab_comments',
+            link_text: "Adnot".html_safe,
+            link_id: 'instance-comments-tab',
+            link_title: 'Adnot',
+            tab_index: increment_tab_index,
+            prev_tab: '',
+            next_tab: ''
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_copy_to_new_reference') %>
+      <% if can? 'instances', 'copy_standalone' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_copy_to_new_reference',
+            link_text: "Copy".html_safe,
+            link_id: 'instance-copy-to-new-reference-tab',
+            link_title: 'Copy the instance',
+            tab_index: increment_tab_index,
+            prev_tab: 'instance-comments-tab',
+            next_tab: '.search-result.show-details'
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_copy_to_new_profile_v2') %>
+      <% if (can? :copy_as_draft_secondary_reference, Instance) && @current_registered_user.available_product_from_roles.present? %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_copy_to_new_profile_v2',
+            link_text: "Copy".html_safe,
+            link_id: 'instance-copy-to-new-profile-v2-tab',
+            link_title: 'Copy the instance',
+            tab_index: increment_tab_index,
+            prev_tab: 'instance-comments-tab',
+            next_tab: '.search-result.show-details'
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_profile_details') %>
+      <% if can? 'classification', 'place' %>
+        <%= render(
+          partial: 'instances/tabs/tab',
+          locals: {
+            first: false,
+            last: false,
+            this_tab: 'tab_profile_details',
+            link_text: "Profile".html_safe,
+            link_id: 'instance-profile-tab',
+            link_title: 'Profile details',
+            tab_index: increment_tab_index,
+            prev_tab: 'instance-copy-to-new-reference-tab',
+            next_tab: 'instance-edit-profile-tab'
+          })
+        %>
+      <% end %>
+    <% end %>
+
+    <% if @tabs_to_offer.include?('tab_edit_profile') %>
+      <% if Rails.configuration.try('profile_edit_aware') %>
+        <% if can? 'classification', 'place' %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: true,
+              this_tab: 'tab_edit_profile',
+              link_text: "Edit Profile".html_safe,
+              link_id: 'instance-edit-profile-tab',
+              link_title: 'Edit Profile',
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-profile-tab',
+              next_tab: 'instance-batch-loader-tab'
+            })
+          %>
         <% end %>
       <% end %>
-  <% end %>
+    <% end %>
 
+    <% if @tabs_to_offer.include?('tab_batch_loader') %>
+      <% if can?('loader/batches', 'process') %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: true,
+              this_tab: 'tab_batch_loader',
+              link_text: "Loader 1".html_safe,
+              link_id: 'instance-batch-loader-tab',
+              link_title: 'Batch Loader operations',
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-edit-profile-tab',
+              next_tab: 'instance-batch-loader-tab-2'
+            })
+          %>
 
+      <% if can?('loader/instances-loader-2', 'use') %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: true,
+              this_tab: 'tab_batch_loader_2',
+              link_text: "Loader 2".html_safe,
+              link_id: 'instance-batch-loader-tab-2',
+              link_title: 'More batch Loader operations',
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-batch-tab-loader',
+              next_tab: 'instance-show-tab'
+            })
+          %>
+          <% end %>
+        <% end %>
+    <% end %>
 
-  <% if @tabs_to_offer.include?('tab_profile_v2') %>
-    <% if can?(:manage_profile, @instance) %>
-      <% if Rails.configuration.try('profile_v2_aware') %>
-        <%= render partial: 'instances/tabs/tab', locals: {first: false,
-                                        last: true,
-                                        this_tab: 'tab_profile_v2',
-                                        link_id: 'instance-profile-v2-tab',
-                                        link_text: "#{user_profile_tab_name} Profile".html_safe,
-                                        link_title: "#{user_profile_tab_name} Profile",
-                                        tab_index: increment_tab_index,
-                                        prev_tab: 'instance-edit-profile-v2-tab',
-                                        next_tab: '.search-result.show-details' } %>
+    <% if @tabs_to_offer.include?('tab_profile_v2') %>
+      <% if can?(:manage_profile, @instance) %>
+        <% if Rails.configuration.try('profile_v2_aware') %>
+          <%= render(
+            partial: 'instances/tabs/tab',
+            locals: {
+              first: false,
+              last: true,
+              this_tab: 'tab_profile_v2',
+              link_id: 'instance-profile-v2-tab',
+              link_text: "#{user_profile_tab_name} Profile".html_safe,
+              link_title: "#{user_profile_tab_name} Profile",
+              tab_index: increment_tab_index,
+              prev_tab: 'instance-edit-profile-v2-tab',
+              next_tab: '.search-result.show-details'
+            })
+          %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/instances/tabs/_tab.html.erb
+++ b/app/views/instances/tabs/_tab.html.erb
@@ -1,19 +1,18 @@
 <% this_tab_re = Regexp.new("^#{this_tab}$") %>
+<% current_product_name = params[:product_name]&.split('?')&.first  || '' %>
+<% tab_product_name = local_assigns[:product_name] || '' %>
+<% active_tab = (@tab.match(this_tab_re) && (current_product_name == tab_product_name || (current_product_name.blank? && local_assigns[:is_first_tab_of_type]))) %>
 
 <% data = Hash.new %>
-<% data['edit-url'] = instance_tab_path(@instance,tab:"#{this_tab}") %>
-<% data['tab-url']  = instance_tab_path(id:@instance,tab:"#{this_tab}") %>
+<% tab_url_params = {tab: this_tab} %>
+<% tab_url_params[:product_name] = local_assigns[:product_name] if local_assigns[:product_name].present? %>
+<% data['edit-url'] = instance_tab_path(@instance, **tab_url_params) %>
+<% data['tab-url'] = instance_tab_path(id: @instance, **tab_url_params) %>
 <% data['prev-tab'] = prev_tab unless prev_tab.blank? %>
 <% data['tab-name'] = this_tab %>
 <% data['row-type'] = params[:rowType] %>
 
-<li class='first <%= @tab.match(this_tab_re) ? "active" : "non-active" %>'>
- <%= link_to link_text,
-             '#',
-             id: link_id,
-             class: 'tab edit-details-tab', 
-             title: link_title,
-             tabindex: tab_index,
-             data: data %>
+<li class='first <%= active_tab ? "active" : "non-active" %>'>
+  <%= link_to link_text, '#', id: link_id, class: 'tab edit-details-tab', title: link_title, tabindex: tab_index, data: data %>
 </li>
 

--- a/app/views/instances/tabs/_tab_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_profile_v2.html.erb
@@ -16,7 +16,17 @@
       <div id="product-config-and-profile-items-container"></div>
     <% else %>
       <div id="product-config-and-profile-items-container">
-        <% all_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs.new(@current_user, @instance, {product_item_config_id: @selected_product_item_config_id}).run_query %>
+        <% all_items, _product = Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs
+          .new(
+            @current_user,
+            @instance,
+            {
+              product_name: local_assigns[:product_name],
+              product_item_config_id: @selected_product_item_config_id
+            }
+          )
+          .run_query
+        %>
         <% all_items.each do |config_items| %>
             <% product_item_config, profile_item = config_items.values_at(:product_item_config, :profile_item) %>
             <div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">

--- a/app/views/names/tabs/_tab.html.erb
+++ b/app/views/names/tabs/_tab.html.erb
@@ -1,7 +1,13 @@
 <% this_tab_re = Regexp.new(this_tab) %>
 <% current_product_name = params[:product_name]&.split('?')&.first  || '' %>
 <% tab_product_name = local_assigns[:product_name] || '' %>
-<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/) && (current_product_name == tab_product_name || (current_product_name.blank? && local_assigns[:is_first_tab_of_type]))) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
+
+<% is_matching_tab = @tab.match(this_tab_re) && !this_tab.match(/tab_more/) %>
+<% is_first_tab_condition = current_product_name.blank? && local_assigns[:is_first_tab_of_type] %>
+<% is_active_tab_condition = current_product_name == tab_product_name || is_first_tab_condition %>
+<% is_tab_more_and_comments = @tab.match(/tab_more/) && this_tab.match(/tab_comments/) %>
+<% active_tab = (is_matching_tab && is_active_tab_condition) || is_tab_more_and_comments %>
+
 <% semi_active_tab = (@tab.match(/tab_comments|tab_name_tags|tab_refresh|tab_de_duplicate/) && this_tab.match(/tab_more/)) %>
 <% semi_active_tab = semi_active_tab || (@tab.match(/tab_more/) && this_tab.match(/tab_more/)) %>
 

--- a/app/views/names/tabs/_tab.html.erb
+++ b/app/views/names/tabs/_tab.html.erb
@@ -1,7 +1,7 @@
 <% this_tab_re = Regexp.new(this_tab) %>
 <% current_product_name = params[:product_name]&.split('?')&.first  || '' %>
 <% tab_product_name = local_assigns[:product_name] || '' %>
-<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/) && (current_product_name == tab_product_name)) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
+<% active_tab = (@tab.match(this_tab_re) && !this_tab.match(/tab_more/) && (current_product_name == tab_product_name || (current_product_name.blank? && local_assigns[:is_first_tab_of_type]))) || (@tab.match(/tab_more/) && this_tab.match(/tab_comments/)) %>
 <% semi_active_tab = (@tab.match(/tab_comments|tab_name_tags|tab_refresh|tab_de_duplicate/) && this_tab.match(/tab_more/)) %>
 <% semi_active_tab = semi_active_tab || (@tab.match(/tab_more/) && this_tab.match(/tab_more/)) %>
 

--- a/app/views/names/tabs/_tabs.html.erb
+++ b/app/views/names/tabs/_tabs.html.erb
@@ -1,74 +1,6 @@
 <ul class="nav nav-tabs">
   <% if Rails.configuration.try('multi_product_tabs_enabled') %>
-    <% @current_registered_user.available_products_from_roles.each do |product| %>
-      <%= render(
-        partial: 'names/tabs/tab',
-        locals: {
-          first: false,
-          last: false,
-          this_tab: 'tab_details',
-          link_text: "#{product.name} Details",
-          link_id: "name-details-#{product.name.downcase}-tab",
-          link_title: "See details of the name for #{product.name}",
-          tab_index: increment_tab_index,
-          prev_tab: '',
-          next_tab: '',
-          product_name: product.name
-        })
-      %>
-
-      <% if can? 'names', 'update' %>
-        <%= render(
-          partial: 'names/tabs/tab',
-          locals: {
-            first: false,
-            last: false,
-            this_tab: 'tab_edit',
-            link_text: "#{product.name} Edit".html_safe,
-            link_id: "name-edit-#{product.name.downcase}-tab",
-            link_title: "Edit details of the name for #{product.name}.",
-            tab_index: increment_tab_index,
-            prev_tab: '',
-            next_tab: '',
-            product_name: product.name
-          })
-        %>
-      <% end %>
-
-      <% if can? :create_with_product_reference, Instance %>
-        <%= render(
-          partial: 'names/tabs/tab',
-          locals: {
-            first: false,
-            last: false,
-            this_tab: 'tab_instances_profile_v2',
-            link_text: "#{product.name} New instance".html_safe,
-            link_id: "name-instances-profile-v2-#{product.name.downcase}-tab",
-            link_title: "Create an instance for the name in #{product.name}.",
-            tab_index: increment_tab_index,
-            prev_tab: '',
-            next_tab: '',
-            product_name: product.name
-          })
-        %>
-      <% elsif can? :create, Instance %>
-        <%= render(
-          partial: 'names/tabs/tab',
-          locals: {
-            first: false,
-            last: false,
-            this_tab: 'tab_instances',
-            link_text: "#{product.name} New instance".html_safe,
-            link_id: "name-instances-#{product.name.downcase}-tab",
-            link_title: "Create an instance for the name in #{product.name}.",
-            tab_index: increment_tab_index,
-            prev_tab: '',
-            next_tab: '',
-            product_name: product.name
-          })
-        %>
-      <% end %>
-    <% end %>
+    <%= render partial: "names/tabs/tabs_multi_product" %>
   <% else %>
     <%= render(
       partial: 'names/tabs/tab',
@@ -133,64 +65,7 @@
         })
       %>
     <% end %>
-  <% end %>
 
-  <% if Rails.configuration.try('multi_product_tabs_enabled') %>
-    <% @current_registered_user.available_products_from_roles.each do |product| %>
-      <% if can? :create, Instance %>
-        <%= render(
-          partial: 'names/tabs/tab',
-          locals: {
-            first: false,
-            last: false,
-            this_tab: 'tab_copy',
-            link_text: "#{product.name} Copy".html_safe,
-            link_id: "name-copy-#{product.name.downcase}-tab",
-            link_title: "Copy the name for #{product.name}.",
-            tab_index: increment_tab_index,
-            prev_tab: '',
-            next_tab: '',
-            product_name: product.name
-          })
-        %>
-      <% end %>
-
-      <% if can? 'names', 'delete' %>
-        <%= render(
-          partial: 'names/tabs/tab',
-          locals: {
-            first: false,
-            last: false,
-            this_tab: 'tab_delete',
-            link_text: "#{product.name} Delete".html_safe,
-            link_id: "name-delete-#{product.name.downcase}-tab",
-            link_title: "Delete name for #{product.name}.",
-            tab_index: increment_tab_index,
-            prev_tab: '',
-            next_tab: '',
-            product_name: product.name
-          })
-        %>
-      <% end %>
-    <% end %>
-
-    <% if can? 'names', 'update' %>
-      <%= render(
-        partial: 'names/tabs/tab',
-        locals: {
-          first: false,
-          last: false,
-          this_tab: 'tab_more',
-          link_text: "More".html_safe,
-          link_id: 'name-more-tab',
-          link_title: 'Show more tabs',
-          tab_index: increment_tab_index,
-          prev_tab: '',
-          next_tab: ''
-        })
-      %>
-    <% end %>
-  <% else %>
     <% if can? :create, Instance %>
       <%= render(
         partial: 'names/tabs/tab',

--- a/app/views/names/tabs/_tabs_multi_product.html.erb
+++ b/app/views/names/tabs/_tabs_multi_product.html.erb
@@ -1,0 +1,136 @@
+<% first_tab_of_each_type = Hash.new(true) %>
+
+<% @current_registered_user.available_products_from_roles.each do |product| %>
+  <%= render(
+    partial: 'names/tabs/tab',
+    locals: {
+      first: false,
+      last: false,
+      this_tab: 'tab_details',
+      link_text: "#{product.name} Details",
+      link_id: "name-details-#{product.name.downcase}-tab",
+      link_title: "See details of the name for #{product.name}",
+      tab_index: increment_tab_index,
+      prev_tab: '',
+      next_tab: '',
+      product_name: product.name,
+      is_first_tab_of_type: first_tab_of_each_type['tab_details']
+    })
+  %>
+  <% first_tab_of_each_type['tab_details'] = false %>
+
+  <% if can? 'names', 'update' %>
+    <%= render(
+      partial: 'names/tabs/tab',
+      locals: {
+        first: false,
+        last: false,
+        this_tab: 'tab_edit',
+        link_text: "#{product.name} Edit".html_safe,
+        link_id: "name-edit-#{product.name.downcase}-tab",
+        link_title: "Edit details of the name for #{product.name}.",
+        tab_index: increment_tab_index,
+        prev_tab: '',
+        next_tab: '',
+        product_name: product.name,
+        is_first_tab_of_type: first_tab_of_each_type['tab_edit']
+      })
+    %>
+    <% first_tab_of_each_type['tab_edit'] = false %>
+  <% end %>
+
+  <% if can? :create_with_product_reference, Instance %>
+    <%= render(
+      partial: 'names/tabs/tab',
+      locals: {
+        first: false,
+        last: false,
+        this_tab: 'tab_instances_profile_v2',
+        link_text: "#{product.name} New instance".html_safe,
+        link_id: "name-instances-profile-v2-#{product.name.downcase}-tab",
+        link_title: "Create an instance for the name in #{product.name}.",
+        tab_index: increment_tab_index,
+        prev_tab: '',
+        next_tab: '',
+        product_name: product.name,
+        is_first_tab_of_type: first_tab_of_each_type['tab_instances_profile_v2']
+      })
+    %>
+    <% first_tab_of_each_type['tab_instances_profile_v2'] = false %>
+  <% elsif can? :create, Instance %>
+    <%= render(
+      partial: 'names/tabs/tab',
+      locals: {
+        first: false,
+        last: false,
+        this_tab: 'tab_instances',
+        link_text: "#{product.name} New instance".html_safe,
+        link_id: "name-instances-#{product.name.downcase}-tab",
+        link_title: "Create an instance for the name in #{product.name}.",
+        tab_index: increment_tab_index,
+        prev_tab: '',
+        next_tab: '',
+        product_name: product.name,
+        is_first_tab_of_type: first_tab_of_each_type['tab_instances']
+      })
+    %>
+    <% first_tab_of_each_type['tab_instances'] = false %>
+  <% end %>
+
+  <% if can? :create, Instance %>
+    <%= render(
+      partial: 'names/tabs/tab',
+      locals: {
+        first: false,
+        last: false,
+        this_tab: 'tab_copy',
+        link_text: "#{product.name} Copy".html_safe,
+        link_id: "name-copy-#{product.name.downcase}-tab",
+        link_title: "Copy the name for #{product.name}.",
+        tab_index: increment_tab_index,
+        prev_tab: '',
+        next_tab: '',
+        product_name: product.name,
+        is_first_tab_of_type: first_tab_of_each_type['tab_copy']
+      })
+    %>
+    <% first_tab_of_each_type['tab_copy'] = false %>
+  <% end %>
+
+  <% if can? 'names', 'delete' %>
+    <%= render(
+      partial: 'names/tabs/tab',
+      locals: {
+        first: false,
+        last: false,
+        this_tab: 'tab_delete',
+        link_text: "#{product.name} Delete".html_safe,
+        link_id: "name-delete-#{product.name.downcase}-tab",
+        link_title: "Delete name for #{product.name}.",
+        tab_index: increment_tab_index,
+        prev_tab: '',
+        next_tab: '',
+        product_name: product.name,
+        is_first_tab_of_type: first_tab_of_each_type['tab_delete']
+      })
+    %>
+    <% first_tab_of_each_type['tab_delete'] = false %>
+  <% end %>
+<% end %>
+
+<% if can? 'names', 'update' %>
+  <%= render(
+    partial: 'names/tabs/tab',
+    locals: {
+      first: false,
+      last: false,
+      this_tab: 'tab_more',
+      link_text: "More".html_safe,
+      link_id: 'name-more-tab',
+      link_title: 'Show more tabs',
+      tab_index: increment_tab_index,
+      prev_tab: '',
+      next_tab: ''
+    })
+  %>
+<% end %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 28-July-2025
+  :jira_id: '82'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Multi-tab support for instances and profile item selection.
 - :date: 22-July-2025
   :jira_id: ''
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.23
+appversion=4.1.9.24

--- a/spec/models/profile/profile_item/defined_query/product_and_product_item_configs_spec.rb
+++ b/spec/models/profile/profile_item/defined_query/product_and_product_item_configs_spec.rb
@@ -1,12 +1,14 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs, type: :model do
+require "rails_helper"
+
+RSpec.describe(Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs, type: :model) do
   let(:session_user) { FactoryBot.create(:session_user) }
   let!(:user) { FactoryBot.create(:user, user_name: session_user.username) }
   let(:instance) { FactoryBot.create(:instance) }
   let(:params) { {} }
 
-  subject { described_class.new(session_user, instance, params)}
+  subject { described_class.new(session_user, instance, params) }
 
   describe ".initialize" do
     it { should respond_to(:product) }
@@ -14,42 +16,42 @@ RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs,
     it { should respond_to(:product_configs_and_profile_items) }
 
     it "has instance variable session_user" do
-      expect(subject.instance_variable_get(:@session_user)).to eq session_user
+      expect(subject.instance_variable_get(:@session_user)).to(eq(session_user))
     end
 
     it "has instance variable user" do
-      expect(subject.instance_variable_get(:@user)).to eq user
+      expect(subject.instance_variable_get(:@user)).to(eq(user))
     end
 
     it "has instance variable product" do
       product = instance_double("Product")
-      allow_any_instance_of(described_class).to receive(:find_product_by_name).and_return(product)
-      expect(subject.instance_variable_get(:@product)).to eq product
+      allow_any_instance_of(described_class).to(receive(:find_product_by_name).and_return(product))
+      expect(subject.instance_variable_get(:@product)).to(eq(product))
     end
 
     it "has instance variable instance" do
-      expect(subject.instance_variable_get(:@instance)).to eq instance
+      expect(subject.instance_variable_get(:@instance)).to(eq(instance))
     end
 
     it "has instance variable params" do
-      expect(subject.instance_variable_get(:@params)).to eq params
+      expect(subject.instance_variable_get(:@params)).to(eq(params))
     end
   end
 
   describe "#run_query" do
-    subject {described_class.new(session_user, instance, params).run_query}
+    subject { described_class.new(session_user, instance, params).run_query }
 
     context "when profile_v2_aware config is enabled" do
       context "when there is no product" do
         it "returns an array of product_configs_and_profile_items and product" do
-          expect(subject).to eq([[],nil])
+          expect(subject).to(eq([[], nil]))
         end
       end
 
       context "whern there is no instance" do
         let(:instance) { nil }
         it "returns an array of product_configs_and_profile_items and product" do
-          expect(subject).to eq([[],nil])
+          expect(subject).to(eq([[], nil]))
         end
       end
 
@@ -58,25 +60,25 @@ RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs,
         let!(:product) { FactoryBot.create(:product, name: "FOA") }
 
         before do
-          allow(session_user.user).to receive(:products).and_return(instance_double(ActiveRecord::Relation, where: [product]))
+          allow(session_user.user).to(receive(:products).and_return(instance_double(ActiveRecord::Relation, where: [product])))
         end
 
         context "and the product is not attached to a product_item_config" do
           it "returns an empty array of product_configs_and_profile_items and product" do
-            expect(subject).to eq([[],product])
+            expect(subject).to(eq([[], product]))
           end
         end
         context "and a product is attached to a product_item_config" do
           let(:product_item_config) { FactoryBot.create(:product_item_config, product: product) }
           it "returns an array of product_configs_and_profile_items and product" do
             profile_item = double("ProfileItem")
-            allow(Profile::ProfileItem).to receive(:new).and_return(profile_item)
+            allow(Profile::ProfileItem).to(receive(:new).and_return(profile_item))
             result = [
-              [{product_item_config: product_item_config, profile_item: profile_item}],
+              [{ product_item_config: product_item_config, profile_item: profile_item }],
               product
             ]
 
-            expect(subject).to eq(result)
+            expect(subject).to(eq(result))
           end
         end
       end
@@ -88,24 +90,24 @@ RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs,
         let!(:user_draft_profile_editor) { FactoryBot.create(:user_product_role, product_role:, user:) }
 
         it "returns the product attached to the role" do
-          expect(subject[1].id).to eq product.id
+          expect(subject[1].id).to(eq(product.id))
         end
       end
     end
 
     context "when profile_v2_aware config is disabled" do
-      before {allow(Rails.configuration).to receive(:try).with('profile_v2_aware').and_return(false) }
+      before { allow(Rails.configuration).to(receive(:try).with("profile_v2_aware").and_return(false)) }
 
       context "when there is no product" do
         it "returns an array of product_configs_and_profile_items and product" do
-          expect(subject).to eq([[],nil])
+          expect(subject).to(eq([[], nil]))
         end
       end
 
       context "whern there is no instance" do
         let(:instance) { nil }
         it "returns an array of product_configs_and_profile_items and product" do
-          expect(subject).to eq([[],nil])
+          expect(subject).to(eq([[], nil]))
         end
       end
 
@@ -115,13 +117,13 @@ RSpec.describe Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs,
 
         context "and the product is not attached to a product_item_config" do
           it "returns an empty array of product_configs_and_profile_items and product" do
-            expect(subject).to eq([[],nil])
+            expect(subject).to(eq([[], nil]))
           end
         end
         context "and a product is attached to a product_item_config" do
           let!(:product_item_config) { FactoryBot.create(:product_item_config, product: product) }
           it "returns an array of product_configs_and_profile_items and product" do
-            expect(subject).to eq([[],nil])
+            expect(subject).to(eq([[], nil]))
           end
         end
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,31 +1,32 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe User, type: :model do
+require "rails_helper"
 
+RSpec.describe(User, type: :model) do
   describe "associations" do
-    it { is_expected.to have_many(:batch_reviewers).class_name('Loader::Batch::Reviewer').with_foreign_key('user_id') }
-    it { is_expected.to have_many(:user_product_roles).class_name('User::ProductRole').with_foreign_key('user_id') }
-    it { is_expected.to have_many(:product_roles).through(:user_product_roles) }
-    it { is_expected.to have_many(:products).through(:product_roles) }
-    it { is_expected.to have_many(:roles).through(:product_roles) }
+    it { is_expected.to(have_many(:batch_reviewers).class_name("Loader::Batch::Reviewer").with_foreign_key("user_id")) }
+    it { is_expected.to(have_many(:user_product_roles).class_name("User::ProductRole").with_foreign_key("user_id")) }
+    it { is_expected.to(have_many(:product_roles).through(:user_product_roles)) }
+    it { is_expected.to(have_many(:products).through(:product_roles)) }
+    it { is_expected.to(have_many(:roles).through(:product_roles)) }
   end
 
-  describe '#is?' do
+  describe "#is?" do
     let(:user) { FactoryBot.create(:user) }
-    let!(:role) { FactoryBot.create(:role, name: 'admin') }
+    let!(:role) { FactoryBot.create(:role, name: "admin") }
     let!(:product) { FactoryBot.create(:product) }
     let!(:product_role) { FactoryBot.create(:product_role, product:, role:) }
     let!(:user_product_role) { FactoryBot.create(:user_product_role, product_role:, user:) }
 
-    context 'when the user has the requested role type' do
-      it 'returns true' do
-        expect(user.is?('admin')).to be true
+    context "when the user has the requested role type" do
+      it "returns true" do
+        expect(user.is?("admin")).to(be(true))
       end
     end
 
-    context 'when the user does not have the requested role type' do
-      it 'returns false' do
-        expect(user.is?('editor')).to be false
+    context "when the user does not have the requested role type" do
+      it "returns false" do
+        expect(user.is?("editor")).to(be(false))
       end
     end
   end
@@ -37,13 +38,13 @@ RSpec.describe User, type: :model do
     let!(:product1) { create(:product, name: "FOO") }
     let!(:product2) { create(:product, name: "BAR") }
 
-    let!(:user) {create(:user, user_name: "testuser", given_name: "Test", family_name: "User", created_by: "Tester", updated_by: "Tester") }
+    let!(:user) { create(:user, user_name: "testuser", given_name: "Test", family_name: "User", created_by: "Tester", updated_by: "Tester") }
 
     let!(:user_product_role1) { create(:user_product_role, user: user, product: product1, role: role1) }
     let!(:user_product_role2) { create(:user_product_role, user: user, product: product2, role: role2) }
 
     it "returns the first product for allowed roles" do
-      expect(user.available_product_from_roles).to eq(product1)
+      expect(user.available_product_from_roles).to(eq(product1))
     end
   end
 
@@ -56,22 +57,21 @@ RSpec.describe User, type: :model do
     let!(:product2) { create(:product, name: "BAR") }
     let!(:product3) { create(:product, name: "CAN") }
 
-    let!(:user) {create(:user, user_name: "testuser", given_name: "Test", family_name: "User", created_by: "Tester", updated_by: "Tester") }
+    let!(:user) { create(:user, user_name: "testuser", given_name: "Test", family_name: "User", created_by: "Tester", updated_by: "Tester") }
 
     let!(:user_product_role1) { create(:user_product_role, user: user, product: product1, role: role1) }
     let!(:user_product_role2) { create(:user_product_role, user: user, product: product2, role: role2) }
     let!(:user_product_role3) { create(:user_product_role, user: user, product: product3, role: role3) }
 
     it "returns all unique products for all roles" do
-      expect(user.available_products_from_roles).to match_array([product1, product2, product3])
+      expect(user.available_products_from_roles).to(match_array([product1, product2, product3]))
     end
 
     it "returns unique products only" do
       test_role = create(:role, name: "test-editor")
       create(:user_product_role, user: user, product: product1, role: test_role)
 
-      expect(user.available_products_from_roles.count(product1)).to eq(1)
+      expect(user.available_products_from_roles.count(product1)).to(eq(1))
     end
-
   end
 end

--- a/spec/views/instances/tabs/tabs_all_tab_headings_partial_spec.rb
+++ b/spec/views/instances/tabs/tabs_all_tab_headings_partial_spec.rb
@@ -1,6 +1,8 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe "instances/tabs/_all_tab_headings.html.erb", type: :view do
+require "rails_helper"
+
+RSpec.describe("instances/tabs/_all_tab_headings.html.erb", type: :view) do
   let(:session_user) { FactoryBot.create(:session_user) }
   let(:user) { FactoryBot.create(:user) }
   let(:instance) { FactoryBot.create(:instance) }
@@ -9,105 +11,107 @@ RSpec.describe "instances/tabs/_all_tab_headings.html.erb", type: :view do
   before do
     assign(:instance, instance)
     assign(:tabs_to_offer, tabs_to_offer)
-    allow(view).to receive(:can?).and_return(false)
-    allow(view).to receive(:increment_tab_index).and_return(1)
-    allow(view).to receive(:user_profile_tab_name).and_return("User")
+    allow(view).to(receive(:can?).and_return(false))
+    allow(view).to(receive(:increment_tab_index).and_return(1))
+    allow(view).to(receive(:user_profile_tab_name).and_return("User"))
 
     assign(:current_user, session_user)
     assign(:current_registered_user, user)
     assign(:instance, instance)
     assign(:tab, "tab_show_1")
+
+    allow(Rails.configuration).to(receive(:multi_product_tabs_enabled).and_return(false))
   end
 
   context "when 'tab_show_1' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_show_1'
-      allow(view).to receive(:can?).with('instances', 'tab_show_1').and_return(true)
+      tabs_to_offer << "tab_show_1"
+      allow(view).to(receive(:can?).with("instances", "tab_show_1").and_return(true))
     end
 
     it "renders the 'Details' tab" do
       render
-      expect(rendered).to have_selector("a#instance-show-tab", text: "Details")
+      expect(rendered).to(have_selector("a#instance-show-tab", text: "Details"))
     end
   end
 
   context "when 'tab_edit' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_edit'
-      allow(view).to receive(:can?).with(:edit, instance).and_return(true)
+      tabs_to_offer << "tab_edit"
+      allow(view).to(receive(:can?).with(:edit, instance).and_return(true))
     end
 
     it "renders the 'Edit' tab" do
       render
-      expect(rendered).to have_selector("a#instance-edit-tab", text: "Edit")
+      expect(rendered).to(have_selector("a#instance-edit-tab", text: "Edit"))
     end
   end
 
   context "when 'tab_edit_notes' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_edit_notes'
-      allow(view).to receive(:can?).with('instance_notes', 'edit').and_return(true)
+      tabs_to_offer << "tab_edit_notes"
+      allow(view).to(receive(:can?).with("instance_notes", "edit").and_return(true))
     end
 
     it "renders the 'Notes' tab" do
       render
-      expect(rendered).to have_selector("a#instance-edit-notes-tab", text: "Notes")
+      expect(rendered).to(have_selector("a#instance-edit-notes-tab", text: "Notes"))
     end
   end
 
   context "when 'tab_synonymy' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_synonymy'
-      allow(view).to receive(:can?).with(:create, Instance).and_return(true)
+      tabs_to_offer << "tab_synonymy"
+      allow(view).to(receive(:can?).with(:create, Instance).and_return(true))
     end
 
     it "renders the 'Synonym' tab" do
       render
-      expect(rendered).to have_selector("a#instance-cite-this-instance-tab", text: "Syn")
+      expect(rendered).to(have_selector("a#instance-cite-this-instance-tab", text: "Syn"))
     end
   end
 
   context "when 'tab_unpublished_citation' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_unpublished_citation'
-      allow(view).to receive(:can?).with(:create, instance).and_return(true)
+      tabs_to_offer << "tab_unpublished_citation"
+      allow(view).to(receive(:can?).with(:create, instance).and_return(true))
     end
 
     it "renders the 'Unpublished citation' tab" do
       render
-      expect(rendered).to have_selector("a#unpublished-citation-tab", text: "Unpub")
+      expect(rendered).to(have_selector("a#unpublished-citation-tab", text: "Unpub"))
     end
   end
 
   context "when 'tab_profile_v2' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_profile_v2'
-      allow(view).to receive(:can?).with(:manage_profile, instance).and_return(true)
-      allow(Rails.configuration).to receive(:profile_v2_aware).and_return(true)
+      tabs_to_offer << "tab_profile_v2"
+      allow(view).to(receive(:can?).with(:manage_profile, instance).and_return(true))
+      allow(Rails.configuration).to(receive(:profile_v2_aware).and_return(true))
     end
 
     it "renders the 'User Profile' tab" do
       render
-      expect(rendered).to have_selector("a#instance-profile-v2-tab", text: "User Profile")
+      expect(rendered).to(have_selector("a#instance-profile-v2-tab", text: "User Profile"))
     end
   end
 
   context "when 'tab_batch_loader' is offered and the user has permission" do
     before do
-      tabs_to_offer << 'tab_batch_loader'
-      allow(view).to receive(:can?).with('loader/batches', 'process').and_return(true)
+      tabs_to_offer << "tab_batch_loader"
+      allow(view).to(receive(:can?).with("loader/batches", "process").and_return(true))
     end
 
     it "renders the 'Batch Loader operations' tab" do
       render
-      expect(rendered).to have_selector("a#instance-batch-loader-tab", text: "Loader 1")
+      expect(rendered).to(have_selector("a#instance-batch-loader-tab", text: "Loader 1"))
     end
   end
 
   context "when no tabs are offered" do
     it "renders no tabs" do
       render
-      expect(rendered).not_to have_selector("a")
+      expect(rendered).not_to(have_selector("a"))
     end
   end
 end

--- a/spec/views/names/tabs/tabs_partial_spec.rb
+++ b/spec/views/names/tabs/tabs_partial_spec.rb
@@ -1,118 +1,124 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe "names/tabs/_tabs.html.erb", type: :view do
-  let(:user) { FactoryBot.create(:session_user) }
-  let(:name) { FactoryBot.create(:name) }
+require "rails_helper"
+
+RSpec.describe("names/tabs/_tabs.html.erb", type: :view) do
+  let(:user) { create(:session_user) }
+  let(:current_registered_user) { create(:user) }
+  let(:name) { create(:name) }
 
   before do
-    allow(view).to receive(:can?).with('instances', 'create').and_return(false)
-    allow(view).to receive(:can?).with('names', 'update').and_return(false)
-    allow(view).to receive(:can?).with('names', 'delete').and_return(false)
-    allow(view).to receive(:can?).with(:create_with_product_reference, Instance).and_return(false)
-    allow(view).to receive(:can?).with(:create, Instance).and_return(true)
-    allow(view).to receive(:increment_tab_index).and_return(1)
+    allow(view).to(receive(:can?).with("instances", "create").and_return(false))
+    allow(view).to(receive(:can?).with("names", "update").and_return(false))
+    allow(view).to(receive(:can?).with("names", "delete").and_return(false))
+    allow(view).to(receive(:can?).with(:create_with_product_reference, Instance).and_return(false))
+    allow(view).to(receive(:can?).with(:create, Instance).and_return(true))
+    allow(view).to(receive(:increment_tab_index).and_return(1))
 
     assign(:current_user, user)
+    assign(:current_registered_user, current_registered_user)
     assign(:tab, "tab_show_1")
     assign(:name, name)
+
+    allow(Rails.configuration).to(receive(:multi_product_tabs_enabled).and_return(false))
   end
 
   subject { render partial: "names/tabs/tabs" }
 
   it "renders the Details tab" do
     subject
-    expect(rendered).to have_selector("ul.nav.nav-tabs")
-    expect(rendered).to have_link("Details", id: "name-details-tab" )
+    expect(rendered).to(have_selector("ul.nav.nav-tabs"))
+    expect(rendered).to(have_link("Details", id: "name-details-tab"))
   end
 
   it "does not render the Edit tab" do
     subject
-    expect(rendered).not_to have_link('Edit', id: 'name-edit-tab')
+    expect(rendered).not_to(have_link("Edit", id: "name-edit-tab"))
   end
 
   it "does not render the Delete tab" do
     subject
-    expect(rendered).not_to have_link('Delete name', id: 'name-delete-tab')
+    expect(rendered).not_to(have_link("Delete name", id: "name-delete-tab"))
   end
 
   it "does not render the product-based New instance tab" do
     subject
-    expect(rendered).not_to have_link('New instance', id: 'name-instances-profile-v2-tab')
+    expect(rendered).not_to(have_link("New instance", id: "name-instances-profile-v2-tab"))
   end
 
   it "renders the non-product based New instance tab" do
     subject
-    expect(rendered).to have_link('New instance', id: 'name-instances-tab')
+    expect(rendered).to(have_link("New instance", id: "name-instances-tab"))
   end
 
   context "when the user can update names" do
     before do
-      allow(view).to receive(:can?).with('names', 'update').and_return(true)
+      allow(view).to(receive(:can?).with("names", "update").and_return(true))
     end
 
     it "renders the Edit tab" do
       subject
-      expect(rendered).to have_link('Edit', id: 'name-edit-tab')
+      expect(rendered).to(have_link("Edit", id: "name-edit-tab"))
     end
   end
 
   context "when a user can create an instance" do
     before do
-      allow(view).to receive(:can?).with('instances', 'create').and_return(true)
+      allow(view).to(receive(:can?).with("instances", "create").and_return(true))
     end
 
     context "and it has :create_with_product_reference to true" do
       before do
-        allow(view).to receive(:can?).with(:create_with_product_reference, Instance).and_return(true)
+        allow(view).to(receive(:can?).with(:create_with_product_reference, Instance).and_return(true))
       end
 
       it "renders the New instance profile v2 tab" do
         subject
-        expect(rendered).to have_link('New instance', id: 'name-instances-profile-v2-tab')
+        expect(rendered).to(have_link("New instance", id: "name-instances-profile-v2-tab"))
       end
 
       it "does not render the regular New instance tab" do
         subject
-        expect(rendered).not_to have_link('New instance', id: 'name-instances-tab')
+        expect(rendered).not_to(have_link("New instance", id: "name-instances-tab"))
       end
     end
 
     context "and it has :create_with_product_reference to false" do
       before do
-        allow(view).to receive(:can?).with(:create_with_product_reference, Instance).and_return(false)
+        allow(view).to(receive(:can?).with(:create_with_product_reference, Instance).and_return(false))
       end
 
       it "does not render the New instance profile v2 tab" do
         subject
-        expect(rendered).not_to have_link('New instance', id: 'name-instances-profile-v2-tab')
+        expect(rendered).not_to(have_link("New instance", id: "name-instances-profile-v2-tab"))
       end
 
       it "renders the regular New instance tab" do
         subject
-        expect(rendered).to have_link('New instance', id: 'name-instances-tab')
+        expect(rendered).to(have_link("New instance", id: "name-instances-tab"))
       end
     end
   end
 
   context "when a user can update a name" do
     before do
-      allow(view).to receive(:can?).with('names', 'update').and_return(true)
+      allow(view).to(receive(:can?).with("names", "update").and_return(true))
     end
 
     it "renders the Edit tab" do
       subject
-      expect(rendered).to have_link('Edit', id: 'name-edit-tab')
+      expect(rendered).to(have_link("Edit", id: "name-edit-tab"))
     end
   end
 
   context "when a user can delete a name" do
     before do
-      allow(view).to receive(:can?).with('names', 'delete').and_return(true)
+      allow(view).to(receive(:can?).with("names", "delete").and_return(true))
     end
 
     it "renders the Delete tab" do
       subject
-      expect(rendered).to have_link('Delete name', id: 'name-delete-tab')
+      expect(rendered).to(have_link("Delete name", id: "name-delete-tab"))
     end
   end
 end


### PR DESCRIPTION
## Description

Muti-tabs for instances and cleanup codes.  The tabs for the names and instances are now supporting multipe products based on the user's product roles. The FOA/PRODUCT profile tab are now filtered and working for the specified product (ie adding item config, profile texts, etc).  

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How to Test
FLOR-82

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-82

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
