### PR TITLE
NSL-5163:  CSV Output: link to CSV export of instance query results works again without breaking the print: directive

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,10 +6,11 @@ class SearchController < ApplicationController
     handle_old
     run_local_search || run_empty_search
     respond_to do |format|
-      format.html
+      format.html do
+        render_html
+      end
       format.csv do
-        data = @search.executed_query.results.to_csv
-        send_data(encode_data_for_csv(data))
+        render_csv
       end
     end
   rescue ActiveRecord::StatementInvalid => e
@@ -137,6 +138,19 @@ class SearchController < ApplicationController
     end
     Rails.logger.info("apply_view_mode:    @view_mode: #{@view_mode}")
     Rails.logger.info("apply_view_mode:    @view: #{@view}")
+  end
+
+  def render_html
+    if @search.parsed_request&.print
+      render :printable, layout: "layouts/print"
+    else
+      render :search
+    end
+  end
+
+  def render_csv
+    data = @search.executed_query.results.to_csv
+    send_data(encode_data_for_csv(data))
   end
 
   def encode_data_for_csv(data)

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 21-Aug-2025
+  :jira_id:  '5163'
+  :description: |-
+    CSV Output: link to CSV export of instance query results works again without breaking the print: directive
+- :date: 21-Aug-2025
   :jira_id:  '5451'
   :description: |-
     Loader Batch: Genus name now consistently sorting before first child species in batch

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.12
+appversion=4.2.0.13


### PR DESCRIPTION
## Description
Re-work the search controller changes so CSV output and print output still both work.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Get Instances as CSV and loader names in print output.

## Tests
- [ ] Unit tests
- [ ] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
