### PR TITLE
NSL-5192: Batch Review: Handle "uncaught throw" error for unassigned reviewers hitting the Search button

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -59,6 +59,7 @@ class SearchController < ApplicationController
 
   def run_local_search
     return false unless params[:query_string].present?
+    raise 'Search needs a target. Do you have the right permissions?' unless params[:query_target].present?
 
     logger.debug("focus_id: #{params[:focus_id]}")
     @focus_id = params[:focus_id]

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 15-Aug-2025
+  :jira_id:  '5192'
+  :description: |-
+    Batch Review: Handle "uncaught throw" error for unassigned reviewers hitting the Search button
+- :date: 15-Aug-2025
   :jira_id:  ''
   :description: |-
     Remove unnecessary libraries in Dockerfile.dev

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.6
+appversion=4.2.0.7

--- a/test/controllers/search/no_target/blank_target_test.rb
+++ b/test/controllers/search/no_target/blank_target_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchControllerBlankTargetTest < ActionController::TestCase
+  tests SearchController
+
+  test "search with a blank target provided" do
+    get(:search,
+        params: { query_target: "", query_string: "*" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [] })
+    assert_response :success
+    assert_match 'Search needs a target. Do you have the right permissions?',
+      @response.body,
+      "Expected an error message referring to the missing search target"
+  end
+end

--- a/test/controllers/search/no_target/no_query_target_test.rb
+++ b/test/controllers/search/no_target/no_query_target_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single search controller test.
+class SearchControllerNoQueryTargetTest < ActionController::TestCase
+  tests SearchController
+
+  test "search with no query target provided" do
+    get(:search,
+        params: { query_string: "*" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [] })
+    assert_response :success
+    assert_match 'Search needs a target. Do you have the right permissions?',
+      @response.body,
+      "Expected an error message referring to the missing search query target"
+  end
+end


### PR DESCRIPTION


## Description
Check for missing target and set error message for user.

## Type of change
It's one or both of these depending on how you look at it...
- [x] Bug fix (non-breaking change which fixes an issue)?
- [x] New feature (non-breaking change which adds functionality)?

## How to Test
Log in as batch review user who hasn't been assigned to review a specific batch.

## Tests
- [x] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
