### PR TITLE
Don't render the New Name option in the menu to foa users

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -48,6 +48,7 @@ module TabsHelper
 
   def tab_available?(tabs_array, tab_name)
     return true unless Rails.configuration.try('multi_product_tabs_enabled')
+    return true if product_context_service.available_contexts.blank?
 
     tabs_array.include?(tab_name)
   end

--- a/app/views/layouts/_new_multi_product_menu.html.erb
+++ b/app/views/layouts/_new_multi_product_menu.html.erb
@@ -7,79 +7,82 @@
   >
     New<span class="caret"></span>
   </a>
+  <% name_tabs_array = product_tab_service.all_available_tabs.dig('name')&.map{|tab| tab[:tab] } || [] %>
   <ul id="create-dropdown-menu" class="dropdown-menu" role="menu">
-    <li class="dropdown-submenu">
-      <a tabindex="-1" href="#" title="Names stuff"> Names </a>
-      <ul id="create-name-dropdown-submenu" class="dropdown-menu" role="menu">
-        <li role="presentation">
-          <%= link_to "Scientific name",
-            name_new_row_path('scientific'),
-            title: 'Add a new scientific name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation">
-          <%= link_to "Scientific name family or above",
-            name_new_row_path('scientific-family-or-above'),
-            title: 'Add a new scientific name family and above',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation">
-          <%= link_to "Phrase name",
-            name_new_row_path('phrase'),
-            title: 'Add a new phrase name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation" class="divider"></li>
-        <li role="presentation">
-          <%= link_to "Hybrid formula name",
-            name_new_row_path('hybrid formula'),
-            title: 'Add a new hybrid name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation">
-          <%= link_to "Hybrid formula unknown 2nd parent name",
-            name_new_row_path('hybrid-formula-unknown-2nd-parent'),
-            title: 'Add a new hybrid formula unknown 2nd parent name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation" class="divider"></li>
-        <li role="presentation">
-          <%= link_to "Cultivar hybrid name",
-            name_new_row_path('cultivar-hybrid'),
-            title: 'Add a new cultivar hybrid name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation">
-          <%= link_to "Cultivar name",
-            name_new_row_path('cultivar'),
-            title: 'Add a new cultivar name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-        <li role="presentation" class="divider"></li>
-        <li role="presentation">
-          <%= link_to "Other name",
-            name_new_row_path('other'),
-            title: 'Add a new other name',
-            remote: true,
-            tabindex: '-1'
-          %>
-        </li>
-      </ul>
-    </li>
+    <% if tab_available?(name_tabs_array, "new") %>
+      <li class="dropdown-submenu">
+        <a tabindex="-1" href="#" title="Names stuff"> Names </a>
+        <ul id="create-name-dropdown-submenu" class="dropdown-menu" role="menu">
+          <li role="presentation">
+            <%= link_to "Scientific name",
+              name_new_row_path('scientific'),
+              title: 'Add a new scientific name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation">
+            <%= link_to "Scientific name family or above",
+              name_new_row_path('scientific-family-or-above'),
+              title: 'Add a new scientific name family and above',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation">
+            <%= link_to "Phrase name",
+              name_new_row_path('phrase'),
+              title: 'Add a new phrase name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation" class="divider"></li>
+          <li role="presentation">
+            <%= link_to "Hybrid formula name",
+              name_new_row_path('hybrid formula'),
+              title: 'Add a new hybrid name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation">
+            <%= link_to "Hybrid formula unknown 2nd parent name",
+              name_new_row_path('hybrid-formula-unknown-2nd-parent'),
+              title: 'Add a new hybrid formula unknown 2nd parent name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation" class="divider"></li>
+          <li role="presentation">
+            <%= link_to "Cultivar hybrid name",
+              name_new_row_path('cultivar-hybrid'),
+              title: 'Add a new cultivar hybrid name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation">
+            <%= link_to "Cultivar name",
+              name_new_row_path('cultivar'),
+              title: 'Add a new cultivar name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+          <li role="presentation" class="divider"></li>
+          <li role="presentation">
+            <%= link_to "Other name",
+              name_new_row_path('other'),
+              title: 'Add a new other name',
+              remote: true,
+              tabindex: '-1'
+            %>
+          </li>
+        </ul>
+      </li>
+    <% end %>
 
     <% author_tabs_array = product_tab_service.all_available_tabs.dig('author')&.collect{|tab| tab[:tab] } || [] %>
     <% if tab_available?(author_tabs_array, 'new') %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,4 @@
-- :date: 12-Sep-2025
+- :date: 15-Sep-2025
   :jira_id: '112'
   :jira_project: FLOR
   :description: |-

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 12-Sep-2025
+  :jira_id: '112'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Don't render the new name option to foa users
+- :date: 12-Sep-2025
   :jira_id: '5429'
   :description: |-
     Tree permissions: Add permissions for treebuilder user to open parent typeahead - as before, for backwards compatibility during transition

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.24
+appversion=4.2.0.25


### PR DESCRIPTION
## Description
This pull request updates the logic for displaying menu items in the `app/views/layouts/_new_multi_product_menu.html.erb` file. The main change is that the "Names" submenu is now conditionally rendered based on the availability of the "new" tab, improving menu accuracy and reducing clutter.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
