### PR TITLE
Refactor profile editor permissions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -159,9 +159,7 @@ class Ability
 
   def profile_editor(user)
     can :manage, :profile_v2
-    can :manage, Profile::ProfileItem do |profile_item|
-      profile_item.product_item_config.product_id == user.product_from_roles&.id
-    end
+    can :manage, Profile::ProfileItem, product: { product_roles: { user_product_roles: { user_id: user.user_id}}}
     can :create_version, Profile::ProfileItem do |profile_item|
       !profile_item.is_draft?
     end
@@ -171,9 +169,7 @@ class Ability
     can :manage, Profile::ProfileItemReference
     can :manage, Profile::ProfileText
     can :manage, Profile::ProfileItemAnnotation
-    can :manage_profile, Instance do |instance|
-      instance.profile_items.by_product(user.product_from_roles).any?
-    end
+    can :manage_profile, Instance, profile_items: { product_item_config: { product: { product_roles: { user_product_roles: { user_id: user.user_id}}}}}
     can "references", "typeahead_on_citation"
     can "profile_items", :all
     can "profile_item_annotations", :all

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 19-Sep-2025
+  :jira_id: '117'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Fixup missing edit tab for profile item when foa context is selected
 - :date: 18-Sep-2025
   :jira_id: '119'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.0
+appversion=4.3.0.1

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -367,13 +367,12 @@ RSpec.describe Ability, type: :model do
     end
 
     it "can manage published Profile::ProfileItem under a user's product" do
-      user = create(:user, id: 1)
+      user = create(:user, id: 1, user_name: session_user.username)
 
       product_role = create(:product_role, product: product)
       create(:user_product_role, user: user, product_role: product_role)
 
       product_item_config = create(:product_item_config, product: product)
-
       profile_item = create(:profile_item, product_item_config: product_item_config, is_draft: false)
 
       allow(profile_item).to receive(:published?).and_return(true)
@@ -442,7 +441,8 @@ RSpec.describe Ability, type: :model do
     end
 
     it "can manage_profile on instance if not draft and has profile items for product" do
-      user = create(:user, id: 1)
+      # Create a user that matches the session_user's username for the user lookup to work
+      user = create(:user, id: 1, user_name: session_user.username)
       product_role = create(:product_role, product: product)
 
       create(:user_product_role, user: user, product_role: product_role)


### PR DESCRIPTION
## Description
This pull request updates the logic for determining profile editing permissions to ensure that users can edit profile items and instances only if they are associated with the correct products. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
