### PR TITLE
Sort the product context in the menu using the product's context_sort_order

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,7 +73,7 @@ class User < ActiveRecord::Base
     product_roles
       .joins(:role, :product)
       .includes(:product, :user_product_roles)
-      .order(Product.arel_table[:name].asc)
+      .order(Product.arel_table[:context_sort_order].asc, Product.arel_table[:name].asc)
       .filter_map(&:product)
       .uniq
   end

--- a/app/services/products/product_context_service.rb
+++ b/app/services/products/product_context_service.rb
@@ -39,7 +39,7 @@ module Products
     end
 
     def products_for_context(context_id)
-      Product.where(context_id: context_id)
+      Product.where(context_id: context_id).order(:context_sort_order)
     end
   end
 end

--- a/app/services/products/product_tab_service.rb
+++ b/app/services/products/product_tab_service.rb
@@ -10,7 +10,7 @@ module Products
     end
 
     def self.products_for_context(context_id)
-      Product.where(context_id: context_id)
+      Product.where(context_id: context_id).order(context_sort_order: :asc)
     end
 
     def initialize(products, config = ProductTabConfig.new, context_id: nil)

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 18-Sep-2025
+  :jira_id: '119'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Sort the product context in the menu using the product's context_sort_order field
+- :date: 18-Sep-2025
   :jira_id: '5571'
   :description: |-
     Batch Review:  Also show total comment count for family header records

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.33
+appversion=4.2.0.34

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,5 +73,13 @@ RSpec.describe(User, type: :model) do
 
       expect(user.available_products_from_roles.count(product1)).to(eq(1))
     end
+
+    it "sorts products by context and name" do
+      product1.update(context_id: 2, context_sort_order: 2)
+      product2.update(context_id: 1, context_sort_order: 1)
+      product3.update(context_id: 1, context_sort_order: 2)
+
+      expect(user.available_products_from_roles).to(eq([product2, product3, product1]))
+    end
   end
 end

--- a/spec/services/products/product_context_service_spec.rb
+++ b/spec/services/products/product_context_service_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Products::ProductContextService do
+  let!(:product_1) { create(:product, name: "APC", context_id: 1, context_sort_order: 1) }
+  let!(:product_2) { create(:product, name: "APNI", context_id: 1, context_sort_order: 3) }
+  let!(:product_3) { create(:product, name: "FOA", context_id: 2, context_sort_order: 2) }
+
+  subject(:service) { described_class.new(products: [product_1, product_2, product_3]) }
+
+  describe ".initialize" do
+    it "sets products" do
+      expect(service.products).to eq([product_1, product_2, product_3])
+    end
+  end
+
+  describe "#execute" do
+    it "returns available contexts based on products" do
+      result = service.execute
+      expect(result.length).to eq(2)
+    end
+
+    it "returns the correct context names and descriptions" do
+      result = service.execute
+      context_names = result.map { |ctx| ctx[:name] }
+      expect(context_names).to include("#{product_1.name}/#{product_2.name}", product_3.name)
+    end
+
+    it "returns products ordered by context_sort_order within each context" do
+      result = service.execute
+      apc_apni_context = result.find { |ctx| ctx[:context_id] == 1 }
+      foa_context = result.find { |ctx| ctx[:context_id] == 2 }
+
+      expect(apc_apni_context[:products].map(&:name)).to eq([product_1.name, product_2.name])
+      expect(foa_context[:products].map(&:name)).to eq([product_3.name])
+    end
+
+    it "sets the available_products instance variable" do
+      result = service.execute
+      expect(service.available_contexts.length).to eq(2)
+    end
+
+    context "when no products are provided" do
+      subject(:empty_service) { described_class.new(products: []) }
+
+      it "returns an empty array" do
+        expect(empty_service.execute).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/products/product_tab_service_spec.rb
+++ b/spec/services/products/product_tab_service_spec.rb
@@ -125,7 +125,9 @@ RSpec.describe Products::ProductTabService do
 
   describe ".products_for_context" do
     it "returns the product context for the given context id" do
-      allow(Product).to receive(:where).with(context_id: context_1).and_return([
+      relation = instance_double(ActiveRecord::Relation)
+      allow(Product).to receive_message_chain(:where).with(context_id: context_1).and_return(relation)
+      allow(relation).to receive(:order).with(context_sort_order: :asc).and_return([
         product_with_name_index,
         product_with_default_reference,
         product_with_manages_taxonomy

--- a/spec/services/products/product_tab_service_spec.rb
+++ b/spec/services/products/product_tab_service_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Products::ProductTabService do
   describe ".products_for_context" do
     it "returns the product context for the given context id" do
       relation = instance_double(ActiveRecord::Relation)
-      allow(Product).to receive_message_chain(:where).with(context_id: context_1).and_return(relation)
+      allow(Product).to receive(:where).with(context_id: context_1).and_return(relation)
       allow(relation).to receive(:order).with(context_sort_order: :asc).and_return([
         product_with_name_index,
         product_with_default_reference,


### PR DESCRIPTION
## Description
This pull request introduces consistent ordering of products by `context_sort_order` (and then by name) across several parts of the codebase, ensuring that products are presented in a predictable and logical order both in application logic and tests. It also adds and updates tests to verify the new ordering and context grouping behavior.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
