### PR TITLE
NSL-5429: Tree permissions fix

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -294,6 +294,14 @@ class Ability
     can :update_excluded, :all
     can :replace_placement, :all
     can :remove_name_placement, :all
+    can :reports, TreeVersion
+    can :show_cas, TreeVersion
+    can :show_diff, TreeVersion
+    can :show_valrep, TreeVersion
+    can :run_cas, TreeVersion
+    can :update_synonymy_by_instance, TreeVersion
+    can :run_diff, TreeVersion
+    can :run_valrep, TreeVersion
   end
 
   def admin_auth

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 10-Sep-2025
+  :jira_id: '5429'
+  :description: |-
+    Tree permissions: Add permissions for treebuilder user on Taxonomy tab reports so they work in the transition period
 - :date: 09-Sep-2025
   :jira_id: '112'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.19
+appversion=4.2.0.20


### PR DESCRIPTION
## Description
 Add permissions for treebuilder user on Taxonomy tab reports so they work in the transition period

## Type of change
- [x] Bug fix for code in test

## How to Test
Anna reported and can replicate the problem  - go to Taxonomy tab and click on various buttons

## Tests
- [x] Unit tests - the integration tests still confirmed a user who can only login cannot access these options
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
