### PR TITLE
FIxup foa copy tab not working anymore after implementing the product context

### DIFF
--- a/app/services/products/product_context_service.rb
+++ b/app/services/products/product_context_service.rb
@@ -16,6 +16,12 @@ module Products
       @available_contexts ||= products.blank? ? [] : product_contexts
     end
 
+    def product_with_context(context_id)
+      return nil if context_id.nil? || products.blank?
+
+      products.find { |product| product.context_id == context_id }
+    end
+
     private
 
     def product_contexts

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -214,7 +214,7 @@
   <% end %>
 
   <% if @tabs_to_offer.include?("tab_copy_to_new_profile_v2") && tab_available?(tabs_array, "copy_profile") %>
-    <% if can?(:copy_as_draft_secondary_reference, Instance) && @current_registered_user.available_product_from_roles.present? %>
+    <% if can?(:copy_as_draft_secondary_reference, Instance) %>
       <%= render(
         partial: "instances/tabs/tab",
         locals: {

--- a/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_copy_to_new_profile_v2.html.erb
@@ -1,9 +1,9 @@
-<% if @current_registered_user.available_product_from_roles&.reference.blank? %>
+<% if product_context_service.product_with_context(current_context_id)&.reference.blank? %>
   <div id="search-result-details-error-message-container" class="message-container">
     You do not have a product reference. Please contact your administrator.
   </div>
 <% else %>
-  <% product_reference = Product.find_by(name: @current_registered_user.available_product_from_roles&.name).reference %>
+  <% product_reference = product_context_service.product_with_context(current_context_id)&.reference %>
   <div id="search-result-details-info-message-container" class="message-container"></div>
   <div id="search-result-details-error-message-container" class="message-container"></div>
   <% increment_tab_index(0) %>
@@ -32,7 +32,7 @@
               method: :post) do |f| %>
 
     <br>
-    The copied instance will be attached to the <%= @current_registered_user.available_product_from_roles&.name %> product reference:<br>
+    The copied instance will be attached to the <%= product_context_service.product_with_context(current_context_id)&.name %> product reference:<br>
     <h6>&mdash; <%= product_reference.citation %></h6>
     <br>
     <label for="instance_type_id">Instance type:</label>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 22-Sep-2025
+  :jira_id: '116'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Fixup foa copy tab with product context logic
 - :date: 19-Sep-2025
   :jira_id: '117'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.1
+appversion=4.3.0.2

--- a/spec/services/products/product_context_service_spec.rb
+++ b/spec/services/products/product_context_service_spec.rb
@@ -47,4 +47,38 @@ RSpec.describe Products::ProductContextService do
       end
     end
   end
+
+  describe "#product_with_context" do
+    subject(:service) { described_class.call(products: [product_1, product_2, product_3]) }
+
+    it "returns the correct product for a given context_id" do
+      result = service.product_with_context(1)
+      expect(result).to eq(product_1)
+    end
+
+    it "returns nil if context_id is nil" do
+      result = service.product_with_context(nil)
+      expect(result).to be_nil
+    end
+
+    it "returns nil if no products match the context_id" do
+      result = service.product_with_context(-1)
+      expect(result).to be_nil
+    end
+  end
+
+  describe "#available_contexts" do
+    subject(:service) { described_class.call(products: [product_1, product_2, product_3]) }
+
+    it "returns cached available contexts after first call" do
+      first_call = service.available_contexts
+      second_call = service.available_contexts
+      expect(first_call).to equal(second_call)
+    end
+
+    it "returns an empty array if products are blank" do
+      empty_service = described_class.new(products: [])
+      expect(empty_service.available_contexts).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## Description
This pull request refactors how product references are accessed and displayed in the "Copy to New Profile" tab, shifting from user-based product lookups to context-based lookups. It introduces a new method to fetch products by context, updates view logic to use this method, and adds corresponding tests for improved reliability and maintainability.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Related Issues
FLOR-116

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
