### PR TITLE
Add multi_product_tabs_enabled check to available_contexts and produc…

### DIFF
--- a/app/services/products/product_context_service.rb
+++ b/app/services/products/product_context_service.rb
@@ -13,7 +13,11 @@ module Products
     end
 
     def available_contexts
-      @available_contexts ||= products.blank? ? [] : product_contexts
+      @available_contexts ||= if Rails.configuration.try(:multi_product_tabs_enabled)
+        products.blank? ? [] : product_contexts
+      else
+        []
+      end
     end
 
     def product_with_context(context_id)

--- a/app/services/products/product_tab_service.rb
+++ b/app/services/products/product_tab_service.rb
@@ -10,6 +10,7 @@ module Products
     end
 
     def self.products_for_context(context_id)
+      return Product.none unless Rails.configuration.try(:multi_product_tabs_enabled)
       Product.where(context_id: context_id).order(context_sort_order: :asc)
     end
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,8 @@
+- :date: 25-Sep-2025
+  :jira_id: '115'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: Add a guard using the multi_product_tabs_enabled flag to the product context service
 - :date: 24-Sep-2025
   :jira_id: '115'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.6
+appversion=4.3.0.7

--- a/spec/services/products/product_context_service_spec.rb
+++ b/spec/services/products/product_context_service_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Products::ProductContextService do
 
   subject(:service) { described_class.new(products: [product_1, product_2, product_3]) }
 
+  before { allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(true)}
+
   describe ".initialize" do
     it "sets products" do
       expect(service.products).to eq([product_1, product_2, product_3])
@@ -80,5 +82,17 @@ RSpec.describe Products::ProductContextService do
       empty_service = described_class.new(products: [])
       expect(empty_service.available_contexts).to eq([])
     end
+
+    context "when multi_product_tabs_enabled is false" do
+      before do
+        allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(false)
+      end
+
+      it "returns product contexts if products are present" do
+        expect(service.available_contexts).to eq([])
+        expect(service.available_contexts.length).to eq(0)
+      end
+    end
   end
+
 end

--- a/spec/services/products/product_tab_service_spec.rb
+++ b/spec/services/products/product_tab_service_spec.rb
@@ -124,6 +124,7 @@ RSpec.describe Products::ProductTabService do
   end
 
   describe ".products_for_context" do
+    before { allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(true) }
     it "returns the product context for the given context id" do
       relation = instance_double(ActiveRecord::Relation)
       allow(Product).to receive(:where).with(context_id: context_1).and_return(relation)
@@ -144,6 +145,14 @@ RSpec.describe Products::ProductTabService do
     it "returns empty array for nil context id" do
       products = described_class.products_for_context(-1)
       expect(products).to eq([])
+    end
+
+    context "when multi_product_tabs_enabled is false" do
+      before { allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(false) }
+
+      it "returns Product.none (empty array)" do
+        expect(described_class.products_for_context(context_1)).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
## Description
This pull request adds support for toggling multi-product tab functionality via the `multi_product_tabs_enabled` configuration flag for systems that are not yet setup with context_id and context_sort_order

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## Tests
- [x] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
