### PR TITLE
NSL-5591: Batch Review: Show NFP status of loader name records to batch reviewers

### DIFF
--- a/app/models/concerns/loader/name/voting.rb
+++ b/app/models/concerns/loader/name/voting.rb
@@ -6,7 +6,7 @@ module Loader::Name::Voting
   end
 
   def summary_of_votes_for_review(review)
-    self.name_review_votes.where(batch_review_id: review.id)
+    self.name_review_votes.includes([:org]).where(batch_review_id: review.id)
         .sort {|v1,v2| v1.org.abbrev <=> v2.org.abbrev}
         .map {|vote| {org_abbrev: vote.org.abbrev, org_name: vote.org.name, vote: (vote.vote ? 'agree' :  'disagree')} }
 

--- a/app/models/search/loader/name/field_rule.rb
+++ b/app/models/search/loader/name/field_rule.rb
@@ -579,7 +579,16 @@ having count(*) > 2
     "hybrid-flag:" => { where_clause: "hybrid_flag like ?"},
     "no-hybrid-flag:" => { where_clause: "hybrid_flag is null",
                            takes_no_arg: true},
-    "no-further-processing:" => { where_clause: " no_further_processing or exists (select null from loader_name kids where kids.parent_id = loader_name.id and kids.no_further_processing) or exists (select null from loader_name pa where pa.id = loader_name.parent_id and pa.no_further_processing)"},
+    "no-further-processing:" => { where_clause: " no_further_processing
+                                  or exists (select null
+                                               from loader_name kids
+                                              where kids.parent_id = loader_name.id
+                                                and kids.no_further_processing)
+                                  or exists (select null
+                                               from loader_name pa
+                                              where pa.id = loader_name.parent_id
+                                                and pa.no_further_processing)",
+                           takes_no_arg: true},
     "isonym:" => { where_clause: "isonym is not null"},
     "orth-var:" => { where_clause: "name_status like 'orth%'"},
     "name-status:" => { where_clause: "name_status like ?",

--- a/app/views/application/search_results/review/link_texts/_loader_name.html.erb
+++ b/app/views/application/search_results/review/link_texts/_loader_name.html.erb
@@ -12,7 +12,15 @@
   <%= "#{search_result.full_name}" %>
   <%= "<i>p.p.</i>".html_safe if search_result.partly? %>
 <% end %>
+
 </span>
+
+<% if search_result.try('parent').try('no_further_processing?') %>
+    <span class="flag exclude-from-further-processing" title='No further processing flag of parent set'>NFP via parent</span>
+<% elsif search_result.no_further_processing? %>
+    <span class="flag exclude-from-further-processing" title='No further processing flag set'>NFP</span>
+<% end %>
+
 
 <% if search_result.votable? %>
   <% search_result.name_review_votes.each do |vote| %>

--- a/app/views/loader/names/review/tabs/main/_tab_details.html.erb
+++ b/app/views/loader/names/review/tabs/main/_tab_details.html.erb
@@ -17,7 +17,23 @@
   <%= render partial: 'detail_line', locals: {label: 'Partly', info: "#{@loader_name.partly}"} %>
   <%= render partial: 'detail_line', locals: {label: 'Publ Partly', info: "#{@loader_name.publ_partly}"} %>
 <% end %>
+<% if @loader_name.no_further_processing? %>
+  <%= render partial: 'detail_line', locals: {info: @loader_name.no_further_processing, label: 'no further processing'} %>
+<% end %>
 <%= divider %>
+<% if @loader_name.no_further_processing? %>
+  <div class="bggray big-vertical-padding" >
+    <h4 class="white">No Further Processing</h4>
+    <p class="white">This record is flagged for no further processing.</p>
+  </div>
+<% end %>
+<% if @loader_name.try('parent').try('no_further_processing?') %>
+  <div class="bggray big-vertical-padding" >
+    <h4 class="white">No Further Processing via parent</h4>
+    <p class="white">This record is flagged for no further processing.</p>
+  </div>
+<% end %>
+
 
 <%= render partial: 'loader/names/review/tabs/common/vote_and_comments', locals: {scope: 'unrestricted'} %>
 

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 01-Oct-2025
+  :jira_id: '5591'
+  :description: |-
+    Batch Review: Show NFP status of loader name records to batch reviewers
 - :date: 30-Sep-2025
   :jira_id: '5588'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.12
+appversion=4.3.0.13


### PR DESCRIPTION
## Description
Add some extra info on the loader name record display for reviewers.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
Login in as a registered batch reviewer and query records, including some marked NFP.


## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
