### PR TITLE
Refactor tree selection logic in new draft form to use available_tree…

### DIFF
--- a/app/views/tree_versions/_new_draft.html.erb
+++ b/app/views/tree_versions/_new_draft.html.erb
@@ -1,5 +1,15 @@
 <div class="focus-details unsaved-record">
   <div id="new-draft-tree-form-container" class="new-record-form-container">
+    <% if current_context_id && Rails.configuration.try(:multi_product_tabs_enabled) %>
+      <%
+        available_trees = Tree.accessible_by(current_ability, :create_draft)
+          .where(id: Product.with_context_and_tree(current_context_id).select(:tree_id))
+      %>
+    <% else %>
+      <%
+        available_trees = Tree.accessible_by(current_ability, :create_draft)
+      %>
+    <% end %>
 
     <h4>New Draft Taxonomy</h4>
     <div>
@@ -7,10 +17,7 @@
         <div class="form-group">
           <label>Tree
             <%= select_tag("tree_id",
-                           options_from_collection_for_select(Tree.accessible_by(current_ability, :create_draft)
-                                                             .where('is_read_only = false')
-                                                             .order('name'),
-                                                             'id', 'name'),
+                           options_from_collection_for_select(available_trees.where('is_read_only = false').order('name'), 'id', 'name'),
                            {class: 'form-control give-me-focus',
                             required: true,
                             autofocus: true,


### PR DESCRIPTION
## Description
This pull request updates the logic for displaying available trees when creating a new draft taxonomy. It introduces context-aware filtering for tree selection, ensuring that only trees associated with the current context are shown when multi-product tabs are enabled.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
