### PR TITLE
Check batch_loader_aware flag before showing batch info on users detail tab

### DIFF
--- a/app/views/users/tabs/_tab_details.html.erb
+++ b/app/views/users/tabs/_tab_details.html.erb
@@ -8,8 +8,10 @@
 <%= render partial: 'detail_line',
            locals: {info: @user.family_name, label: 'Family Name'} %>
 
-<%= render partial: 'detail_line',
-           locals: {info: @user.batch_reviewers.size, label: 'Batch Reviews Count'} %>
+<% if Rails.configuration.try(:batch_loader_aware) %>
+  <%= render partial: 'detail_line',
+             locals: {info: @user.batch_reviewers.size, label: 'Batch Reviews Count'} %>
+<% end %>
 
 
 <%= divider %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 29-July-2025
+  :jira_id: 
+  :description: |-
+    Check the batch_loader_aware flag on the Users detail tab before querying batch info
 - :date: 28-July-2025
   :jira_id: '82'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.1.9.24
+appversion=4.1.9.25


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Query a user and show their details in a database without the batch_* tables.

## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
