### PR TITLE
Add scope for filtering products by context and tree; update views to…

### DIFF
--- a/app/controllers/product_contexts/set_context_controller.rb
+++ b/app/controllers/product_contexts/set_context_controller.rb
@@ -21,11 +21,13 @@ module ProductContexts
     def clear_context_session
       session.delete(:current_context_id)
       session.delete(:current_context_name)
+      session.delete(:draft)
     end
 
     def set_context_session(context_id)
       session[:current_context_id] = context_id.to_i
       session[:current_context_name] = context_name_for_id(context_id)
+      session.delete(:draft)
     end
 
     def permitted_params

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -59,4 +59,8 @@ class Product < ApplicationRecord
       .joins("INNER JOIN tree_element ON tree_element.id = tree_version_element.tree_element_id")
       .where("tree_element.id = ?", tree_element.id)
   end
+
+  scope :with_context_and_tree, ->(context_id) {
+    where(context_id: context_id).where.not(tree_id: nil)
+  }
 end

--- a/app/views/layouts/_taxonomy_menu.html.erb
+++ b/app/views/layouts/_taxonomy_menu.html.erb
@@ -41,7 +41,16 @@
       <% end %>
 
 
-      <% Tree.all.order('name').each do |tree| %>
+      <% if current_context_id && Rails.configuration.try(:multi_product_tabs_enabled) %>
+        <%
+          product = Product.with_context_and_tree(current_context_id).first
+          all_trees = Tree.where(id: product&.tree_id)
+        %>
+      <% else %>
+        <% all_trees = Tree.all %>
+      <% end %>
+
+      <% all_trees.order('name').each do |tree| %>
         <% if can?(:create_draft, tree) %>
         <li role="presentation" class="divider"></li>
         <li>

--- a/app/views/layouts/_taxonomy_menu.html.erb
+++ b/app/views/layouts/_taxonomy_menu.html.erb
@@ -43,8 +43,7 @@
 
       <% if current_context_id && Rails.configuration.try(:multi_product_tabs_enabled) %>
         <%
-          product = Product.with_context_and_tree(current_context_id).first
-          all_trees = Tree.where(id: product&.tree_id)
+          all_trees = Tree.where(id: Product.with_context_and_tree(current_context_id).select(:tree_id))
         %>
       <% else %>
         <% all_trees = Tree.all %>

--- a/app/views/tree_versions/_drafts_menu.html.erb
+++ b/app/views/tree_versions/_drafts_menu.html.erb
@@ -1,4 +1,13 @@
-<% Tree.menu_drafts.each do |menu_item| %>
+<% if current_context_id && Rails.configuration.try(:multi_product_tabs_enabled) %>
+  <%
+    product = Product.with_context_and_tree(current_context_id).first
+    draft_trees = Tree.menu_drafts.where(id: product&.tree_id)
+  %>
+<% else %>
+  <% draft_trees = Tree.menu_drafts %>
+<% end %>
+
+<% draft_trees.each do |menu_item| %>
 
   <% tree = Tree.find(menu_item[:id]) %>
   <% if can? :toggle_draft, tree %>

--- a/app/views/tree_versions/_drafts_menu.html.erb
+++ b/app/views/tree_versions/_drafts_menu.html.erb
@@ -1,7 +1,8 @@
 <% if current_context_id && Rails.configuration.try(:multi_product_tabs_enabled) %>
   <%
-    product = Product.with_context_and_tree(current_context_id).first
-    draft_trees = Tree.menu_drafts.where(id: product&.tree_id)
+    draft_trees = Tree.menu_drafts.where(
+      id: Product.with_context_and_tree(current_context_id).select(:tree_id)
+    )
   %>
 <% else %>
   <% draft_trees = Tree.menu_drafts %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 23-Sep-2025
+  :jira_id: '115'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Use product context to offer draft taxonomies in the menu
 - :date: 22-Sep-2025
   :jira_id: '5550'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.3
+appversion=4.3.0.4

--- a/spec/controllers/product_contexts/set_context_controller_spec.rb
+++ b/spec/controllers/product_contexts/set_context_controller_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe ProductContexts::SetContextController, type: :controller do
       expect(session[:current_context_name]).to eq("Test Context")
     end
 
+    it "clears any existing draft in the session" do
+      session[:draft] = { id: 123 }
+      post_create
+      expect(session[:draft]).to be_nil
+    end
+
     it "redirects to the previous page when HTTP_REFERER is set" do
       request.env["HTTP_REFERER"] = "/previous_page"
       post_create
@@ -55,6 +61,7 @@ RSpec.describe ProductContexts::SetContextController, type: :controller do
         post_create
         expect(session[:current_context_id]).to be_nil
         expect(session[:current_context_name]).to be_nil
+        expect(session[:draft]).to be_nil
       end
     end
 

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Product, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:tree).optional }
     it { is_expected.to belong_to(:reference).optional }
-    it { is_expected.to have_many(:user_product_roles).class_name('User::ProductRole').with_foreign_key('product_id') }
+    it { is_expected.to have_many(:user_product_roles).class_name('User::ProductRole').through(:product_roles) }
   end
 
   describe '.by_tree_element' do
@@ -30,4 +30,26 @@ RSpec.describe Product, type: :model do
       expect(described_class.by_tree_element(nil)).to be_empty
     end
   end
+
+  describe '.with_context_and_tree' do
+    let!(:context_id) { 1 }
+    let!(:tree) { create(:tree) }
+    let!(:product_with_tree) do
+      create(:product, name: 'WithTree', context_id: context_id, tree_id: tree.id)
+    end
+    let!(:product_without_tree) do
+      create(:product, name: 'NoTree', context_id: context_id, tree_id: nil)
+    end
+    let!(:product_other_context) do
+      create(:product, name: 'OtherContext', context_id: 2, tree_id: tree.id)
+    end
+
+    it 'returns products with given context_id and non-nil tree_id' do
+      result = Product.with_context_and_tree(context_id)
+      expect(result).to include(product_with_tree)
+      expect(result).not_to include(product_without_tree)
+      expect(result).not_to include(product_other_context)
+    end
+  end
 end
+

--- a/test/factories/product.rb
+++ b/test/factories/product.rb
@@ -48,5 +48,6 @@ FactoryBot.define do
     updated_by { "Sample Updated by" }
     api_name { "Sample Api name" }
     api_date { Time.current }
+    context_id { 1 }
   end
 end


### PR DESCRIPTION
## Description
This pull request introduces enhancements to how draft taxonomies are presented in menus based on the current product context. The changes ensure that only relevant trees and drafts associated with the selected product context are shown, and improve session management for draft-related data. Additionally, new model scopes and tests were added to support these features.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
