### PR TITLE
Refresh tab access for product roles

### DIFF
--- a/app/views/names/tabs/_tab_more.html.erb
+++ b/app/views/names/tabs/_tab_more.html.erb
@@ -1,3 +1,11 @@
+<%
+  tabs = product_tab_service.all_available_tabs["name"] || []
+  tabs_array = tabs.collect{|tab| tab[:tab] }
+%>
+
 <% increment_tab_index(0) %>
 <%= render partial: "names/tabs/tabs_row_2" %>
-<%= render partial: "names/tabs/tab_comments" %>
+
+<% if tab_available?(tabs_array, "more_comment") %>
+  <%= render partial: "names/tabs/tab_comments" %>
+<% end %>

--- a/app/views/names/tabs/_tabs_row_2.html.erb
+++ b/app/views/names/tabs/_tabs_row_2.html.erb
@@ -37,19 +37,21 @@
       %>
     <% end %>
 
-    <%= render partial: "names/tabs/tab",
-      locals: {
-        first: false,
-        last: true,
-        this_tab: "tab_refresh",
-        link_text: "Refresh",
-        link_id: "name-refresh-tab",
-        link_title: "Refresh the constructed elements of the name or of its children.",
-        tab_index: increment_tab_index,
-        prev_tab: "",
-        next_tab: ""
-      }
-    %>
+    <% if tab_available?(tabs_array, "more_refresh")%>
+      <%= render partial: "names/tabs/tab",
+        locals: {
+          first: false,
+          last: true,
+          this_tab: "tab_refresh",
+          link_text: "Refresh",
+          link_id: "name-refresh-tab",
+          link_title: "Refresh the constructed elements of the name or of its children.",
+          tab_index: increment_tab_index,
+          prev_tab: "",
+          next_tab: ""
+        }
+      %>
+    <% end %>
   <% end %>
 
   <% if @name.duplicate? && can?("names", "update") %>

--- a/app/views/names/tabs/_tabs_row_2.html.erb
+++ b/app/views/names/tabs/_tabs_row_2.html.erb
@@ -21,7 +21,7 @@
       %>
     <% end %>
 
-    <% if NameTag.all.count > 0 && tab_available?(tabs_array, "more_tag")%>
+    <% if NameTag.all.count > 0 && tab_available?(tabs_array, "more_tag") %>
       <%= render partial: "names/tabs/tab",
         locals: {
           first: false,
@@ -37,7 +37,7 @@
       %>
     <% end %>
 
-    <% if tab_available?(tabs_array, "more_refresh")%>
+    <% if tab_available?(tabs_array, "more_refresh") %>
       <%= render partial: "names/tabs/tab",
         locals: {
           first: false,

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 15-Sep-2025
+  :jira_id: '112'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Refresh tab access for users with product roles
+- :date: 15-Sep-2025
   :jira_id: '5449'
   :description: |-
      Batch Loader: Return Loader Name records in context for <code>id:</code> and <code>ids:</code> query directives

--- a/config/product_tabs/tabs.json
+++ b/config/product_tabs/tabs.json
@@ -35,7 +35,7 @@
   },
   "name": {
     "is_name_index": {
-      "tabs": ["new", "details", "edit", "new_instance", "copy", "more", "more_comment", "more_tag"]
+      "tabs": ["new", "details", "edit", "new_instance", "copy", "more", "more_comment", "more_tag", "more_refresh"]
     },
     "has_default_reference": {
       "tabs": ["details", "new_instance", "more", "more_tag"]

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.26
+appversion=4.2.0.27

--- a/spec/services/products/product_tab_config_spec.rb
+++ b/spec/services/products/product_tab_config_spec.rb
@@ -56,12 +56,7 @@ RSpec.describe Products::ProductTabConfig do
       context "for name" do
         it "returns tabs for is_name_index flag for name" do
           tabs = config.tabs_for(:name, ["is_name_index"])
-          expect(tabs).to eq(["new", "details", "edit", "new_instance", "copy", "more", "more_comment", "more_tag"])
-        end
-
-        it "returns tabs for is_name_index flag for name" do
-          tabs = config.tabs_for(:name, ["is_name_index"])
-          expect(tabs).to eq(["new", "details", "edit", "new_instance", "copy", "more", "more_comment", "more_tag"])
+          expect(tabs).to eq(["new", "details", "edit", "new_instance", "copy", "more", "more_comment", "more_tag", "more_refresh"])
         end
       end
 


### PR DESCRIPTION
## Description
This pull request adds a new tab called `more_refresh` to the name index view and ensures it is properly displayed in the UI when available. The changes update both the configuration and the view logic to support this new tab.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
