### PR TITLE
NSL-5362:  Loader Batch Query: Add query syn-matched-to-autonym for preferred matches that are autonyms

### DIFF
--- a/app/models/search/loader/name/field_rule.rb
+++ b/app/models/search/loader/name/field_rule.rb
@@ -1022,6 +1022,15 @@ group by loader_name.family, family.simple_name) subq
 where simple_name is null
  )
 )",
-  }
+  },
+"syn-matched-to-autonym:" => { where_clause: "record_type = 'synonym' 
+  and exists (select null
+                from loader_name_match
+                     join instance on loader_name_match.instance_id = instance.id
+                     join instance_type on instance.instance_type_id = instance_type.id
+               where loader_name.id = loader_name_match.loader_name_id
+                 and instance_type.name like '%autonym%'
+             )", 
+            takes_no_arg: true},
   }.freeze
 end

--- a/app/views/loader/names/help/_fields.html.erb
+++ b/app/views/loader/names/help/_fields.html.erb
@@ -248,6 +248,8 @@
      description: "match fragment on the name status field (no wildcards added, but you can add them)"},
     {field_name: 'name-status-empty-string:',
      description: "loader name with an empty string in name status (these came about during early raw editing of loader name data when empty fields were mistakenly saved as empty strings)"},
+    {field_name: 'syn-matched-to-autonym:',
+     description: "loader name synonym with a preferred match to an autonym, implicit autonym, or explicit autonym (i.e. includes any instance type matching '%autonym%')"},
       ].each do |val| %>
   <tr>
     <td class="width-20-percent">

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 20-Aug-2025
+  :jira_id:  '5362'
+  :description: |-
+    Loader Batch Query: Add query <code>syn-matched-to-autonym:</code> for preferred matches that are autonyms
 - :date: 18-Aug-2025
   :jira_id:  '5196'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.8
+appversion=4.2.0.9


### PR DESCRIPTION


## Description
New query directive

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How to Test
As a batch loader run the query directive on a batch.

## Tests
- [x] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
