### PR TITLE
NSL-5590: Batch Loader: Allow conversion from synonym to misapplication and vice versa

### DIFF
--- a/app/views/loader/names/tabs/_tab_edit.html.erb
+++ b/app/views/loader/names/tabs/_tab_edit.html.erb
@@ -5,8 +5,18 @@
   <%= render partial: 'loader/names/tabs/forms/form_for_accepted_or_excluded', locals: { loader_name: @loader_name } %>
 <% elsif @loader_name.synonym? %>
   <%= render partial: 'loader/names/tabs/forms/form_for_synonym', locals: { loader_name: @loader_name } %>
+  <br>
+  <%= divider %>
+  <%= render partial: 'loader/names/tabs/forms/form_convert_syn_to_misapp', locals: { loader_name: @loader_name } %>
+  <div id="search-result-details-info-message-container2" class="message-container"></div>
+  <div id="search-result-details-error-message-container2" class="message-container error-container"></div>
 <% elsif @loader_name.misapp? %>
   <%= render partial: 'loader/names/tabs/forms/form_for_misapp', locals: { loader_name: @loader_name } %>
+  <br>
+  <%= divider %>
+  <%= render partial: 'loader/names/tabs/forms/form_convert_misapp_to_syn', locals: { loader_name: @loader_name } %>
+  <div id="search-result-details-info-message-container2" class="message-container"></div>
+  <div id="search-result-details-error-message-container2" class="message-container error-container"></div>
 <% else %>
   Unknown type of record to edit
 <% end %>

--- a/app/views/loader/names/tabs/forms/_form_convert_misapp_to_syn.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_convert_misapp_to_syn.html.erb
@@ -1,0 +1,17 @@
+<h5>Convert to misapp</h5>
+<% if loader_name.preferred_match? %>
+  You cannot convert this synonym to a misapp because it already has a preferred match.  
+  <br>
+  Remove the preferred match to allow this operation.
+<% else %>
+  <%= form_with(model: loader_name, role: 'form', data: { turbo: false }, local: false) do |f| %>
+    <br>
+    <%= f.hidden_field :record_type, value: 'synonym' %>
+    <%= f.hidden_field(:parent_typeahead, value: loader_name.parent.simple_name) %>
+    <%= f.hidden_field(:parent_id) %>
+
+    <%= render partial: "loader/names/tabs/forms/synonym_type", locals: {f: f, loader_name: loader_name} %>
+
+    <%= f.submit "Convert", id: 'loader-name-save2', class: 'btn btn-primary width-5em pull-right', title: "Save changes", tabindex: increment_tab_index, disabled: false %>
+  <% end %>
+<% end %>

--- a/app/views/loader/names/tabs/forms/_form_convert_syn_to_misapp.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_convert_syn_to_misapp.html.erb
@@ -1,0 +1,17 @@
+<h5>Convert to misapp</h5>
+<% if loader_name.preferred_match? %>
+  You cannot convert this synonym to a misapp because it already has a preferred match.  
+  <br>
+  Remove the preferred match to allow this operation.
+<% else %>
+  <%= form_with(model: loader_name, role: 'form', data: { turbo: false }, local: false) do |f| %>
+    <br>
+    <%= f.hidden_field :record_type, value: 'misapplied' %>
+    <%= f.hidden_field(:parent_typeahead, value: loader_name.parent.simple_name) %>
+    <%= f.hidden_field(:parent_id) %>
+
+    <%= render partial: "loader/names/tabs/forms/misapp_synonym_type", locals: {f: f, loader_name: loader_name} %>
+
+    <%= f.submit "Convert", id: 'loader-name-save2', class: 'btn btn-primary width-5em pull-right', title: "Save changes", tabindex: increment_tab_index, disabled: false %>
+  <% end %>
+<% end %>

--- a/app/views/loader/names/tabs/forms/_form_for_misapp.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_misapp.html.erb
@@ -86,6 +86,4 @@
     <% end %>
 
     <%= f.submit "Save", id: 'loader-name-save2', class: 'btn btn-primary width-5em pull-right', title: "Save changes", tabindex: increment_tab_index, disabled: false %>
-    <div id="search-result-details-info-message-container2" class="message-container"></div>
-    <div id="search-result-details-error-message-container2" class="message-container error-container"></div>
 <% end %>

--- a/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
+++ b/app/views/loader/names/tabs/forms/_form_for_synonym.html.erb
@@ -75,6 +75,4 @@
     <% end %>
 
     <%= f.submit "Save", id: 'loader-name-save2', class: 'btn btn-primary width-5em pull-right', title: "Save changes", tabindex: increment_tab_index, disabled: false %>
-    <div id="search-result-details-info-message-container2" class="message-container"></div>
-    <div id="search-result-details-error-message-container2" class="message-container error-container"></div>
 <% end %>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
 - :date: 30-Sep-2025
+  :jira_id: '5590'
+  :description: |-
+    Batch Loader: Allow conversion from synonym to misapplication and vice versa
+- :date: 30-Sep-2025
   :jira_id: '5588'
   :description: |-
     Batch Load and Review: Show misapp and pro parte data on web and print outputs consistently

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.10
+appversion=4.3.0.11


### PR DESCRIPTION
## Description
Forms to allow edit operations to change record_type from 'synonym' to 'misapp' and vice versa

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Batch loader operation - described in the Jira.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
