### PR TITLE
NSL-5534: Change history log reference from 5529 to 5534

### DIFF
--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -16,7 +16,7 @@
   :description: |-
     Batch: Loader Name queries <code>in-accepted-taxonomy</code> (renamed), <code>not-in-accepted-taxonomy</code> (added), <code>in-or-not-in-accepted-taxonomy</code> (added)
 - :date: 12-Aug-2025
-  :jira_id:  '5529'
+  :jira_id:  '5534'
   :description: |-
     Ruby: Upgrade docker image to ruby:3.4.5-bullseye
 - :date: 07-Aug-2025


### PR DESCRIPTION
## Description
Tiny change to history log

## Type of change
- [x] Tiny change to doco

## How to Test
View Changes for 2025


## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps

No need for these...

- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
