### PR TITLE
Feature/flor 128 foa draft editor tabs

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -141,12 +141,17 @@ class Ability
       :synonymy_as_draft_secondary_reference,
       :unpublished_citation_as_draft_secondary_reference
     ], Instance do |instance|
-      instance.draft? && instance.reference.products.pluck(:name).any?(user.product_from_roles&.name.to_s)
+      instance.draft? && instance.reference.products.pluck(:name).any?(selected_product(user)&.name.to_s)
     end
     can :edit, Instance do |instance|
       instance.relationship? &&
-      instance.this_is_cited_by.draft? &&
-      instance.this_is_cited_by.reference.products.pluck(:name).any?(user.product_from_roles&.name.to_s)
+        instance.this_is_cited_by.draft? &&
+        instance
+          .this_is_cited_by
+          .reference
+          .products
+          .pluck(:name)
+          .any?(selected_product(user)&.name.to_s)
     end
     can "instances", "create"
     can "instances", "tab_edit"
@@ -459,5 +464,11 @@ class Ability
 
     can "trees", "update_synonymy_by_instance"
     can :update_synonymy_by_instance, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
+  end
+
+  def selected_product(user)
+    # NOTES: The selected product is either the one set in context or, if none set,
+    # the first product from the user's roles.
+    @selected_product ||= user.product_from_context || user.product_from_roles
   end
 end

--- a/app/views/instances/tabs/_tab_show_1.html.erb
+++ b/app/views/instances/tabs/_tab_show_1.html.erb
@@ -61,7 +61,7 @@
 <% end %>
 
 <% if Rails.configuration.try('profile_v2_aware') && @instance.profile_items.present? %>
-  <h5><%= user_profile_tab_name %> Profile</h5>
+  <h5>Profile</h5>
   <dl class="dl-horizontal">
     <% @instance.profile_items.includes(:product_item_config, :profile_text).each do |profile_item| %>
       <dt><%= profile_item.product_item_config.try(:display_html) %></dt>

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,9 @@
 - :date: 03-Oct-2025
+  :jira_id: '128'
+  :jira_project: FLOR
+  :description: |-
+    Foa Project: fixup the profile tabs not showing when user has selected the foa context in test
+- :date: 03-Oct-2025
   :jira_id: '5593'
   :description: |-
     Rails Upgrade: Upgrade to Rails 8.0.0 and update related dependencies

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.0.0.0
+appversion=5.0.0.1


### PR DESCRIPTION
## Description
This pull request improves how user product context is handled when determining permissions for editing and managing draft instances. The main change is to prefer the user's selected product context (if set) over their default product roles when checking access. The update also adds comprehensive tests to ensure this logic works as expected and includes a minor UI tweak and version bump.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
