### PR TITLE
NSL-5451: Loader Batch: Genus name now consistently sorting before first child species in batch

### DIFF
--- a/app/models/concerns/loader/name/sort_key.rb
+++ b/app/models/concerns/loader/name/sort_key.rb
@@ -20,9 +20,9 @@ module Loader::Name::SortKey
     normalise_sort_key unless sort_key.blank?
     case record_type
     when "accepted"
-      self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{' agenus' if rank == 'genus'}"
+      self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{'1genus' if rank == 'genus'}"
     when "excluded"
-      self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{' agenus' if rank == 'genus'}"
+      self.sort_key = "#{family.downcase}.family.#{record_type}.#{simple_name.downcase} #{'1genus' if rank == 'genus'}"
     when "synonym"
       self.sort_key = synonym_sort_key(parent.sort_key)
     when "misapplied"

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 21-Aug-2025
+  :jira_id:  '5451'
+  :description: |-
+    Loader Batch: Genus name now consistently sorting before first child species in batch
+- :date: 21-Aug-2025
   :jira_id:  '5549'
   :description: |-
     Software Upgrade: Update many outdated gems/libraries

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.11
+appversion=4.2.0.12


### PR DESCRIPTION
## Description
Tweaking the sort-key algorithm.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
As described in the Jira.

## Tests
- [ ] Unit tests
- [ ] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
